### PR TITLE
fix: recalcular entitled_days en getOrCreateBalance para balances con 0 días

### DIFF
--- a/app/Services/VacationService.php
+++ b/app/Services/VacationService.php
@@ -340,6 +340,18 @@ class VacationService
                 'used_days' => 0,
                 'pending_days' => 0,
             ]);
+        } elseif ($balance->entitled_days === 0) {
+            // Balance existente con entitled_days=0, posiblemente creado con la referencia
+            // incorrecta (Jan 1 en lugar de Dec 31). Recalcular y corregir si corresponde.
+            $yearsOfService = self::getYearsOfService($employee, Carbon::create($year, 12, 31));
+            $entitledDays = self::getEntitledDays($yearsOfService);
+
+            if ($entitledDays > 0) {
+                $balance->update([
+                    'entitled_days' => $entitledDays,
+                    'years_of_service' => $yearsOfService,
+                ]);
+            }
         }
 
         return $balance;


### PR DESCRIPTION
## Problema

Balances de vacaciones creados antes del fix de referencia Dec 31 quedaban con `entitled_days=0` aunque el empleado ya tuviera 1 año de servicio. Al abrir el formulario de crear vacaciones, `getOrCreateBalance()` encontraba el balance existente y lo devolvía sin modificar, mostrando incorrectamente "Sin días disponibles".

## Causa

`getOrCreateBalance()` solo calculaba `entitled_days` al **crear** un balance nuevo. Si el balance ya existía con `entitled_days=0` (creado con la referencia Jan 1 antes del fix), lo retornaba tal cual.

## Fix

Se agrega un `elseif` que recalcula y actualiza `entitled_days` cuando el balance existente tiene 0 días pero el cálculo con referencia Dec 31 devuelve un valor mayor. No toca balances con `entitled_days > 0`.

## Datos en producción

Se corrigieron 36 balances manualmente via tinker. Los 45 omitidos son empleados contratados en 2026 que genuinamente no tienen derecho todavía.

## Test plan

- [ ] Abrir formulario de crear vacaciones para un empleado con balance `entitled_days=0` corregible
- [ ] Verificar que ahora muestra los días disponibles correctamente

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_