### PR TITLE
fix(attendance): bugs y mejoras en AttendanceDayResource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1362,6 +1362,121 @@ public function cancel(): array
 
 La modal de confirmación de cancelar debe advertir explícitamente si hay cuotas pendientes (aunque ninguna pagada), para que el usuario sepa cuántas cuotas se eliminarán.
 
+### Carbon — mutación accidental de atributos de fecha del modelo
+
+Carbon 3 (usado en Laravel 12) es **mutable por defecto**. Al llamar modificadores como `startOfWeek()`, `endOfWeek()`, `startOfMonth()` sobre un atributo Carbon del modelo, se muta el valor almacenado en la instancia — afectando cualquier acceso posterior al atributo en el mismo request.
+
+Siempre usar `.copy()` antes de aplicar modificadores:
+
+```php
+// ❌ Muta $record->date — cualquier acceso posterior verá startOfWeek()
+$weekStart = $record->date->startOfWeek()->toDateString();
+
+// ✅ Seguro — el original no se toca
+$weekStart = $record->date->copy()->startOfWeek()->toDateString();
+$weekEnd   = $record->date->copy()->endOfWeek()->toDateString();
+```
+
+Aplica a cualquier campo con cast `'date'` o `'datetime'` en el modelo.
+
+### Valores de configuración en labels de acciones estáticas
+
+Cuando una acción (definida como método `static`) necesita valores de `PayrollSettings` u otro objeto de configuración para construir sus labels o descripciones, resolver el settings una sola vez al inicio del método factory:
+
+```php
+// ✅ Resolver settings al inicio del factory estático
+public static function getAdjustExtraHoursTableAction(): TableAction
+{
+    $settings    = app(PayrollSettings::class);
+    $pctDiurno   = (int) (($settings->overtime_multiplier_diurno - 1) * 100);
+    $pctNocturno = (int) (($settings->overtime_multiplier_nocturno - 1) * 100);
+
+    return TableAction::make('adjust_extra_hours')
+        ->form([
+            TextInput::make('extra_hours_diurnas')
+                ->label("Horas extra diurnas (+{$pctDiurno}%)")
+                // ...
+        ]);
+}
+```
+
+Nunca hardcodear multiplicadores, porcentajes o tasas directamente en labels — si cambian en `PayrollSettings`, el label quedaría desactualizado.
+
+### Consolidar row actions en un único `ActionGroup`
+
+Cuando un recurso tiene múltiples row actions que pueden aparecer condicionalmente, consolidarlas en un único `ActionGroup` para evitar una columna de acciones congestionada visualmente:
+
+```php
+->actions([
+    TableActionGroup::make([
+        self::getApproveOvertimeTableAction(),
+        self::getApproveTardinessTableAction(),
+        self::getAdjustExtraHoursTableAction(),
+        self::getExportPdfTableAction(),
+        self::getCalculateTableAction(),
+    ]),
+])
+```
+
+**Labels en dropdown:** dentro de un `ActionGroup` expandir labels abreviados a nombres descriptivos completos — el espacio no es limitado como en botones de fila:
+- `"PDF"` → `"Exportar PDF"`
+- `"Ajustar HE"` → `"Ajustar Horas Extra"`
+
+Agregar `->tooltip()` a cada acción cuando varias tienen propósito similar y el label solo no basta para diferenciarlas.
+
+### Filtrar solo empleados activos en selects de modales
+
+Cualquier `Select` de empleado en formularios de acciones (modales) debe filtrar `where('status', 'active')` — nunca mostrar empleados desvinculados o inactivos como opción seleccionable:
+
+```php
+Select::make('employee_id')
+    ->label('Empleado')
+    ->options(fn () => Employee::where('status', 'active')
+        ->orderBy('first_name')->orderBy('last_name')
+        ->get()
+        ->mapWithKeys(fn ($e) => [$e->id => "{$e->first_name} {$e->last_name} (CI: {$e->ci})"])
+        ->toArray()
+    )
+    ->searchable()
+    ->required()
+```
+
+Incluir la CI en el label del option para facilitar la identificación cuando hay homónimos.
+
+### Advertencia reactiva de sobreescritura en patrones `firstOrNew`
+
+Cuando una acción usa `firstOrNew()` o `updateOrCreate()` para crear-o-actualizar un registro, agregar un `Placeholder` reactivo que avise al usuario si el registro ya existe, mostrando su estado actual. Requiere `->live()` en los campos identificadores:
+
+```php
+Select::make('employee_id')->live(),
+DatePicker::make('date')->live(),
+
+Placeholder::make('existing_warning')
+    ->label('')
+    ->content(function (Get $get): ?string {
+        $existing = AttendanceDay::where('employee_id', $get('employee_id'))
+            ->where('date', $get('date'))->first();
+        if (! $existing) {
+            return null;
+        }
+        $statusLabel = AttendanceDay::getStatusLabel($existing->status);
+        $msg = "Ya existe un registro para este empleado en esta fecha (estado: {$statusLabel}";
+        if ((float) $existing->extra_hours > 0) {
+            $msg .= ", {$existing->extra_hours} hrs registradas";
+        }
+
+        return $msg.'). Los valores serán reemplazados.';
+    })
+    ->visible(fn (Get $get): bool =>
+        filled($get('employee_id')) && filled($get('date')) &&
+        AttendanceDay::where('employee_id', $get('employee_id'))
+            ->where('date', $get('date'))->exists()
+    )
+    ->columnSpanFull(),
+```
+
+El `Placeholder` debe mostrar datos relevantes del registro existente (estado, valores actuales) para que el usuario decida conscientemente si continuar.
+
 ### Important Notes
 - Monetary values use `decimal:2` cast
 - `Employee::getAdvanceReferenceSalary()` does **not** yet include the weekly paid rest day for jornaleros — pending automatic calculation

--- a/app/Filament/Resources/AttendanceDayResource.php
+++ b/app/Filament/Resources/AttendanceDayResource.php
@@ -318,14 +318,11 @@ class AttendanceDayResource extends Resource
                     }),
             ])
             ->actions([
-                self::getApproveOvertimeTableAction(),
-
-                self::getApproveTardinessTableAction(),
-
-                self::getExportPdfTableAction(),
-
                 TableActionGroup::make([
+                    self::getApproveOvertimeTableAction(),
+                    self::getApproveTardinessTableAction(),
                     self::getAdjustExtraHoursTableAction(),
+                    self::getExportPdfTableAction(),
                     self::getCalculateTableAction(),
                 ]),
             ])
@@ -752,7 +749,7 @@ class AttendanceDayResource extends Resource
     public static function getExportPdfTableAction(): TableAction
     {
         return TableAction::make('export')
-            ->label('PDF')
+            ->label('Exportar PDF')
             ->icon('heroicon-o-arrow-down-tray')
             ->color('info')
             ->tooltip('Exportar registro como PDF')
@@ -947,7 +944,7 @@ class AttendanceDayResource extends Resource
         $pctNocturno = (int) (($settings->overtime_multiplier_nocturno - 1) * 100);
 
         return TableAction::make('adjust_extra_hours')
-            ->label('Ajustar HE')
+            ->label('Ajustar Horas Extra')
             ->icon('heroicon-o-clock')
             ->color('warning')
             ->tooltip('Cargar horas extras manualmente para este día')


### PR DESCRIPTION
## Resumen

- **Fix Carbon mutation**: `.copy()` antes de `startOfWeek()`/`endOfWeek()` en `buildOvertimeModalDescription()` — evitaba que `$record->date` quedara mutado para el resto del request
- **Fix iconos grises sin marcación**: `getCheckInStatusColor()` / `getCheckOutStatusColor()` retornaban `'success'` cuando el tiempo era null; ahora retornan `'gray'`
- **Fix emojis en modelo**: eliminados de `getStatusMessage()` y `getCalculationStatusMessages()` (incompatibles con algunos entornos)
- **Fix DateTimePicker → solo hora en EventsRelationManager**: el `EditAction` de marcaciones usaba un `DateTimePicker` completo que permitía mover el evento a otro día accidentalmente; reemplazado con `Hidden + Placeholder + TimePicker`
- **Labels dinámicos desde PayrollSettings**: los multiplicadores de horas extras (`+50%`, `+160%`) ya no están hardcodeados en los labels del formulario — se calculan desde `overtime_multiplier_diurno` / `overtime_multiplier_nocturno`
- **Filtro de empleados activos**: el select de empleado en `getRegisterExtraHoursAction()` ahora filtra `where('status', 'active')` e incluye la CI en el label
- **Advertencia de sobreescritura**: `Placeholder` reactivo en `getRegisterExtraHoursAction()` avisa cuando ya existe un `AttendanceDay` para el empleado/fecha seleccionado
- **Acción "Ajustar Horas Extra" en ViewRecord**: agregada a los header actions de `ViewAttendanceDay` (antes solo existía como row action de tabla)
- **Consolidación de row actions en ActionGroup**: las 5 acciones de tabla se agrupan en un único dropdown para evitar congestión visual; labels abreviados expandidos a nombres descriptivos
- **Deploy webhook fix**: curl enviaba `Content-Type: application/x-www-form-urlencoded` por defecto con `-d`; openresty lo rechazaba con HTTP 415 — corregido con `-H "Content-Type: application/json" -d '{}'`
- **Documentación**: guía de usuario `05-asistencias.md` expandida (~180 → ~290 líneas) con secciones nuevas para horas extras manuales, aprobaciones y vista de detalle
- **CLAUDE.md**: 4 nuevas convenciones documentadas (Carbon mutation, Settings en factory estático, ActionGroup, employees activos, firstOrNew warning)

## Test plan

- [ ] Abrir un `AttendanceDay` sin marcación de entrada → el icono de check-in debe mostrarse en gris (no verde)
- [ ] Abrir un `AttendanceDay` sin marcación de salida → el icono de check-out debe mostrarse en gris (no verde)
- [ ] Editar una marcación desde el RelationManager de eventos → el modal muestra fecha no editable y solo permite cambiar la hora
- [ ] En la tabla de `AttendanceDays`, todas las acciones de fila aparecen dentro de un único menú desplegable
- [ ] En `ViewAttendanceDay`, el botón "Ajustar Horas Extra" aparece en el encabezado
- [ ] En la acción "Registrar Horas Extras", seleccionar un empleado y fecha que ya tiene registro → debe aparecer el aviso de sobreescritura
- [ ] El formulario de horas extras muestra porcentajes correctos según la configuración actual de `PayrollSettings`
- [ ] Push a `main` dispara el deploy webhook y retorna HTTP 200

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_