### PR TITLE
Fix deploy.php: set HOME and COMPOSER_HOME for web context

### DIFF
--- a/public/deploy.php
+++ b/public/deploy.php
@@ -25,6 +25,10 @@ $log  = $base . '/storage/logs/deploy.log';
 set_time_limit(300);
 ignore_user_abort(true);
 
+// Composer requires HOME when running from a web context
+putenv('HOME=/home/sedvouco');
+putenv('COMPOSER_HOME=/home/sedvouco/.composer');
+
 $php    = '/opt/cpanel/ea-php82/root/usr/bin/php';
 $artisan  = "{$php} artisan";
 $composer = "{$php} /opt/cpanel/composer/bin/composer";


### PR DESCRIPTION
PHP exec() from Apache does not inherit the user's HOME env var. Composer requires HOME or COMPOSER_HOME to be set.

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr