### PR TITLE
fix(migration): drop FK on branch_id by querying INFORMATION_SCHEMA

### DIFF
--- a/database/migrations/2026_06_08_175158_make_employee_branch_id_not_nullable.php
+++ b/database/migrations/2026_06_08_175158_make_employee_branch_id_not_nullable.php
@@ -14,8 +14,9 @@ return new class extends Migration
             throw new \RuntimeException('No se puede aplicar la migración: existen empleados sin sucursal asignada.');
         }
 
+        $this->dropForeignKeyOnColumn('employees', 'branch_id');
+
         Schema::table('employees', function (Blueprint $table) {
-            $table->dropForeign(['branch_id']);
             $table->unsignedBigInteger('branch_id')->nullable(false)->change();
             $table->foreign('branch_id')->references('id')->on('branches');
         });
@@ -23,10 +24,35 @@ return new class extends Migration
 
     public function down(): void
     {
+        $this->dropForeignKeyOnColumn('employees', 'branch_id');
+
         Schema::table('employees', function (Blueprint $table) {
-            $table->dropForeign(['branch_id']);
             $table->unsignedBigInteger('branch_id')->nullable()->change();
             $table->foreign('branch_id')->references('id')->on('branches')->onDelete('set null');
         });
+    }
+
+    /**
+     * Drops all foreign keys on a given column, regardless of their generated name.
+     */
+    private function dropForeignKeyOnColumn(string $tableName, string $columnName): void
+    {
+        $fks = DB::select(
+            "SELECT kcu.CONSTRAINT_NAME
+             FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+             JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+               ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+              AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+              AND tc.TABLE_NAME = kcu.TABLE_NAME
+             WHERE kcu.TABLE_SCHEMA = DATABASE()
+               AND kcu.TABLE_NAME = ?
+               AND kcu.COLUMN_NAME = ?
+               AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
+            [$tableName, $columnName]
+        );
+
+        foreach ($fks as $fk) {
+            DB::statement("ALTER TABLE `{$tableName}` DROP FOREIGN KEY `{$fk->CONSTRAINT_NAME}`");
+        }
     }
 };


### PR DESCRIPTION
Instead of hardcoding the constraint name (which Laravel derives from table+column and may differ in production), query INFORMATION_SCHEMA to find any FK on employees.branch_id and drop it by its actual name.

https://claude.ai/code/session_01YU3bF2EE2goK9zAQwE8cmr