### PR TITLE
Fix deploy 415: send empty JSON body with Content-Type

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
             -X POST \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             -H "Content-Type: application/json" \
+            -d '{}' \
             https://nominapp.sedacosmetica.com/deploy.php)
 
           echo "Server response: $(cat /tmp/deploy_out.json)"


### PR DESCRIPTION
OpenResty rechaza POST requests que declaran `Content-Type: application/json` sin body. Agregando `-d '{}'` al curl se satisface el contrato del content-type.

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_