### PR TITLE
Add GitHub Actions workflow for automatic production deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy via SSH
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script_stop: true
+          script: |
+            cd /home/sedvouco/nominapp.sedacosmetica.com/nominapp
+            artisan82 down || true
+            trap 'artisan82 up' EXIT
+            git pull origin main
+            composer82 install --no-dev --optimize-autoloader
+            artisan82 migrate --force
+            artisan82 optimize:clear
+            artisan82 optimize
+            artisan82 filament:optimize
+            artisan82 queue:restart


### PR DESCRIPTION
Deploys to sedacosmetica.com on every push to main via SSH. Uses maintenance mode (artisan82 down/up) with trap to ensure the site comes back up even if a deployment step fails.

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr