### PR TITLE
fix: switch deploy webhook to form-encoded to avoid 415

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,7 @@ jobs:
             --max-time 300 \
             -X POST \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
+            -d 'ping=1' \
             https://nominapp.sedacosmetica.com/deploy.php)
 
           echo "Server response: $(cat /tmp/deploy_out.json)"


### PR DESCRIPTION
## Summary

- Removes `Content-Type: application/json` header and `-d '{}'` from the deploy webhook curl call
- Uses curl's default `application/x-www-form-urlencoded` with `-d 'ping=1'` instead
- OpenResty was intermittently rejecting `application/json` with HTTP 415; form-encoded is universally accepted

## Test plan

- [ ] Merge and verify GitHub Actions deploy completes with HTTP 200

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_