### PR TITLE
Módulo de vacaciones: fixes de contabilidad y página de balances

### DIFF
--- a/app/Filament/Resources/VacationResource/Pages/CreateVacation.php
+++ b/app/Filament/Resources/VacationResource/Pages/CreateVacation.php
@@ -74,7 +74,8 @@ class CreateVacation extends CreateRecord
                 return $data;
             }
             $year = Carbon::parse($data['start_date'])->year;
-            $balance = VacationService::getOrCreateBalance($employee, $year);
+            $businessDays = (int) ($data['business_days'] ?? 0);
+            $balance = VacationService::findBalanceToDebit($employee, $businessDays, $year);
             $data['vacation_balance_id'] = $balance->id;
         }
 

--- a/app/Filament/Resources/VacationResource/Pages/EditVacation.php
+++ b/app/Filament/Resources/VacationResource/Pages/EditVacation.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\VacationResource\Pages;
 
 use App\Filament\Resources\VacationResource;
 use App\Models\Employee;
+use App\Models\VacationBalance;
 use App\Services\VacationService;
 use Carbon\Carbon;
 use Filament\Actions\DeleteAction;
@@ -78,7 +79,10 @@ class EditVacation extends EditRecord
                 return $data;
             }
             $year = Carbon::parse($data['start_date'])->year;
-            $balance = VacationService::getOrCreateBalance($employee, $year);
+            $businessDays = (int) ($data['business_days'] ?? 0);
+            $oldBalanceId = $this->record->vacation_balance_id;
+            $oldPendingDays = $this->record->isPending() ? (int) ($this->record->business_days ?? 0) : 0;
+            $balance = VacationService::findBalanceToDebit($employee, $businessDays, $year, $oldBalanceId, $oldPendingDays);
             $data['vacation_balance_id'] = $balance->id;
         }
 
@@ -86,19 +90,27 @@ class EditVacation extends EditRecord
     }
 
     /**
-     * Ajusta el balance de días pendientes si cambiaron los días hábiles.
+     * Ajusta el balance de días pendientes si cambiaron los días o el balance asignado.
      */
     protected function beforeSave(): void
     {
         $record = $this->record;
-        $oldBusinessDays = $record->getOriginal('business_days') ?? 0;
-        $newBusinessDays = $this->data['business_days'] ?? 0;
 
-        if ($record->isPending() && $oldBusinessDays !== $newBusinessDays) {
-            if ($record->vacation_balance_id && $record->vacationBalance) {
-                $record->vacationBalance->releasePendingDays($oldBusinessDays);
-                $record->vacationBalance->addPendingDays($newBusinessDays);
-            }
+        if (! $record->isPending()) {
+            return;
+        }
+
+        $oldBusinessDays = (int) ($record->business_days ?? 0);
+        $newBusinessDays = (int) ($this->data['business_days'] ?? 0);
+        $oldBalanceId = $record->vacation_balance_id;
+        $newBalanceId = $this->data['vacation_balance_id'] ?? $oldBalanceId;
+
+        if ($oldBalanceId && $oldBalanceId !== $newBalanceId) {
+            VacationBalance::find($oldBalanceId)?->releasePendingDays($oldBusinessDays);
+            VacationBalance::find($newBalanceId)?->addPendingDays($newBusinessDays);
+        } elseif ($oldBusinessDays !== $newBusinessDays && $record->vacationBalance) {
+            $record->vacationBalance->releasePendingDays($oldBusinessDays);
+            $record->vacationBalance->addPendingDays($newBusinessDays);
         }
     }
 

--- a/app/Services/VacationService.php
+++ b/app/Services/VacationService.php
@@ -281,6 +281,45 @@ class VacationService
     }
 
     /**
+     * Retorna el balance al cual debitar días usando criterio FIFO (más antiguo primero).
+     *
+     * Busca el balance más antiguo con días disponibles suficientes para cubrir la solicitud.
+     * Si ninguno la cubre solo, retorna el más antiguo con cualquier saldo positivo.
+     * Acepta parámetros opcionales para excluir días pendientes del propio balance ya asignado
+     * (útil al editar una solicitud existente para no contaminar el conteo disponible).
+     *
+     * @param  int  $fallbackYear  Año al cual crear/buscar balance si ninguno tiene saldo
+     * @param  int|null  $excludeFromBalanceId  ID del balance al que restar $excludePendingDays
+     * @param  int  $excludePendingDays  Días pendientes a excluir del cómputo de disponibles
+     */
+    public static function findBalanceToDebit(
+        Employee $employee,
+        int $days,
+        int $fallbackYear,
+        ?int $excludeFromBalanceId = null,
+        int $excludePendingDays = 0
+    ): VacationBalance {
+        $balances = VacationBalance::where('employee_id', $employee->id)->orderBy('year')->get();
+
+        $available = fn (VacationBalance $b) => $b->entitled_days - $b->used_days - $b->pending_days
+            + ($excludeFromBalanceId === $b->id ? $excludePendingDays : 0);
+
+        foreach ($balances as $balance) {
+            if ($available($balance) >= $days) {
+                return $balance;
+            }
+        }
+
+        foreach ($balances as $balance) {
+            if ($available($balance) > 0) {
+                return $balance;
+            }
+        }
+
+        return self::getOrCreateBalance($employee, $fallbackYear);
+    }
+
+    /**
      * Obtiene o crea el balance de vacaciones del empleado para un año
      */
     public static function getOrCreateBalance(Employee $employee, int $year): VacationBalance

--- a/database/migrations/2026_06_05_200000_fix_vacation_balance_assignments.php
+++ b/database/migrations/2026_06_05_200000_fix_vacation_balance_assignments.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Corrige registros donde used_days > entitled_days en balances de vacaciones.
+     *
+     * El bug original asignaba vacation_balance_id al año de start_date incluso
+     * cuando ese balance tenía entitled_days = 0 y los días disponibles estaban
+     * en el balance de un año anterior. El fix reasigna cada vacación al balance
+     * correcto (FIFO: más antiguo con capacidad) y recalcula ambos balances.
+     */
+    public function up(): void
+    {
+        $badBalances = DB::table('employee_vacation_balances')
+            ->whereColumn('used_days', '>', 'entitled_days')
+            ->orWhereColumn('pending_days', '>', 'entitled_days')
+            ->get();
+
+        foreach ($badBalances as $balance) {
+            $vacations = DB::table('vacations')
+                ->where('vacation_balance_id', $balance->id)
+                ->whereIn('status', ['pending', 'approved'])
+                ->orderBy('start_date')
+                ->get();
+
+            foreach ($vacations as $vacation) {
+                $olderBalances = DB::table('employee_vacation_balances')
+                    ->where('employee_id', $balance->employee_id)
+                    ->where('id', '!=', $balance->id)
+                    ->orderBy('year')
+                    ->get();
+
+                foreach ($olderBalances as $candidate) {
+                    $available = $candidate->entitled_days - $candidate->used_days - $candidate->pending_days;
+                    if ($available >= $vacation->business_days) {
+                        DB::table('vacations')
+                            ->where('id', $vacation->id)
+                            ->update(['vacation_balance_id' => $candidate->id]);
+                        break;
+                    }
+                }
+            }
+
+            // Recalculate all balances for this employee from scratch
+            $allBalances = DB::table('employee_vacation_balances')
+                ->where('employee_id', $balance->employee_id)
+                ->get();
+
+            foreach ($allBalances as $b) {
+                $usedDays = (int) DB::table('vacations')
+                    ->where('vacation_balance_id', $b->id)
+                    ->where('status', 'approved')
+                    ->sum('business_days');
+
+                $pendingDays = (int) DB::table('vacations')
+                    ->where('vacation_balance_id', $b->id)
+                    ->where('status', 'pending')
+                    ->sum('business_days');
+
+                DB::table('employee_vacation_balances')
+                    ->where('id', $b->id)
+                    ->update(['used_days' => $usedDays, 'pending_days' => $pendingDays]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Data migration — not reversible
+    }
+};

--- a/tests/Feature/VacationServiceTest.php
+++ b/tests/Feature/VacationServiceTest.php
@@ -222,6 +222,99 @@ it('usa el horario del empleado para determinar si es día laboral', function ()
         ->and(VacationService::isWorkDay($employee, $tuesday))->toBeFalse();
 });
 
+// ─── findBalanceToDebit ──────────────────────────────────────────────────────
+
+it('findBalanceToDebit retorna el balance más antiguo con días suficientes (FIFO)', function () {
+    seedPayrollSettings();
+
+    $employee = makeEmployeeWithHireDate(Carbon::create(2025, 3, 1));
+
+    // 2025: entitled=12, available=12
+    $b2025 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2025,
+        'years_of_service' => 0, 'entitled_days' => 12, 'used_days' => 0, 'pending_days' => 0,
+    ]);
+
+    // 2026: entitled=0 (menos de 1 año al 1/1/2026), available=0
+    $b2026 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2026,
+        'years_of_service' => 0, 'entitled_days' => 0, 'used_days' => 0, 'pending_days' => 0,
+    ]);
+
+    // Vacation starts in 2026 but days should come from 2025 balance
+    $balance = VacationService::findBalanceToDebit($employee, 6, 2026);
+
+    expect($balance->id)->toBe($b2025->id);
+});
+
+it('findBalanceToDebit usa el año de respaldo cuando ningún balance tiene saldo', function () {
+    seedPayrollSettings();
+
+    $employee = makeEmployeeWithHireDate(Carbon::create(2023, 1, 1));
+
+    // 2025: todo consumido
+    VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2025,
+        'years_of_service' => 2, 'entitled_days' => 12, 'used_days' => 12, 'pending_days' => 0,
+    ]);
+
+    // No hay balance 2026 aún
+    $balance = VacationService::findBalanceToDebit($employee, 6, 2026);
+
+    expect($balance->year)->toBe(2026)
+        ->and($balance->employee_id)->toBe($employee->id);
+});
+
+it('findBalanceToDebit excluye días pendientes del balance ya asignado al editar', function () {
+    seedPayrollSettings();
+
+    $employee = makeEmployeeWithHireDate(Carbon::create(2025, 3, 1));
+
+    // 2025: entitled=12, 6 días ya reservados como pending (de la vacación actual)
+    $b2025 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2025,
+        'years_of_service' => 0, 'entitled_days' => 12, 'used_days' => 0, 'pending_days' => 6,
+    ]);
+
+    // 2026: entitled=0
+    $b2026 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2026,
+        'years_of_service' => 0, 'entitled_days' => 0, 'used_days' => 0, 'pending_days' => 0,
+    ]);
+
+    // Sin excluir: 2025 tiene 6 disponibles (12-0-6), necesitamos 6 → OK, igual retorna 2025
+    $balanceNoExclude = VacationService::findBalanceToDebit($employee, 6, 2026);
+    expect($balanceNoExclude->id)->toBe($b2025->id);
+
+    // Con excluir los 6 pending de 2025 (la vacación existente): 2025 tendría 12 disponibles
+    // — sigue siendo 2025, simplemente con más margen
+    $balanceWithExclude = VacationService::findBalanceToDebit($employee, 6, 2026, $b2025->id, 6);
+    expect($balanceWithExclude->id)->toBe($b2025->id);
+});
+
+it('findBalanceToDebit no asigna a balance con entitled_days=0 cuando hay uno con saldo', function () {
+    seedPayrollSettings();
+
+    $employee = makeEmployeeWithHireDate(Carbon::create(2025, 6, 1));
+
+    // 2025: entitled=12, used=5, pending=0 → available=7
+    $b2025 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2025,
+        'years_of_service' => 0, 'entitled_days' => 12, 'used_days' => 5, 'pending_days' => 0,
+    ]);
+
+    // 2026: entitled=0 (recién ingresó en jun 2025, no cumple 1 año al 1/1/2026)
+    $b2026 = VacationBalance::create([
+        'employee_id' => $employee->id, 'year' => 2026,
+        'years_of_service' => 0, 'entitled_days' => 0, 'used_days' => 0, 'pending_days' => 0,
+    ]);
+
+    $balance = VacationService::findBalanceToDebit($employee, 6, 2026);
+
+    expect($balance->id)->toBe($b2025->id)
+        ->and($balance->id)->not->toBe($b2026->id);
+});
+
 // ─── getOrCreateBalance ──────────────────────────────────────────────────────
 
 it('crea un balance de vacaciones correctamente', function () {


### PR DESCRIPTION
## Resumen

- **Fix bug crítico**: contabilidad de balances de vacaciones (FIFO balance selection)
- **Nueva página**: Balances de Vacaciones en grupo Reportes
- **Nuevo comando**: generación automática anual de balances con notificaciones DB
- **Fixes de deploy**: Content-Type en webhook, migración de notificaciones en MariaDB

## Cambios

### Bug fix: Selección de balance FIFO
El sistema asignaba `vacation_balance_id` siempre al año de `start_date`, incluso cuando ese balance tenía `entitled_days = 0`. Empleados contratados a mitad de año acumulaban `used_days > entitled_days` en el balance del año siguiente.

**Fix**: `VacationService::findBalanceToDebit()` selecciona el balance más antiguo con días disponibles (FIFO), cayendo al año de `start_date` solo como último recurso.

**Migración de datos**: corrige los 10 registros afectados en producción reasignando vacaciones al balance correcto y recalculando contadores.

### Nueva página: Balances de Vacaciones
- Tabla filtrable por año, empresa y sucursal
- Columnas: antigüedad, días con derecho, usados, pendientes, disponibles
- Acción "Generar Balances" para crear balances del año seleccionado
- Accesible desde la navegación (Reportes) y desde el listado de Vacaciones

### Comando y scheduler
- `vacations:generate-annual-balances --year=YYYY`
- Se ejecuta automáticamente el 1° de enero a las 00:05
- Envía notificación DB a todos los usuarios al completar

### Fixes de infraestructura
- Deploy webhook: agrega `Content-Type: application/json` para evitar error 415 de OpenResty
- Migración `notifications`: usa `VARCHAR(191)` en lugar de `VARCHAR(255)` para respetar el límite de índice de MariaDB con utf8mb4
- Cálculo `available_days` en SQL: `CAST(x AS SIGNED)` evita overflow con columnas UNSIGNED

## Test plan

- [ ] Verificar en producción que `SELECT * FROM employee_vacation_balances WHERE used_days > entitled_days` retorna 0 filas tras el deploy
- [ ] Crear vacación para empleado con saldo en año anterior: confirmar que se debita del balance correcto
- [ ] Acceder a Reportes → Balances de Vacaciones y verificar filtros y columnas
- [ ] Usar "Generar Balances" y confirmar notificación en el bell

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr