### PR TITLE
feat: filtros en cascada y nuevos filtros Departamento/Empleado en Reporte de Salarios

### DIFF
--- a/app/Exports/SalaryReportExport.php
+++ b/app/Exports/SalaryReportExport.php
@@ -40,6 +40,8 @@ class SalaryReportExport implements FromQuery, ShouldAutoSize, WithEvents, WithH
      * @param  string|null  $status  Filtrar por estado (null = todos).
      * @param  string|null  $paymentMethod  Filtrar por método de pago (null = todos).
      * @param  array<string>  $columns  Claves de columnas a incluir (ver availableColumns()).
+     * @param  int|null  $departmentId  Filtrar por departamento vía contrato activo (null = todos).
+     * @param  int|null  $employeeId  Filtrar por empleado específico (null = todos).
      */
     public function __construct(
         protected ?int $periodId = null,
@@ -48,6 +50,8 @@ class SalaryReportExport implements FromQuery, ShouldAutoSize, WithEvents, WithH
         protected ?string $status = null,
         protected ?string $paymentMethod = null,
         protected array $columns = [],
+        protected ?int $departmentId = null,
+        protected ?int $employeeId = null,
     ) {
         if (empty($this->columns)) {
             $this->columns = static::defaultColumns();
@@ -130,6 +134,15 @@ class SalaryReportExport implements FromQuery, ShouldAutoSize, WithEvents, WithH
             ->when($this->branchId, fn ($q) => $q->where('employees.branch_id', $this->branchId))
             ->when($this->status, fn ($q) => $q->where('payrolls.status', $this->status))
             ->when($this->paymentMethod, fn ($q) => $q->where('payrolls.payment_method', $this->paymentMethod))
+            ->when($this->departmentId, fn ($q) => $q->whereExists(fn ($sub) => $sub
+                ->select(\DB::raw(1))
+                ->from('contracts')
+                ->join('positions', 'positions.id', '=', 'contracts.position_id')
+                ->whereColumn('contracts.employee_id', 'employees.id')
+                ->where('contracts.status', 'active')
+                ->where('positions.department_id', $this->departmentId)
+            ))
+            ->when($this->employeeId, fn ($q) => $q->where('payrolls.employee_id', $this->employeeId))
             ->orderBy('employees.last_name')
             ->orderBy('employees.first_name');
     }
@@ -283,6 +296,15 @@ class SalaryReportExport implements FromQuery, ShouldAutoSize, WithEvents, WithH
             ->when($this->branchId, fn ($q) => $q->where('employees.branch_id', $this->branchId))
             ->when($this->status, fn ($q) => $q->where('payrolls.status', $this->status))
             ->when($this->paymentMethod, fn ($q) => $q->where('payrolls.payment_method', $this->paymentMethod))
+            ->when($this->departmentId, fn ($q) => $q->whereExists(fn ($sub) => $sub
+                ->select(\DB::raw(1))
+                ->from('contracts')
+                ->join('positions', 'positions.id', '=', 'contracts.position_id')
+                ->whereColumn('contracts.employee_id', 'employees.id')
+                ->where('contracts.status', 'active')
+                ->where('positions.department_id', $this->departmentId)
+            ))
+            ->when($this->employeeId, fn ($q) => $q->where('payrolls.employee_id', $this->employeeId))
             ->pluck('payrolls.id');
 
         $base = Payroll::whereIn('id', $payrollIds)

--- a/app/Filament/Pages/SalaryReport.php
+++ b/app/Filament/Pages/SalaryReport.php
@@ -5,6 +5,8 @@ namespace App\Filament\Pages;
 use App\Exports\SalaryReportExport;
 use App\Models\Branch;
 use App\Models\Company;
+use App\Models\Department;
+use App\Models\Employee;
 use App\Models\Payroll;
 use App\Models\PayrollPeriod;
 use Filament\Actions\Action;
@@ -49,14 +51,22 @@ class SalaryReport extends Page implements HasTable
     protected ?string $heading = 'Reporte de Salarios';
 
     /**
-     * Limpia el filtro de planilla cuando cambia la empresa seleccionada,
-     * ya que el período anterior puede no pertenecer a la nueva empresa.
+     * Limpia los filtros dependientes en cascada cuando cambia un filtro padre.
+     * Cadena: empresa → planilla, sucursal, departamento, empleado
+     *         sucursal → empleado
+     *         departamento → empleado
      */
     public function updated(string $name): void
     {
         if ($name === 'tableFilters.company_id.value') {
             $this->tableFilters['period_id']['value'] = '';
             $this->tableFilters['branch_id']['value'] = '';
+            $this->tableFilters['department_id']['value'] = '';
+            $this->tableFilters['employee_id']['value'] = '';
+        }
+
+        if ($name === 'tableFilters.branch_id.value' || $name === 'tableFilters.department_id.value') {
+            $this->tableFilters['employee_id']['value'] = '';
         }
     }
 
@@ -100,10 +110,6 @@ class SalaryReport extends Page implements HasTable
         $columnOptions = SalaryReportExport::availableColumns();
         $columnDefaults = SalaryReportExport::defaultColumns();
 
-        if (Company::active()->count() <= 1) {
-            // company_name no está en las columnas del SalaryReport, no hay ajuste necesario
-        }
-
         $subtableOptions = [
             'perceptions' => 'Desglose de Percepciones',
             'deductions' => 'Desglose de Deducciones',
@@ -138,12 +144,14 @@ class SalaryReport extends Page implements HasTable
                         ->required(),
                 ])
                 ->action(function (array $data) {
-                    [$periodId, $companyId, $branchId, $status, $paymentMethod] = $this->resolveActiveFilters();
+                    [$periodId, $companyId, $branchId, $status, $paymentMethod, $departmentId, $employeeId] = $this->resolveActiveFilters();
 
                     $params = array_filter([
                         'periodId' => $periodId,
                         'companyId' => $companyId,
                         'branchId' => $branchId,
+                        'departmentId' => $departmentId,
+                        'employeeId' => $employeeId,
                         'status' => $status,
                         'paymentMethod' => $paymentMethod,
                         'columns' => implode(',', $data['columns']),
@@ -172,7 +180,7 @@ class SalaryReport extends Page implements HasTable
                         ->required(),
                 ])
                 ->action(function (array $data) {
-                    [$periodId, $companyId, $branchId, $status, $paymentMethod] = $this->resolveActiveFilters();
+                    [$periodId, $companyId, $branchId, $status, $paymentMethod, $departmentId, $employeeId] = $this->resolveActiveFilters();
 
                     Notification::make()
                         ->success()
@@ -181,7 +189,7 @@ class SalaryReport extends Page implements HasTable
                         ->send();
 
                     return Excel::download(
-                        new SalaryReportExport($periodId, $companyId, $branchId, $status, $paymentMethod, $data['columns']),
+                        new SalaryReportExport($periodId, $companyId, $branchId, $status, $paymentMethod, $data['columns'], $departmentId, $employeeId),
                         'salarios_'.now()->format('Y_m_d_H_i').'.xlsx'
                     );
                 }),
@@ -193,7 +201,7 @@ class SalaryReport extends Page implements HasTable
         return $table
             ->query($this->buildQuery())
             ->filters($this->buildFilters(), layout: FiltersLayout::AboveContent)
-            ->filtersFormColumns(5)
+            ->filtersFormColumns(4)
             ->persistFiltersInSession()
             ->defaultSort('employees.last_name', 'asc')
             ->paginationPageOptions([25, 50, 100])
@@ -348,6 +356,11 @@ class SalaryReport extends Page implements HasTable
     }
 
     /**
+     * Construye los filtros con cascada dinámica:
+     * Empresa → Planilla, Sucursal, Departamento, Empleado
+     * Sucursal → Empleado
+     * Departamento → Empleado
+     *
      * @return array<int, mixed>
      */
     private function buildFilters(): array
@@ -374,41 +387,134 @@ class SalaryReport extends Page implements HasTable
                 );
         }
 
-        $filters[] = SelectFilter::make('period_id')
-            ->label('Planilla')
-            ->options(function () {
-                $companyId = $this->tableFilters['company_id']['value'] ?? null;
-                $showCompanyInLabel = Company::active()->count() > 1 && ! $companyId;
+        $filters[] = Filter::make('period_id')
+            ->form([
+                FormSelect::make('value')
+                    ->label('Planilla')
+                    ->options(function () {
+                        $companyId = $this->tableFilters['company_id']['value'] ?? null;
+                        $showCompanyInLabel = Company::active()->count() > 1 && ! $companyId;
 
-                return PayrollPeriod::when($companyId, fn ($q) => $q->where('company_id', $companyId))
-                    ->when($showCompanyInLabel, fn ($q) => $q->with('company'))
-                    ->orderByDesc('start_date')
-                    ->get()
-                    ->mapWithKeys(fn ($p) => [
-                        $p->id => $showCompanyInLabel
-                            ? "{$p->name} — {$p->company->name}"
-                            : $p->name,
-                    ])
-                    ->toArray();
-            })
-            ->searchable()
-            ->query(
-                fn (Builder $query, array $data) => $data['value']
-                    ? $query->where('payrolls.payroll_period_id', $data['value'])
-                    : $query
+                        return PayrollPeriod::when($companyId, fn ($q) => $q->where('company_id', $companyId))
+                            ->when($showCompanyInLabel, fn ($q) => $q->with('company'))
+                            ->orderByDesc('start_date')
+                            ->get()
+                            ->mapWithKeys(fn ($p) => [
+                                $p->id => $showCompanyInLabel
+                                    ? "{$p->name} — {$p->company->name}"
+                                    : $p->name,
+                            ])
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->placeholder('Seleccione una planilla')
+                    ->live(),
+            ])
+            ->query(fn (Builder $query, array $data) => filled($data['value'])
+                ? $query->where('payrolls.payroll_period_id', (int) $data['value'])
+                : $query
+            )
+            ->indicateUsing(fn (array $data): ?string => filled($data['value'])
+                ? 'Planilla: '.PayrollPeriod::find($data['value'])?->name
+                : null
             );
 
-        return array_merge($filters, [
-            SelectFilter::make('branch_id')
-                ->label('Sucursal')
-                ->options(fn () => Branch::orderBy('name')->pluck('name', 'id'))
-                ->searchable()
-                ->query(
-                    fn (Builder $query, array $data) => $data['value']
-                        ? $query->where('employees.branch_id', $data['value'])
-                        : $query
-                ),
+        $filters[] = Filter::make('branch_id')
+            ->form([
+                FormSelect::make('value')
+                    ->label('Sucursal')
+                    ->options(function () {
+                        $companyId = $this->tableFilters['company_id']['value'] ?? null;
 
+                        return Branch::when($companyId, fn ($q) => $q->where('company_id', $companyId))
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->placeholder('Todas')
+                    ->live(),
+            ])
+            ->query(fn (Builder $query, array $data) => filled($data['value'])
+                ? $query->where('employees.branch_id', (int) $data['value'])
+                : $query
+            )
+            ->indicateUsing(fn (array $data): ?string => filled($data['value'])
+                ? 'Sucursal: '.Branch::find($data['value'])?->name
+                : null
+            );
+
+        $filters[] = Filter::make('department_id')
+            ->form([
+                FormSelect::make('value')
+                    ->label('Departamento')
+                    ->options(function () {
+                        $companyId = $this->tableFilters['company_id']['value'] ?? null;
+
+                        return Department::when($companyId, fn ($q) => $q->where('company_id', $companyId))
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->placeholder('Todos')
+                    ->live(),
+            ])
+            ->query(fn (Builder $query, array $data) => filled($data['value'])
+                ? $query->whereExists(fn ($sub) => $sub
+                    ->select(DB::raw(1))
+                    ->from('contracts')
+                    ->join('positions', 'positions.id', '=', 'contracts.position_id')
+                    ->whereColumn('contracts.employee_id', 'employees.id')
+                    ->where('contracts.status', 'active')
+                    ->where('positions.department_id', (int) $data['value'])
+                )
+                : $query
+            )
+            ->indicateUsing(fn (array $data): ?string => filled($data['value'])
+                ? 'Departamento: '.Department::find($data['value'])?->name
+                : null
+            );
+
+        $filters[] = Filter::make('employee_id')
+            ->form([
+                FormSelect::make('value')
+                    ->label('Empleado')
+                    ->options(function () {
+                        $companyId = $this->tableFilters['company_id']['value'] ?? null;
+                        $branchId = $this->tableFilters['branch_id']['value'] ?? null;
+                        $departmentId = $this->tableFilters['department_id']['value'] ?? null;
+
+                        return Employee::query()
+                            ->when($companyId, fn ($q) => $q->whereHas('branch', fn ($b) => $b->where('company_id', $companyId)))
+                            ->when($branchId, fn ($q) => $q->where('branch_id', $branchId))
+                            ->when($departmentId, fn ($q) => $q->whereHas('contracts', fn ($c) => $c
+                                ->where('status', 'active')
+                                ->whereHas('position', fn ($p) => $p->where('department_id', $departmentId))
+                            ))
+                            ->orderBy('first_name')
+                            ->orderBy('last_name')
+                            ->get()
+                            ->mapWithKeys(fn ($e) => [$e->id => "{$e->first_name} {$e->last_name} (CI: {$e->ci})"])
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->placeholder('Todos'),
+            ])
+            ->query(fn (Builder $query, array $data) => filled($data['value'])
+                ? $query->where('payrolls.employee_id', (int) $data['value'])
+                : $query
+            )
+            ->indicateUsing(function (array $data): ?string {
+                if (! filled($data['value'])) {
+                    return null;
+                }
+                $employee = Employee::find($data['value']);
+
+                return $employee ? "Empleado: {$employee->first_name} {$employee->last_name}" : null;
+            });
+
+        return array_merge($filters, [
             SelectFilter::make('status')
                 ->label('Estado')
                 ->options(Payroll::getStatusLabels())
@@ -434,7 +540,7 @@ class SalaryReport extends Page implements HasTable
     /**
      * Extrae los valores activos de los filtros para export/PDF.
      *
-     * @return array{int|null, int|null, int|null, string|null, string|null}
+     * @return array{int|null, int|null, int|null, string|null, string|null, int|null, int|null}
      */
     private function resolveActiveFilters(): array
     {
@@ -446,6 +552,8 @@ class SalaryReport extends Page implements HasTable
             isset($f['branch_id']['value']) && $f['branch_id']['value'] !== '' ? (int) $f['branch_id']['value'] : null,
             isset($f['status']['value']) && $f['status']['value'] !== '' ? $f['status']['value'] : null,
             isset($f['payment_method']['value']) && $f['payment_method']['value'] !== '' ? $f['payment_method']['value'] : null,
+            isset($f['department_id']['value']) && $f['department_id']['value'] !== '' ? (int) $f['department_id']['value'] : null,
+            isset($f['employee_id']['value']) && $f['employee_id']['value'] !== '' ? (int) $f['employee_id']['value'] : null,
         ];
     }
 }

--- a/app/Filament/Pages/SalaryReport.php
+++ b/app/Filament/Pages/SalaryReport.php
@@ -196,7 +196,7 @@ class SalaryReport extends Page implements HasTable
             ->filtersFormColumns(5)
             ->persistFiltersInSession()
             ->defaultSort('employees.last_name', 'asc')
-            ->paginated([25, 50, 100, 'all'])
+            ->paginationPageOptions([25, 50, 100])
             ->striped()
             ->columns([
                 TextColumn::make('employee_name')
@@ -308,10 +308,16 @@ class SalaryReport extends Page implements HasTable
 
     /**
      * Query base con subqueries para montos de deducciones por tipo.
+     * Retorna 0 registros si no hay planilla seleccionada — la guardia aquí es
+     * necesaria porque SelectFilter puede omitir su callback cuando está inactivo.
      */
     private function buildQuery(): Builder
     {
-        return Payroll::query()
+        $periodId = isset($this->tableFilters['period_id']['value']) && $this->tableFilters['period_id']['value'] !== ''
+            ? (int) $this->tableFilters['period_id']['value']
+            : null;
+
+        $query = Payroll::query()
             ->select([
                 'payrolls.id',
                 'payrolls.employee_id',
@@ -333,6 +339,12 @@ class SalaryReport extends Page implements HasTable
             ])
             ->join('employees', 'employees.id', '=', 'payrolls.employee_id')
             ->join('branches', 'branches.id', '=', 'employees.branch_id');
+
+        if (! $periodId) {
+            $query->whereRaw('1=0');
+        }
+
+        return $query;
     }
 
     /**
@@ -383,7 +395,7 @@ class SalaryReport extends Page implements HasTable
             ->query(
                 fn (Builder $query, array $data) => $data['value']
                     ? $query->where('payrolls.payroll_period_id', $data['value'])
-                    : $query->whereRaw('1=0')
+                    : $query
             );
 
         return array_merge($filters, [

--- a/app/Http/Controllers/SalaryReportController.php
+++ b/app/Http/Controllers/SalaryReportController.php
@@ -26,6 +26,8 @@ class SalaryReportController extends Controller
         $periodId = $request->query('periodId') ? (int) $request->query('periodId') : null;
         $companyId = $request->query('companyId') ? (int) $request->query('companyId') : null;
         $branchId = $request->query('branchId') ? (int) $request->query('branchId') : null;
+        $departmentId = $request->query('departmentId') ? (int) $request->query('departmentId') : null;
+        $employeeId = $request->query('employeeId') ? (int) $request->query('employeeId') : null;
         $status = $request->query('status') ?: null;
         $paymentMethod = $request->query('paymentMethod') ?: null;
 
@@ -74,6 +76,15 @@ class SalaryReportController extends Controller
             ->when($branchId, fn ($q) => $q->where('employees.branch_id', $branchId))
             ->when($status, fn ($q) => $q->where('payrolls.status', $status))
             ->when($paymentMethod, fn ($q) => $q->where('payrolls.payment_method', $paymentMethod))
+            ->when($departmentId, fn ($q) => $q->whereExists(fn ($sub) => $sub
+                ->select(\DB::raw(1))
+                ->from('contracts')
+                ->join('positions', 'positions.id', '=', 'contracts.position_id')
+                ->whereColumn('contracts.employee_id', 'employees.id')
+                ->where('contracts.status', 'active')
+                ->where('positions.department_id', $departmentId)
+            ))
+            ->when($employeeId, fn ($q) => $q->where('payrolls.employee_id', $employeeId))
             ->orderBy('employees.last_name')
             ->orderBy('employees.first_name')
             ->get();
@@ -132,6 +143,13 @@ class SalaryReportController extends Controller
         }
         if ($branchId) {
             $appliedFilters['Sucursal'] = Branch::find($branchId)?->name ?? 'ID '.$branchId;
+        }
+        if ($departmentId) {
+            $appliedFilters['Departamento'] = \App\Models\Department::find($departmentId)?->name ?? 'ID '.$departmentId;
+        }
+        if ($employeeId) {
+            $emp = \App\Models\Employee::find($employeeId);
+            $appliedFilters['Empleado'] = $emp ? "{$emp->first_name} {$emp->last_name}" : 'ID '.$employeeId;
         }
         if ($status) {
             $appliedFilters['Estado'] = Payroll::getStatusLabels()[$status] ?? $status;

--- a/app/Observers/AttendanceEventObserver.php
+++ b/app/Observers/AttendanceEventObserver.php
@@ -20,15 +20,13 @@ class AttendanceEventObserver
 
     /**
      * Handle the AttendanceEvent "created" event.
-     * Crear o actualizar AttendanceDay cuando se marca entrada
+     * Recalcula el AttendanceDay en tres situaciones:
+     * - check_in cuando el día estaba marcado como ausente (entrada tardía)
+     * - check_out: actualiza horas trabajadas y horas extras en tiempo real
+     * - break_end: actualiza minutos de pausa en tiempo real
      */
     public function created(AttendanceEvent $attendanceEvent): void
     {
-        // Solo procesar eventos de check_in (entrada)
-        if ($attendanceEvent->event_type !== 'check_in') {
-            return;
-        }
-
         try {
             $day = $attendanceEvent->day;
 
@@ -41,15 +39,24 @@ class AttendanceEventObserver
                 return;
             }
 
-            // Si el registro existe y está marcado como ausente, actualizarlo
-            if ($day->status === 'absent') {
+            $type = $attendanceEvent->event_type;
+
+            // Entrada tardía: el día ya existía como ausente y ahora el empleado llegó
+            if ($type === 'check_in' && $day->status === 'absent') {
                 Log::info("Entrada tardía registrada — CI {$attendanceEvent->employee_ci} {$attendanceEvent->employee_name}: de ausente a presente ({$day->date})", [
                     'attendance_day_id' => $day->id,
                     'employee_id' => $day->employee_id,
                     'date' => $day->date,
                 ]);
 
-                // Calcular y actualizar el registro
+                AttendanceCalculator::apply($day);
+                $day->save();
+
+                return;
+            }
+
+            // Salida o fin de pausa: recalcular totales y horas extras en tiempo real
+            if ($type === 'check_out' || $type === 'break_end') {
                 AttendanceCalculator::apply($day);
                 $day->save();
             }

--- a/tests/Feature/AttendanceEventObserverTest.php
+++ b/tests/Feature/AttendanceEventObserverTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function seedObserverSettings(): void
+{
+    $settings = [
+        'overtime_max_daily_hours' => 3,
+        'overtime_multiplier_nocturno_holiday' => 2.6,
+        'min_salary_monthly' => 2_550_328,
+        'min_salary_daily_jornal' => 87_950,
+        'family_bonus_percentage' => 5.0,
+    ];
+
+    foreach ($settings as $name => $value) {
+        DB::table('settings')->updateOrInsert(
+            ['group' => 'payroll', 'name' => $name],
+            ['payload' => json_encode($value)]
+        );
+    }
+}
+
+function makeObsEmployee(): Employee
+{
+    static $ci = 9000000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Obs',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'email' => "obs{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => Carbon::now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+function makeObsDay(Employee $employee, string $status = 'present', array $attrs = []): AttendanceDay
+{
+    return AttendanceDay::create(array_merge([
+        'employee_id' => $employee->id,
+        'date' => '2026-03-16',
+        'status' => $status,
+        'expected_check_in' => '08:00:00',
+        'expected_check_out' => '17:00:00',
+        'expected_hours' => 9.0,
+        'is_calculated' => true,
+        'is_weekend' => false,
+        'is_holiday' => false,
+        'on_vacation' => false,
+        'justified_absence' => false,
+    ], $attrs));
+}
+
+function createObsEvent(AttendanceDay $day, string $type, string $time): AttendanceEvent
+{
+    return AttendanceEvent::create([
+        'attendance_day_id' => $day->id,
+        'employee_id' => $day->employee_id,
+        'event_type' => $type,
+        'recorded_at' => Carbon::parse('2026-03-16 '.$time),
+    ]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+beforeEach(fn () => seedObserverSettings());
+
+it('recalcula el día al registrar check_out', function () {
+    $employee = makeObsEmployee();
+    $day = makeObsDay($employee);
+
+    createObsEvent($day, 'check_in', '08:00:00');
+    createObsEvent($day, 'check_out', '19:00:00'); // 11h total → 2h extras
+
+    $day->refresh();
+
+    expect($day->check_out_time)->toBe('19:00:00')
+        ->and((float) $day->extra_hours)->toBe(2.0)
+        ->and($day->status)->toBe('present');
+});
+
+it('recalcula el día al registrar break_end', function () {
+    $employee = makeObsEmployee();
+    $day = makeObsDay($employee);
+
+    createObsEvent($day, 'check_in', '08:00:00');
+    createObsEvent($day, 'break_start', '12:00:00');
+    createObsEvent($day, 'break_end', '13:00:00'); // 60 min pausa → recalcula
+
+    $day->refresh();
+
+    expect($day->break_minutes)->toBe(60);
+});
+
+it('recalcula al registrar check_in cuando el día estaba ausente', function () {
+    $employee = makeObsEmployee();
+    $day = makeObsDay($employee, 'absent');
+
+    createObsEvent($day, 'check_in', '10:00:00'); // Llegada tardía
+
+    $day->refresh();
+
+    expect($day->status)->toBe('present')
+        ->and($day->check_in_time)->toBe('10:00:00');
+});
+
+it('NO recalcula al registrar check_in si el día ya estaba presente', function () {
+    $employee = makeObsEmployee();
+    $day = makeObsDay($employee, 'present', [
+        'check_in_time' => '08:00:00',
+        'check_out_time' => '17:00:00',
+        'total_hours' => 9.0,
+        'net_hours' => 9.0,
+        'extra_hours' => 0.0,
+    ]);
+
+    // Un segundo check_in no debe disparar recálculo
+    createObsEvent($day, 'check_in', '08:05:00');
+
+    $day->refresh();
+
+    // Los valores se mantienen — no hubo recálculo por check_in presente
+    expect($day->total_hours)->toBe('9.00');
+});
+
+it('no recalcula al registrar break_start', function () {
+    $employee = makeObsEmployee();
+    $day = makeObsDay($employee, 'present', [
+        'check_in_time' => '08:00:00',
+        'break_minutes' => 0,
+    ]);
+
+    createObsEvent($day, 'check_in', '08:00:00');
+    createObsEvent($day, 'break_start', '12:00:00');
+
+    $day->refresh();
+
+    // break_start solo no actualiza break_minutes (aún no hay break_end)
+    expect($day->break_minutes)->toBe(0);
+});


### PR DESCRIPTION
## Resumen

- Todos los filtros del Reporte de Salarios son ahora dinámicos y se filtran en cascada según las selecciones previas
- Se agregaron dos nuevos filtros: **Departamento** y **Empleado**
- Se corrigió un bug donde la tabla mostraba todos los recibos si no había planilla seleccionada
- Se agregó recálculo inmediato del día de asistencia al registrar `check_out` o `break_end` (via observer)

## Detalle de cambios

### Reporte de Salarios — filtros en cascada

**Cadena de dependencias:**
```
Empresa → Planilla, Sucursal, Departamento, Empleado
Sucursal → Empleado
Departamento → Empleado
```

Al cambiar un filtro padre, los hijos se limpian automáticamente y sus opciones se recalculan para mostrar solo los registros de la selección activa.

**Conversiones:** `period_id` y `branch_id` pasaron de `SelectFilter` a `Filter::make()` con `FormSelect + ->live()` para que sus opciones reaccionen a la empresa seleccionada.

**Nuevos filtros:**
- **Departamento** — usa `WHERE EXISTS` correlacionado a través de `contracts → positions → department_id`
- **Empleado** — filtra directamente por `payrolls.employee_id`; sus opciones se reducen según empresa, sucursal y departamento activos

Ambos filtros se propagan al export **Excel** (`SalaryReportExport`) y al **PDF** (`SalaryReportController`), incluyendo el encabezado de filtros aplicados en el PDF.

### Asistencias — recálculo en tiempo real

El `AttendanceEventObserver` ahora dispara `AttendanceCalculator::apply()` al registrar `check_out` (actualiza horas trabajadas y extras) y `break_end` (actualiza minutos de pausa), además del ya existente `check_in` en días ausentes.

## Plan de pruebas

- [ ] Seleccionar una empresa: verificar que Planilla y Sucursal solo muestren opciones de esa empresa
- [ ] Seleccionar una sucursal: verificar que Empleado solo muestre empleados de esa sucursal
- [ ] Seleccionar un departamento: verificar que Empleado solo muestre empleados de ese departamento
- [ ] Cambiar la empresa seleccionada: verificar que todos los filtros dependientes se limpian
- [ ] Exportar PDF/Excel con filtros de departamento y empleado activos: verificar que el resultado respete los filtros
- [ ] Registrar un `check_out` en el módulo de asistencias: verificar que `extra_hours` y `total_hours` se actualizan sin necesidad de recálculo manual

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_