### PR TITLE
fix: mostrar días disponibles correctamente para empleados sin balance previo

### DIFF
--- a/app/Filament/Resources/VacationResource.php
+++ b/app/Filament/Resources/VacationResource.php
@@ -111,6 +111,8 @@ class VacationResource extends Resource
                                     ");
                                 }
 
+                                VacationService::getOrCreateBalance($employee, now()->year);
+
                                 $balances = VacationBalance::where('employee_id', $employee->id)->orderByDesc('year')->get();
                                 $totalAvail = VacationService::getTotalAvailableDays($employee);
                                 $totalUsed = $balances->sum('used_days');
@@ -166,6 +168,8 @@ class VacationResource extends Resource
                         if (VacationService::getYearsOfService($employee) < $minYears) {
                             return true;
                         }
+
+                        VacationService::getOrCreateBalance($employee, now()->year);
 
                         return VacationService::getTotalAvailableDays($employee) === 0;
                     })


### PR DESCRIPTION
## Problema

Al crear una vacación para un empleado que nunca había tenido vacaciones registradas, el formulario mostraba "Sin días disponibles. No es posible solicitar vacaciones." aunque el empleado tuviera 1 año de antigüedad y 12 días de derecho.

## Causa

`getTotalAvailableDays()` suma los balances existentes en la BD. Si el empleado no tiene ningún balance todavía, la suma da 0. `validateRequest()` llama `getOrCreateBalance()` antes de verificar, pero el display del formulario no lo hacía.

## Fix

Se llama `getOrCreateBalance(employee, now()->year)` en el placeholder de "Saldo de vacaciones" y en el `hidden` de la sección de fechas, garantizando que el balance del año actual exista antes de consultar el total disponible.

## Test plan

- [ ] Abrir el formulario de creación de vacaciones para un empleado que nunca tuvo vacaciones
- [ ] Verificar que muestra correctamente los días disponibles (ej. 12 días)
- [ ] Verificar que la sección "Período de Vacaciones" aparece correctamente

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_