### PR TITLE
Replace SSH deploy with HTTP webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,26 +6,23 @@ on:
 
 jobs:
   deploy:
-    name: Deploy via SSH
+    name: Deploy via Webhook
     runs-on: ubuntu-latest
 
     steps:
-      - name: Deploy
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.SSH_PORT }}
-          script_stop: true
-          script: |
-            cd /home/sedvouco/nominapp.sedacosmetica.com/nominapp
-            artisan82 down || true
-            trap 'artisan82 up' EXIT
-            git pull origin main
-            composer82 install --no-dev --optimize-autoloader
-            artisan82 migrate --force
-            artisan82 optimize:clear
-            artisan82 optimize
-            artisan82 filament:optimize
-            artisan82 queue:restart
+      - name: Trigger deploy webhook
+        run: |
+          HTTP_STATUS=$(curl -s -o /tmp/deploy_out.json -w "%{http_code}" \
+            --max-time 300 \
+            -X POST \
+            -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            https://nominapp.sedacosmetica.com/deploy.php)
+
+          echo "Server response: $(cat /tmp/deploy_out.json)"
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Deploy failed — HTTP $HTTP_STATUS"
+            exit 1
+          fi
+
+          echo "Deploy successful!"

--- a/public/deploy.php
+++ b/public/deploy.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+// Read DEPLOY_TOKEN from .env
+$envPath = dirname(__DIR__) . '/.env';
+preg_match('/^DEPLOY_TOKEN=(.+)$/m', (string) @file_get_contents($envPath), $m);
+$expectedToken = trim($m[1] ?? '');
+
+$receivedToken = $_SERVER['HTTP_X_DEPLOY_TOKEN'] ?? '';
+
+if ($expectedToken === '' || ! hash_equals($expectedToken, $receivedToken)) {
+    http_response_code(401);
+    exit;
+}
+
+$base = dirname(__DIR__);
+$log  = $base . '/storage/logs/deploy.log';
+
+set_time_limit(300);
+ignore_user_abort(true);
+
+$steps = [
+    "artisan82 down 2>&1 || true",
+    "git -C {$base} pull origin main 2>&1",
+    "composer82 install --no-dev --optimize-autoloader --working-dir={$base} 2>&1",
+    "artisan82 migrate --force 2>&1",
+    "artisan82 optimize:clear 2>&1",
+    "artisan82 optimize 2>&1",
+    "artisan82 filament:optimize 2>&1",
+    "artisan82 queue:restart 2>&1",
+    "artisan82 up 2>&1",
+];
+
+$failed = false;
+
+file_put_contents($log, PHP_EOL . '[' . date('Y-m-d H:i:s') . '] === Deploy started ===' . PHP_EOL, FILE_APPEND);
+
+foreach ($steps as $cmd) {
+    $result = [];
+    $code   = 0;
+
+    exec("cd {$base} && {$cmd}", $result, $code);
+
+    file_put_contents(
+        $log,
+        '[' . date('H:i:s') . '] $ ' . $cmd . PHP_EOL . implode(PHP_EOL, $result) . PHP_EOL,
+        FILE_APPEND
+    );
+
+    if ($code !== 0 && ! str_contains($cmd, '|| true')) {
+        $failed = true;
+        exec("cd {$base} && artisan82 up 2>&1");
+        file_put_contents($log, '[' . date('H:i:s') . '] Step failed — site restored.' . PHP_EOL, FILE_APPEND);
+        break;
+    }
+}
+
+file_put_contents($log, '[' . date('H:i:s') . '] === Deploy ' . ($failed ? 'FAILED' : 'OK') . ' ===' . PHP_EOL, FILE_APPEND);
+
+http_response_code($failed ? 500 : 200);
+header('Content-Type: application/json');
+echo json_encode(['status' => $failed ? 'failed' : 'ok']);


### PR DESCRIPTION
Since sshd is not running on the server, use a POST webhook instead. deploy.php reads DEPLOY_TOKEN from .env to authenticate the request. All deployment output is logged to storage/logs/deploy.log.

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr