### PR TITLE
Fix notifications migration: key too long on MariaDB

### DIFF
--- a/database/migrations/2026_06_05_181148_create_notifications_table.php
+++ b/database/migrations/2026_06_05_181148_create_notifications_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
         Schema::create('notifications', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('type');
-            $table->morphs('notifiable');
+            $table->string('notifiable_type', 191);
+            $table->unsignedBigInteger('notifiable_id');
+            $table->index(['notifiable_type', 'notifiable_id']);
             $table->text('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();


### PR DESCRIPTION
`morphs()` genera `VARCHAR(255)` que con `utf8mb4` supera el límite de 1000 bytes de MariaDB. Se reemplaza con columnas explícitas `VARCHAR(191)` + índice manual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_