### PR TITLE
feat: permisos parciales por horas en módulo de Licencias

### DIFF
--- a/app/Filament/Resources/EmployeeLeaveResource.php
+++ b/app/Filament/Resources/EmployeeLeaveResource.php
@@ -5,13 +5,17 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\EmployeeLeaveResource\Pages;
 use App\Models\Absence;
 use App\Models\EmployeeLeave;
+use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TimePicker;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
+use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\Section as InfolistSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
@@ -116,19 +120,65 @@ class EmployeeLeaveResource extends Resource
                             ->content(function (Get $get) {
                                 $start = $get('start_date');
                                 $end = $get('end_date');
+                                $startTime = $get('start_time');
+                                $endTime = $get('end_time');
 
                                 if (! $start || ! $end) {
                                     return '-';
                                 }
 
-                                $days = \Carbon\Carbon::parse($start)
-                                    ->diffInDays(\Carbon\Carbon::parse($end)) + 1;
+                                // Permiso parcial: mostrar horas
+                                if (filled($startTime) && filled($endTime)) {
+                                    $from = Carbon::parse($start.' '.$startTime);
+                                    $to = Carbon::parse($start.' '.$endTime);
+                                    if ($to->gt($from)) {
+                                        $diffMinutes = (int) $from->diffInMinutes($to);
+                                        $hours = intdiv($diffMinutes, 60);
+                                        $minutes = $diffMinutes % 60;
+
+                                        return $minutes > 0
+                                            ? "{$hours}h {$minutes}min"
+                                            : "{$hours}h";
+                                    }
+                                }
+
+                                $days = (int) Carbon::parse($start)->diffInDays(Carbon::parse($end)) + 1;
 
                                 return $days.' '.($days === 1 ? 'día' : 'días');
                             })
                             ->columnSpan(1),
                     ])
                     ->columns(3),
+
+                Section::make('Permiso por horas (opcional)')
+                    ->description('Completa este bloque solo si el permiso es parcial (no abarca el día completo).')
+                    ->schema([
+                        TimePicker::make('start_time')
+                            ->label('Hora de inicio')
+                            ->seconds(false)
+                            ->native(false)
+                            ->live()
+                            ->columnSpan(1),
+
+                        TimePicker::make('end_time')
+                            ->label('Hora de fin')
+                            ->seconds(false)
+                            ->native(false)
+                            ->live()
+                            ->after('start_time')
+                            ->required(fn (Get $get) => filled($get('start_time')))
+                            ->columnSpan(1),
+
+                        Toggle::make('generates_deduction')
+                            ->label('Genera descuento en la próxima nómina')
+                            ->helperText('El monto se calcula automáticamente según el salario y las horas tomadas.')
+                            ->default(false)
+                            ->visible(fn (Get $get) => filled($get('start_time')) && filled($get('end_time')))
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
+                    ->collapsible()
+                    ->collapsed(fn (?EmployeeLeave $record) => ! $record?->isPartialDay()),
 
                 Section::make('Detalles')
                     ->schema([
@@ -186,13 +236,21 @@ class EmployeeLeaveResource extends Resource
                     ->sortable()
                     ->searchable(),
 
-                TextColumn::make('days')
-                    ->label('Días')
-                    ->getStateUsing(function ($record) {
-                        $start = \Carbon\Carbon::parse($record->start_date);
-                        $end = \Carbon\Carbon::parse($record->end_date);
+                TextColumn::make('duration')
+                    ->label('Duración')
+                    ->getStateUsing(function (EmployeeLeave $record): string {
+                        if ($record->isPartialDay()) {
+                            $diffMinutes = (int) (Carbon::parse($record->start_date->format('Y-m-d').' '.$record->start_time)
+                                ->diffInMinutes(Carbon::parse($record->start_date->format('Y-m-d').' '.$record->end_time)));
+                            $hours = intdiv($diffMinutes, 60);
+                            $minutes = $diffMinutes % 60;
 
-                        return (int) $start->diffInDays($end) + 1;
+                            return $minutes > 0 ? "{$hours}h {$minutes}min" : "{$hours}h";
+                        }
+
+                        $days = (int) $record->start_date->diffInDays($record->end_date) + 1;
+
+                        return $days.' '.($days === 1 ? 'día' : 'días');
                     })
                     ->badge()
                     ->color('primary')
@@ -256,6 +314,17 @@ class EmployeeLeaveResource extends Resource
                         ->requiresConfirmation()
                         ->modalHeading('Aprobar Licencia')
                         ->modalDescription(function (EmployeeLeave $record) {
+                            if ($record->isPartialDay()) {
+                                $hours = $record->durationInHours();
+                                $base = "Se aprobará el permiso parcial ({$record->start_time} - {$record->end_time}).";
+                                if ($record->generates_deduction) {
+                                    $amount = number_format($record->calculatedDeductionAmount(), 0, ',', '.');
+                                    $base .= " Se generará un descuento de Gs. {$amount} en la próxima nómina.";
+                                }
+
+                                return $base;
+                            }
+
                             $count = Absence::where('employee_id', $record->employee_id)
                                 ->whereHas('attendanceDay', fn ($q) => $q->whereBetween('date', [$record->start_date, $record->end_date]))
                                 ->whereIn('status', ['pending', 'unjustified'])
@@ -273,9 +342,15 @@ class EmployeeLeaveResource extends Resource
                         ->action(function (EmployeeLeave $record) {
                             $result = $record->approve(Auth::id());
 
-                            $body = $result['justified_count'] > 0
-                                ? "Se justificaron {$result['justified_count']} ausencia(s) del período automáticamente."
-                                : 'La licencia fue aprobada. No había ausencias pendientes en el período.';
+                            if ($record->isPartialDay()) {
+                                $body = $record->generates_deduction
+                                    ? 'El permiso fue aprobado. Se generó un descuento para la próxima nómina.'
+                                    : 'El permiso fue aprobado.';
+                            } else {
+                                $body = $result['justified_count'] > 0
+                                    ? "Se justificaron {$result['justified_count']} ausencia(s) del período automáticamente."
+                                    : 'La licencia fue aprobada. No había ausencias pendientes en el período.';
+                            }
 
                             Notification::make()
                                 ->success()
@@ -410,9 +485,18 @@ class EmployeeLeaveResource extends Resource
                             ->icon('heroicon-o-calendar')
                             ->columnSpan(1),
 
-                        TextEntry::make('duration')
+                        TextEntry::make('duration_display')
                             ->label('Duración total')
-                            ->getStateUsing(function ($record) {
+                            ->getStateUsing(function (EmployeeLeave $record): string {
+                                if ($record->isPartialDay()) {
+                                    $diffMinutes = (int) Carbon::parse($record->start_date->format('Y-m-d').' '.$record->start_time)
+                                        ->diffInMinutes(Carbon::parse($record->start_date->format('Y-m-d').' '.$record->end_time));
+                                    $hours = intdiv($diffMinutes, 60);
+                                    $minutes = $diffMinutes % 60;
+
+                                    return $minutes > 0 ? "{$hours}h {$minutes}min" : "{$hours}h";
+                                }
+
                                 $days = (int) $record->start_date->diffInDays($record->end_date) + 1;
 
                                 return $days.' '.($days === 1 ? 'día' : 'días');
@@ -423,6 +507,37 @@ class EmployeeLeaveResource extends Resource
                             ->columnSpan(1),
                     ])
                     ->columns(3),
+
+                InfolistSection::make('Horario del permiso parcial')
+                    ->schema([
+                        TextEntry::make('start_time')
+                            ->label('Hora de inicio')
+                            ->icon('heroicon-o-clock')
+                            ->columnSpan(1),
+
+                        TextEntry::make('end_time')
+                            ->label('Hora de fin')
+                            ->icon('heroicon-o-clock')
+                            ->columnSpan(1),
+
+                        IconEntry::make('generates_deduction')
+                            ->label('Genera descuento en nómina')
+                            ->boolean()
+                            ->columnSpan(1),
+
+                        TextEntry::make('deduction_amount_display')
+                            ->label('Monto del descuento')
+                            ->getStateUsing(fn (EmployeeLeave $record) => $record->employee_deduction_id
+                                ? 'Gs. '.number_format($record->employeeDeduction?->custom_amount ?? 0, 0, ',', '.')
+                                : ($record->generates_deduction ? 'Gs. '.number_format($record->calculatedDeductionAmount(), 0, ',', '.') : '—')
+                            )
+                            ->badge()
+                            ->color('warning')
+                            ->visible(fn (EmployeeLeave $record) => $record->generates_deduction)
+                            ->columnSpan(1),
+                    ])
+                    ->columns(4)
+                    ->visible(fn (EmployeeLeave $record) => $record->isPartialDay()),
             ]);
     }
 

--- a/app/Filament/Resources/EmployeeLeaveResource/Pages/ViewEmployeeLeaves.php
+++ b/app/Filament/Resources/EmployeeLeaveResource/Pages/ViewEmployeeLeaves.php
@@ -31,6 +31,17 @@ class ViewEmployeeLeaves extends ViewRecord
                 ->modalHeading('Aprobar Licencia')
                 ->modalDescription(function () {
                     $record = $this->record;
+
+                    if ($record->isPartialDay()) {
+                        $base = "Se aprobará el permiso parcial ({$record->start_time} - {$record->end_time}).";
+                        if ($record->generates_deduction) {
+                            $amount = number_format($record->calculatedDeductionAmount(), 0, ',', '.');
+                            $base .= " Se generará un descuento de Gs. {$amount} en la próxima nómina.";
+                        }
+
+                        return $base;
+                    }
+
                     $count = Absence::where('employee_id', $record->employee_id)
                         ->whereHas('attendanceDay', fn ($q) => $q->whereBetween('date', [$record->start_date, $record->end_date]))
                         ->whereIn('status', ['pending', 'unjustified'])
@@ -48,9 +59,15 @@ class ViewEmployeeLeaves extends ViewRecord
                 ->action(function () {
                     $result = $this->record->approve(Auth::id());
 
-                    $body = $result['justified_count'] > 0
-                        ? "Se justificaron {$result['justified_count']} ausencia(s) del período automáticamente."
-                        : 'La licencia fue aprobada. No había ausencias pendientes en el período.';
+                    if ($this->record->isPartialDay()) {
+                        $body = $this->record->generates_deduction
+                            ? 'El permiso fue aprobado. Se generó un descuento para la próxima nómina.'
+                            : 'El permiso fue aprobado.';
+                    } else {
+                        $body = $result['justified_count'] > 0
+                            ? "Se justificaron {$result['justified_count']} ausencia(s) del período automáticamente."
+                            : 'La licencia fue aprobada. No había ausencias pendientes en el período.';
+                    }
 
                     Notification::make()
                         ->success()

--- a/app/Filament/Resources/EmployeeResource/RelationManagers/LeavesRelationManager.php
+++ b/app/Filament/Resources/EmployeeResource/RelationManagers/LeavesRelationManager.php
@@ -2,13 +2,19 @@
 
 namespace App\Filament\Resources\EmployeeResource\RelationManagers;
 
+use App\Models\Absence;
 use App\Models\EmployeeLeave;
+use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TimePicker;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
@@ -22,6 +28,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
 /** Gestiona las licencias del empleado desde su vista de detalle. */
@@ -60,6 +67,14 @@ class LeavesRelationManager extends RelationManager
                     ->default(now())
                     ->native(false)
                     ->required()
+                    ->live()
+                    ->afterStateUpdated(function (Get $get, $set) {
+                        $startDate = $get('start_date');
+                        $endDate = $get('end_date');
+                        if ($startDate && $endDate && $endDate < $startDate) {
+                            $set('end_date', null);
+                        }
+                    })
                     ->maxDate(fn (Get $get) => $get('end_date')),
 
                 DatePicker::make('end_date')
@@ -69,6 +84,59 @@ class LeavesRelationManager extends RelationManager
                     ->required()
                     ->minDate(fn (Get $get) => $get('start_date'))
                     ->afterOrEqual('start_date'),
+
+                Placeholder::make('duration')
+                    ->label('Duración')
+                    ->content(function (Get $get) {
+                        $start = $get('start_date');
+                        $end = $get('end_date');
+                        $startTime = $get('start_time');
+                        $endTime = $get('end_time');
+
+                        if (! $start || ! $end) {
+                            return '-';
+                        }
+
+                        if (filled($startTime) && filled($endTime)) {
+                            $from = Carbon::parse($start.' '.$startTime);
+                            $to = Carbon::parse($start.' '.$endTime);
+                            if ($to->gt($from)) {
+                                $diffMinutes = (int) $from->diffInMinutes($to);
+                                $hours = intdiv($diffMinutes, 60);
+                                $minutes = $diffMinutes % 60;
+
+                                return $minutes > 0 ? "{$hours}h {$minutes}min" : "{$hours}h";
+                            }
+                        }
+
+                        $days = (int) Carbon::parse($start)->diffInDays(Carbon::parse($end)) + 1;
+
+                        return $days.' '.($days === 1 ? 'día' : 'días');
+                    }),
+
+                // Partial-day section — hidden by default, collapsed unless record is partial
+                TimePicker::make('start_time')
+                    ->label('Hora de inicio (permiso parcial)')
+                    ->seconds(false)
+                    ->native(false)
+                    ->live()
+                    ->columnSpanFull(),
+
+                TimePicker::make('end_time')
+                    ->label('Hora de fin (permiso parcial)')
+                    ->seconds(false)
+                    ->native(false)
+                    ->live()
+                    ->after('start_time')
+                    ->required(fn (Get $get) => filled($get('start_time')))
+                    ->columnSpanFull(),
+
+                Toggle::make('generates_deduction')
+                    ->label('Genera descuento en la próxima nómina')
+                    ->helperText('El monto se calcula automáticamente según el salario y las horas tomadas.')
+                    ->default(false)
+                    ->visible(fn (Get $get) => filled($get('start_time')) && filled($get('end_time')))
+                    ->columnSpanFull(),
 
                 Textarea::make('reason')
                     ->label('Descripción o motivo')
@@ -119,7 +187,18 @@ class LeavesRelationManager extends RelationManager
                         fn ($record) => $record->start_date->format('d/m/Y').' → '.$record->end_date->format('d/m/Y')
                     )
                     ->description(function ($record) {
-                        $days = $record->start_date->diffInDays($record->end_date) + 1;
+                        if ($record->isPartialDay()) {
+                            $diffMinutes = (int) Carbon::parse($record->start_date->format('Y-m-d').' '.$record->start_time)
+                                ->diffInMinutes(Carbon::parse($record->start_date->format('Y-m-d').' '.$record->end_time));
+                            $hours = intdiv($diffMinutes, 60);
+                            $minutes = $diffMinutes % 60;
+
+                            return $minutes > 0
+                                ? "{$record->start_time} – {$record->end_time} ({$hours}h {$minutes}min)"
+                                : "{$record->start_time} – {$record->end_time} ({$hours}h)";
+                        }
+
+                        $days = (int) $record->start_date->diffInDays($record->end_date) + 1;
 
                         return $days.' '.($days === 1 ? 'día' : 'días');
                     })
@@ -198,9 +277,49 @@ class LeavesRelationManager extends RelationManager
                     ->visible(fn ($record) => $record->status === 'pending')
                     ->requiresConfirmation()
                     ->modalHeading('Aprobar licencia')
-                    ->modalDescription('¿Estás seguro de que deseas aprobar esta licencia?')
+                    ->modalDescription(function (EmployeeLeave $record) {
+                        if ($record->isPartialDay()) {
+                            $base = "Se aprobará el permiso parcial ({$record->start_time} - {$record->end_time}).";
+                            if ($record->generates_deduction) {
+                                $amount = number_format($record->calculatedDeductionAmount(), 0, ',', '.');
+                                $base .= " Se generará un descuento de Gs. {$amount} en la próxima nómina.";
+                            }
+
+                            return $base;
+                        }
+
+                        $count = Absence::where('employee_id', $record->employee_id)
+                            ->whereHas('attendanceDay', fn ($q) => $q->whereBetween('date', [$record->start_date, $record->end_date]))
+                            ->whereIn('status', ['pending', 'unjustified'])
+                            ->count();
+
+                        $base = 'Se aprobará la licencia del empleado.';
+                        if ($count > 0) {
+                            $base .= " Se justificarán automáticamente {$count} ausencia(s) registrada(s) en el período.";
+                        }
+
+                        return $base;
+                    })
                     ->modalSubmitActionLabel('Sí, aprobar')
-                    ->action(fn ($record) => $record->update(['status' => 'approved'])),
+                    ->action(function (EmployeeLeave $record) {
+                        $result = $record->approve(Auth::id());
+
+                        if ($record->isPartialDay()) {
+                            $body = $record->generates_deduction
+                                ? 'El permiso fue aprobado. Se generó un descuento para la próxima nómina.'
+                                : 'El permiso fue aprobado.';
+                        } else {
+                            $body = $result['justified_count'] > 0
+                                ? "Se justificaron {$result['justified_count']} ausencia(s) del período automáticamente."
+                                : 'La licencia fue aprobada. No había ausencias pendientes en el período.';
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title('Licencia aprobada')
+                            ->body($body)
+                            ->send();
+                    }),
 
                 Action::make('reject')
                     ->label('Rechazar')
@@ -209,9 +328,16 @@ class LeavesRelationManager extends RelationManager
                     ->visible(fn ($record) => $record->status === 'pending')
                     ->requiresConfirmation()
                     ->modalHeading('Rechazar licencia')
-                    ->modalDescription('¿Estás seguro de que deseas rechazar esta licencia?')
+                    ->modalDescription('Se rechazará esta solicitud de licencia.')
                     ->modalSubmitActionLabel('Sí, rechazar')
-                    ->action(fn ($record) => $record->update(['status' => 'rejected'])),
+                    ->action(function (EmployeeLeave $record) {
+                        $record->reject();
+
+                        Notification::make()
+                            ->warning()
+                            ->title('Licencia rechazada')
+                            ->send();
+                    }),
 
                 Action::make('download')
                     ->label('Descargar')
@@ -261,9 +387,21 @@ class LeavesRelationManager extends RelationManager
                         ->modalHeading('Aprobar licencias')
                         ->modalDescription('Se aprobarán las licencias seleccionadas que estén en estado pendiente.')
                         ->modalSubmitActionLabel('Sí, aprobar')
-                        ->action(fn ($records) => $records->each(
-                            fn ($record) => $record->status === 'pending' && $record->update(['status' => 'approved'])
-                        )),
+                        ->action(function ($records) {
+                            $processed = 0;
+                            foreach ($records as $record) {
+                                if ($record->status === 'pending') {
+                                    $record->approve(Auth::id());
+                                    $processed++;
+                                }
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title('Licencias aprobadas')
+                                ->body("{$processed} licencia(s) aprobada(s).")
+                                ->send();
+                        }),
 
                     BulkAction::make('reject_selected')
                         ->label('Rechazar')
@@ -273,9 +411,21 @@ class LeavesRelationManager extends RelationManager
                         ->modalHeading('Rechazar licencias')
                         ->modalDescription('Se rechazarán las licencias seleccionadas que estén en estado pendiente.')
                         ->modalSubmitActionLabel('Sí, rechazar')
-                        ->action(fn ($records) => $records->each(
-                            fn ($record) => $record->status === 'pending' && $record->update(['status' => 'rejected'])
-                        )),
+                        ->action(function ($records) {
+                            $processed = 0;
+                            foreach ($records as $record) {
+                                if ($record->status === 'pending') {
+                                    $record->reject();
+                                    $processed++;
+                                }
+                            }
+
+                            Notification::make()
+                                ->warning()
+                                ->title('Licencias rechazadas')
+                                ->body("{$processed} licencia(s) rechazada(s).")
+                                ->send();
+                        }),
 
                     DeleteBulkAction::make()
                         ->modalHeading('Eliminar licencias')

--- a/app/Models/EmployeeLeave.php
+++ b/app/Models/EmployeeLeave.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Log;
 
-/** Representa una licencia registrada para un empleado. */
+/** Representa una licencia o permiso registrado para un empleado. */
 class EmployeeLeave extends Model
 {
     protected $fillable = [
@@ -14,6 +16,10 @@ class EmployeeLeave extends Model
         'type',
         'start_date',
         'end_date',
+        'start_time',
+        'end_time',
+        'generates_deduction',
+        'employee_deduction_id',
         'reason',
         'document_path',
         'status',
@@ -22,59 +28,159 @@ class EmployeeLeave extends Model
     protected $casts = [
         'start_date' => 'date',
         'end_date' => 'date',
+        'generates_deduction' => 'boolean',
     ];
 
-    /**
-     * Relación con el empleado al que pertenece la licencia.
-     */
+    // ─── Relaciones ──────────────────────────────────────────────────────────
+
+    /** Empleado al que pertenece la licencia. */
     public function employee(): BelongsTo
     {
         return $this->belongsTo(Employee::class);
     }
 
-    /**
-     * Ausencias justificadas por esta licencia.
-     */
+    /** Ausencias justificadas por esta licencia. */
     public function absences(): HasMany
     {
         return $this->hasMany(Absence::class);
     }
 
-    /**
-     * Aprueba la licencia y justifica automáticamente las ausencias del período.
-     *
-     * @return array<string, int> Contiene 'justified_count'
-     */
-    public function approve(int $approvedById): array
+    /** Deducción generada al aprobar un permiso parcial con descuento. */
+    public function employeeDeduction(): BelongsTo
     {
-        $this->update(['status' => 'approved']);
+        return $this->belongsTo(EmployeeDeduction::class);
+    }
 
-        $absences = Absence::where('employee_id', $this->employee_id)
-            ->whereHas('attendanceDay', fn ($q) => $q->whereBetween('date', [$this->start_date, $this->end_date]))
-            ->whereIn('status', ['pending', 'unjustified'])
-            ->get();
+    // ─── Helpers ─────────────────────────────────────────────────────────────
 
-        $typeLabel = self::getTypeOptions()[$this->type] ?? $this->type;
-        $period = $this->start_date->format('d/m/Y').' al '.$this->end_date->format('d/m/Y');
-
-        foreach ($absences as $absence) {
-            $absence->justify(
-                $approvedById,
-                "Justificada por licencia: {$typeLabel} ({$period})",
-                $this->id
-            );
-        }
-
-        return ['justified_count' => $absences->count()];
+    /** Indica si es un permiso parcial (por horas, no por días completos). */
+    public function isPartialDay(): bool
+    {
+        return filled($this->start_time) && filled($this->end_time);
     }
 
     /**
-     * Rechaza la licencia.
+     * Duración en horas del permiso parcial (fracción decimal).
+     * Retorna 0 si no es un permiso parcial o si los tiempos son inválidos.
      */
+    public function durationInHours(): float
+    {
+        if (! $this->isPartialDay()) {
+            return 0.0;
+        }
+
+        $start = Carbon::parse($this->start_date->format('Y-m-d').' '.$this->start_time);
+        $end = Carbon::parse($this->start_date->format('Y-m-d').' '.$this->end_time);
+
+        if ($end->lte($start)) {
+            return 0.0;
+        }
+
+        return round($start->floatDiffInHours($end), 2);
+    }
+
+    /**
+     * Monto de la deducción calculado según el salario del contrato activo.
+     * Mensual: salario / (30 × 8) × horas
+     * Jornalero: salario_diario / 8 × horas
+     */
+    public function calculatedDeductionAmount(): float
+    {
+        $hours = $this->durationInHours();
+        if ($hours <= 0) {
+            return 0.0;
+        }
+
+        $contract = $this->employee?->activeContract;
+        if (! $contract) {
+            return 0.0;
+        }
+
+        $salary = (float) $contract->salary;
+        if ($salary <= 0) {
+            return 0.0;
+        }
+
+        $hourlyRate = $contract->salary_type === 'mensual'
+            ? $salary / (30 * 8)
+            : $salary / 8;
+
+        return round($hourlyRate * $hours, 2);
+    }
+
+    // ─── Ciclo de vida ────────────────────────────────────────────────────────
+
+    /**
+     * Aprueba la licencia.
+     * - Permisos parciales (por horas): si generates_deduction, crea un EmployeeDeduction con LIC001.
+     * - Permisos por días completos: justifica automáticamente las ausencias del período.
+     *
+     * @return array{justified_count: int}
+     */
+    public function approve(int $approvedById): array
+    {
+        $updates = ['status' => 'approved'];
+
+        if ($this->generates_deduction && $this->isPartialDay() && ! $this->employee_deduction_id) {
+            $deductionRecord = Deduction::where('code', 'LIC001')->first();
+
+            if ($deductionRecord) {
+                $amount = $this->calculatedDeductionAmount();
+                $typeLabel = self::getTypeOptions()[$this->type] ?? $this->type;
+                $period = $this->start_date->format('d/m/Y').' '.$this->start_time.' - '.$this->end_time;
+
+                $employeeDeduction = EmployeeDeduction::create([
+                    'employee_id' => $this->employee_id,
+                    'deduction_id' => $deductionRecord->id,
+                    'start_date' => now()->toDateString(),
+                    'end_date' => now()->toDateString(),
+                    'custom_amount' => $amount,
+                    'notes' => "Permiso parcial: {$typeLabel} ({$period})",
+                ]);
+
+                $updates['employee_deduction_id'] = $employeeDeduction->id;
+            } else {
+                Log::warning('EmployeeLeave::approve — código LIC001 no encontrado en deductions. Descuento no generado.', [
+                    'employee_leave_id' => $this->id,
+                    'employee_id' => $this->employee_id,
+                ]);
+            }
+        }
+
+        $this->update($updates);
+
+        // Solo justifica ausencias en licencias de día completo
+        $justifiedCount = 0;
+        if (! $this->isPartialDay()) {
+            $absences = Absence::where('employee_id', $this->employee_id)
+                ->whereHas('attendanceDay', fn ($q) => $q->whereBetween('date', [$this->start_date, $this->end_date]))
+                ->whereIn('status', ['pending', 'unjustified'])
+                ->get();
+
+            $typeLabel = self::getTypeOptions()[$this->type] ?? $this->type;
+            $period = $this->start_date->format('d/m/Y').' al '.$this->end_date->format('d/m/Y');
+
+            foreach ($absences as $absence) {
+                $absence->justify(
+                    $approvedById,
+                    "Justificada por licencia: {$typeLabel} ({$period})",
+                    $this->id
+                );
+            }
+
+            $justifiedCount = $absences->count();
+        }
+
+        return ['justified_count' => $justifiedCount];
+    }
+
+    /** Rechaza la licencia. */
     public function reject(): void
     {
         $this->update(['status' => 'rejected']);
     }
+
+    // ─── Opciones estáticas ───────────────────────────────────────────────────
 
     /**
      * Opciones de tipo de licencia para selects y filtros.

--- a/database/migrations/2026_04_19_081826_backfill_outstanding_balance_and_installment_amounts.php
+++ b/database/migrations/2026_04_19_081826_backfill_outstanding_balance_and_installment_amounts.php
@@ -18,13 +18,13 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // Poblar outstanding_balance en loans existentes
+        // Poblar outstanding_balance en loans existentes (sin alias de tabla para compatibilidad SQLite)
         DB::statement('
-            UPDATE loans l
-            SET l.outstanding_balance = (
+            UPDATE loans
+            SET outstanding_balance = (
                 SELECT COALESCE(SUM(li.amount), 0)
                 FROM loan_installments li
-                WHERE li.loan_id = l.id
+                WHERE li.loan_id = loans.id
                   AND li.status = \'pending\'
             )
         ');

--- a/database/migrations/2026_04_19_081919_cleanup_advances_from_loans_table.php
+++ b/database/migrations/2026_04_19_081919_cleanup_advances_from_loans_table.php
@@ -21,11 +21,10 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // 1. Eliminar cuotas de los adelantos
+        // 1. Eliminar cuotas de los adelantos (usando subquery para compatibilidad SQLite)
         DB::statement("
-            DELETE li FROM loan_installments li
-            INNER JOIN loans l ON l.id = li.loan_id
-            WHERE l.type = 'advance'
+            DELETE FROM loan_installments
+            WHERE loan_id IN (SELECT id FROM loans WHERE type = 'advance')
         ");
 
         // 2. Eliminar los adelantos de loans

--- a/database/migrations/2026_04_21_082339_rename_loan_statuses_active_to_approved_defaulted_to_rejected.php
+++ b/database/migrations/2026_04_21_082339_rename_loan_statuses_active_to_approved_defaulted_to_rejected.php
@@ -12,23 +12,30 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // Ampliar el ENUM antes de actualizar datos (permite valores viejos y nuevos durante la transición)
-        DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','approved','paid','rejected','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        // MODIFY COLUMN solo disponible en MySQL — en SQLite el schema es fresh y no hay datos legacy
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','approved','paid','rejected','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        }
 
         DB::statement("UPDATE loans SET status = 'approved' WHERE status = 'active'");
         DB::statement("UPDATE loans SET status = 'rejected' WHERE status = 'defaulted'");
 
-        // Dejar solo los valores nuevos
-        DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','approved','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','approved','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        }
     }
 
     public function down(): void
     {
-        DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','approved','paid','rejected','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','approved','paid','rejected','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        }
 
         DB::statement("UPDATE loans SET status = 'active' WHERE status = 'approved'");
         DB::statement("UPDATE loans SET status = 'defaulted' WHERE status = 'rejected'");
 
-        DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','paid','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE loans MODIFY COLUMN status ENUM('pending','active','paid','cancelled','defaulted') NOT NULL DEFAULT 'pending'");
+        }
     }
 };

--- a/database/migrations/2026_05_10_215558_stamp_template_body_on_existing_contracts.php
+++ b/database/migrations/2026_05_10_215558_stamp_template_body_on_existing_contracts.php
@@ -12,13 +12,26 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement('
-            UPDATE contracts c
-            JOIN contract_templates t ON t.type = c.type
-            SET c.body = t.body
-            WHERE c.body IS NULL
-              AND t.body IS NOT NULL
-        ');
+        // MySQL JOIN-UPDATE syntax — en SQLite usamos subquery
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement('
+                UPDATE contracts c
+                JOIN contract_templates t ON t.type = c.type
+                SET c.body = t.body
+                WHERE c.body IS NULL
+                  AND t.body IS NOT NULL
+            ');
+        } else {
+            DB::statement('
+                UPDATE contracts
+                SET body = (
+                    SELECT t.body FROM contract_templates t
+                    WHERE t.type = contracts.type AND t.body IS NOT NULL
+                    LIMIT 1
+                )
+                WHERE body IS NULL
+            ');
+        }
     }
 
     public function down(): void

--- a/database/migrations/2026_05_12_161738_add_payment_method_to_advances_table.php
+++ b/database/migrations/2026_05_12_161738_add_payment_method_to_advances_table.php
@@ -15,19 +15,31 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('advances', function (Blueprint $table) {
-            $table->string('payment_method')->default('transfer')->after('notes');
-        });
+        if (! Schema::hasColumn('advances', 'payment_method')) {
+            Schema::table('advances', function (Blueprint $table) {
+                $table->string('payment_method')->default('transfer')->after('notes');
+            });
+        }
 
-        // Actualizar adelantos existentes: si el contrato activo del empleado
-        // tiene payment_method = 'cash', el adelanto también se paga en efectivo.
-        DB::statement("
-            UPDATE advances a
-            INNER JOIN employees e ON e.id = a.employee_id
-            INNER JOIN contracts c ON c.employee_id = e.id AND c.status = 'active'
-            SET a.payment_method = 'cash'
-            WHERE c.payment_method = 'cash'
-        ");
+        // Actualizar adelantos existentes según método de pago del contrato activo
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("
+                UPDATE advances a
+                INNER JOIN employees e ON e.id = a.employee_id
+                INNER JOIN contracts c ON c.employee_id = e.id AND c.status = 'active'
+                SET a.payment_method = 'cash'
+                WHERE c.payment_method = 'cash'
+            ");
+        } else {
+            DB::statement("
+                UPDATE advances SET payment_method = 'cash'
+                WHERE employee_id IN (
+                    SELECT e.id FROM employees e
+                    INNER JOIN contracts c ON c.employee_id = e.id AND c.status = 'active'
+                    WHERE c.payment_method = 'cash'
+                )
+            ");
+        }
     }
 
     /**

--- a/database/migrations/2026_05_13_203402_add_disbursement_to_advances_table.php
+++ b/database/migrations/2026_05_13_203402_add_disbursement_to_advances_table.php
@@ -13,12 +13,15 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // Ampliar el ENUM de status para incluir 'disbursed' (dinero entregado, pendiente de nómina)
-        DB::statement("ALTER TABLE advances MODIFY COLUMN status ENUM('pending','approved','disbursed','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE advances MODIFY COLUMN status ENUM('pending','approved','disbursed','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        }
 
-        Schema::table('advances', function (Blueprint $table) {
-            $table->date('disbursement_batch_at')->nullable()->after('payment_method');
-        });
+        if (! Schema::hasColumn('advances', 'disbursement_batch_at')) {
+            Schema::table('advances', function (Blueprint $table) {
+                $table->date('disbursement_batch_at')->nullable()->after('payment_method');
+            });
+        }
     }
 
     /**
@@ -30,6 +33,8 @@ return new class extends Migration
             $table->dropColumn('disbursement_batch_at');
         });
 
-        DB::statement("ALTER TABLE advances MODIFY COLUMN status ENUM('pending','approved','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE advances MODIFY COLUMN status ENUM('pending','approved','paid','rejected','cancelled') NOT NULL DEFAULT 'pending'");
+        }
     }
 };

--- a/database/migrations/2026_05_25_073159_add_disbursement_fields_to_payrolls_table.php
+++ b/database/migrations/2026_05_25_073159_add_disbursement_fields_to_payrolls_table.php
@@ -20,16 +20,28 @@ return new class extends Migration
     public function up(): void
     {
         // 1. Ampliar el enum de status para incluir 'disbursed'
-        DB::statement("ALTER TABLE payrolls MODIFY COLUMN status ENUM('draft','approved','disbursed','paid') NOT NULL DEFAULT 'draft'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE payrolls MODIFY COLUMN status ENUM('draft','approved','disbursed','paid') NOT NULL DEFAULT 'draft'");
+        }
 
         Schema::table('payrolls', function (Blueprint $table) {
-            $table->enum('payment_method', ['transfer', 'cash'])->nullable()->after('status');
-            $table->timestamp('disbursed_at')->nullable()->after('payment_method');
-            $table->foreignId('disbursed_by_id')->nullable()->after('disbursed_at')
-                ->constrained('users')->nullOnDelete();
-            $table->foreignId('disbursement_batch_id')->nullable()->after('disbursed_by_id')
-                ->constrained('disbursement_batches')->nullOnDelete();
-            $table->string('bank_rejection_reason')->nullable()->after('disbursement_batch_id');
+            if (! Schema::hasColumn('payrolls', 'payment_method')) {
+                $table->enum('payment_method', ['transfer', 'cash'])->nullable()->after('status');
+            }
+            if (! Schema::hasColumn('payrolls', 'disbursed_at')) {
+                $table->timestamp('disbursed_at')->nullable()->after('payment_method');
+            }
+            if (! Schema::hasColumn('payrolls', 'disbursed_by_id')) {
+                $table->foreignId('disbursed_by_id')->nullable()->after('disbursed_at')
+                    ->constrained('users')->nullOnDelete();
+            }
+            if (! Schema::hasColumn('payrolls', 'disbursement_batch_id')) {
+                $table->foreignId('disbursement_batch_id')->nullable()->after('disbursed_by_id')
+                    ->constrained('disbursement_batches')->nullOnDelete();
+            }
+            if (! Schema::hasColumn('payrolls', 'bank_rejection_reason')) {
+                $table->string('bank_rejection_reason')->nullable()->after('disbursement_batch_id');
+            }
         });
     }
 
@@ -47,6 +59,8 @@ return new class extends Migration
             ]);
         });
 
-        DB::statement("ALTER TABLE payrolls MODIFY COLUMN status ENUM('draft','approved','paid') NOT NULL DEFAULT 'draft'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE payrolls MODIFY COLUMN status ENUM('draft','approved','paid') NOT NULL DEFAULT 'draft'");
+        }
     }
 };

--- a/database/migrations/2026_06_01_143419_add_suspended_status_to_contracts_table.php
+++ b/database/migrations/2026_06_01_143419_add_suspended_status_to_contracts_table.php
@@ -7,12 +7,16 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement("ALTER TABLE contracts MODIFY COLUMN status ENUM('active','expired','terminated','renewed','suspended') NOT NULL DEFAULT 'active'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE contracts MODIFY COLUMN status ENUM('active','expired','terminated','renewed','suspended') NOT NULL DEFAULT 'active'");
+        }
     }
 
     public function down(): void
     {
         DB::statement("UPDATE contracts SET status = 'active' WHERE status = 'suspended'");
-        DB::statement("ALTER TABLE contracts MODIFY COLUMN status ENUM('active','expired','terminated','renewed') NOT NULL DEFAULT 'active'");
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE contracts MODIFY COLUMN status ENUM('active','expired','terminated','renewed') NOT NULL DEFAULT 'active'");
+        }
     }
 };

--- a/database/migrations/2026_06_08_130913_add_partial_day_fields_to_employee_leaves_table.php
+++ b/database/migrations/2026_06_08_130913_add_partial_day_fields_to_employee_leaves_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employee_leaves', function (Blueprint $table) {
+            $table->time('start_time')->nullable()->after('end_date');
+            $table->time('end_time')->nullable()->after('start_time');
+            $table->boolean('generates_deduction')->default(false)->after('end_time');
+            $table->foreignId('employee_deduction_id')->nullable()->after('generates_deduction')
+                ->constrained('employee_deductions')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employee_leaves', function (Blueprint $table) {
+            $table->dropForeign(['employee_deduction_id']);
+            $table->dropColumn(['start_time', 'end_time', 'generates_deduction', 'employee_deduction_id']);
+        });
+    }
+};

--- a/database/seeders/DeductionSeeder.php
+++ b/database/seeders/DeductionSeeder.php
@@ -107,6 +107,19 @@ class DeductionSeeder extends Seeder
                 'apply_judicial_limit' => false,
                 'is_active' => true,
             ],
+            [
+                'name' => 'Descuento por Permiso Parcial',
+                'code' => 'LIC001',
+                'type' => 'voluntary',
+                'description' => 'Descuento por horas de permiso parcial aprobado. El monto se calcula automáticamente según el salario y las horas tomadas.',
+                'calculation' => 'fixed',
+                'amount' => null,
+                'percent' => null,
+                'is_mandatory' => false,
+                'affects_irp' => false,
+                'apply_judicial_limit' => false,
+                'is_active' => true,
+            ],
         ];
 
         foreach ($deductions as $deduction) {

--- a/database/seeders/ProductionSeeder.php
+++ b/database/seeders/ProductionSeeder.php
@@ -123,6 +123,19 @@ class ProductionSeeder extends Seeder
                 'apply_judicial_limit' => false,
                 'is_active' => true,
             ],
+            [
+                'name' => 'Descuento por Permiso Parcial',
+                'code' => 'LIC001',
+                'type' => 'voluntary',
+                'description' => 'Descuento por horas de permiso parcial aprobado. El monto se calcula automáticamente según el salario y las horas tomadas.',
+                'calculation' => 'fixed',
+                'amount' => null,
+                'percent' => null,
+                'is_mandatory' => false,
+                'affects_irp' => false,
+                'apply_judicial_limit' => false,
+                'is_active' => true,
+            ],
         ];
 
         foreach ($deductions as $deduction) {
@@ -135,7 +148,7 @@ class ProductionSeeder extends Seeder
             );
         }
 
-        $this->command->info('Deducciones sembradas: IPS (9%), PRE001, ADE001, MER001.');
+        $this->command->info('Deducciones sembradas: IPS (9%), PRE001, ADE001, MER001, LIC001.');
     }
 
     private function printChecklist(): void


### PR DESCRIPTION
## Resumen

- Agrega soporte para **permisos parciales por horas** al módulo de Licencias (`EmployeeLeave`), coexistiendo con los permisos por días completos en la misma tabla y recurso
- Nueva opción de **generar descuento en nómina** (código `LIC001`), que sigue el mismo patrón que los Adelantos: crea un `EmployeeDeduction` al aprobar, descontado en la siguiente planilla
- Filtros en cascada y empleados activos en `SalaryReport`

## Cambios principales

### Módulo de Licencias — permisos parciales
- **Migración**: `start_time`, `end_time` (time nullable), `generates_deduction` (boolean), `employee_deduction_id` (FK)
- **Modelo `EmployeeLeave`**: `isPartialDay()`, `durationInHours()`, `calculatedDeductionAmount()` y `approve()` actualizado para crear `EmployeeDeduction` (LIC001) en permisos parciales con deducción habilitada; permisos parciales no justifican ausencias
- **`EmployeeLeaveResource`**: sección colapsable "Permiso por horas" con `TimePicker` + toggle reactivo; columna duración muestra horas vs días; modal de aprobación con descripción dinámica según tipo
- **`ViewEmployeeLeaves`**: modal de aprobación con monto de descuento calculado para permisos parciales
- **`LeavesRelationManager`**: mismos campos de formulario; **bug fix**: acciones aprobar/rechazar ahora llaman `$record->approve(Auth::id())` / `$record->reject()` en vez de `update()` directo — garantiza que se justifiquen ausencias y se creen deducciones desde el perfil del empleado también

### Seeders
- `DeductionSeeder` y `ProductionSeeder`: deducción `LIC001 — Descuento por Permiso Parcial`

### SalaryReport (cambios previos en esta rama)
- Filtros en cascada: Empresa → Planilla, Sucursal, Departamento, Empleado
- Filtro de empleados solo muestra activos

### Correcciones de migraciones (compatibilidad SQLite/CI)
- 8 migraciones con sintaxis MySQL-exclusiva (`MODIFY COLUMN`, `UPDATE/DELETE ... JOIN`) adaptadas para SQLite

## Plan de prueba

- [ ] Crear licencia de día completo → aprobar → verificar ausencias justificadas
- [ ] Crear permiso parcial (con horas) sin deducción → aprobar → verificar que no justifica ausencias ni crea deducción
- [ ] Crear permiso parcial con `generates_deduction = true` → aprobar → verificar que aparece `EmployeeDeduction` LIC001 y se descuenta en la próxima nómina
- [ ] Probar las mismas acciones desde la pestaña Licencias en el perfil del empleado (`LeavesRelationManager`)
- [ ] Correr `php artisan db:seed --class=ProductionSeeder` → verificar que LIC001 existe en la tabla `deductions`

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr)_