### PR TITLE
Security: remove unauthenticated /api/employees endpoint exposing face biometrics

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,8 +25,6 @@ use App\Http\Controllers\ShiftPlannerController;
 use App\Http\Controllers\VacationDocumentController;
 use App\Http\Controllers\VacationReportController;
 use App\Http\Controllers\WarningController;
-use App\Models\Employee;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -65,30 +63,6 @@ Route::prefix('registro-facial')->name('face-enrollment.')->middleware('throttle
     Route::get('/{token}', [FaceEnrollmentController::class, 'show'])->name('show');
     Route::post('/{token}', [FaceEnrollmentController::class, 'store'])->name('store');
 });
-
-/*
-|--------------------------------------------------------------------------
-| API Pública - Empleados
-|--------------------------------------------------------------------------
-|
-| Endpoint para obtener lista de empleados activos con rostro registrado.
-| Usado por el sistema de reconocimiento facial para identificación.
-| Requiere que el empleado tenga face_descriptor (datos biométricos).
-|
-*/
-
-Route::get('/api/employees', function (Request $request) {
-    $branchId = $request->query('branch_id');
-
-    $employees = Employee::query()
-        ->where('status', 'activo')
-        ->when($branchId, fn ($query) => $query->where('branch_id', $branchId))
-        ->whereNotNull('face_descriptor') // Requiere rostro registrado para reconocimiento
-        ->select('id', 'first_name', 'last_name', 'ci', 'photo', 'face_descriptor')
-        ->get();
-
-    return response()->json($employees);
-})->name('api.employees');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

While auditing the full attendance-marking process end to end, found `GET /api/employees` (`routes/web.php`) publicly reachable with **no authentication middleware**, returning `face_descriptor` (raw biometric face template) plus name/CI/photo for every active employee with a registered face — in plain JSON, for anyone.

Confirmed before removing:
- **No current code path uses it.** `mark.js`/`terminal.js` (the actual facial clock-in flows) never call it — facial matching happens entirely server-side in `AttendanceFaceMarkController::identifyEmployeeByDescriptor()`, which has its own independent cached query (`Cache::remember('employees_face_descriptors', 300, ...)`).
- `grep -rn "api.employees\|api/employees" app/ resources/ routes/ tests/` returns only the route definition itself — zero other references anywhere in the codebase.
- Confirmed with the repo owner that no external consumer (separate mobile app, script, client integration) depends on it either.

It's an orphaned endpoint from an earlier architecture (most likely a prior client-side face-matching design, before that logic moved server-side) — real risk, zero current or foreseeable function. Removing it outright rather than gating it behind auth, since nothing legitimate needs it and a future "employee list" API (if ever needed) should be purpose-built with only the fields that use case requires, and auth from the start — not resurrect this shape.

## Changes

- Removed the `GET /api/employees` route and its doc block from `routes/web.php`.
- Removed the now-unused `Employee` and `Request` imports from the same file (`pint --dirty`).

## Test plan

- [x] `grep -rn "api.employees\|api/employees" app/ resources/ routes/ tests/` — no references outside the route itself, before removal.
- [x] `php artisan route:list | grep api/employees` — confirmed the route is gone after the change.
- [x] `php artisan test --compact` — full suite green: 404 tests, 796 assertions.
- [x] `vendor/bin/pint --dirty` applied.

## Deployment note

This affects all three client deployments (bar777, arca, Macro) — same repo, same exposure on all three. Recommend deploying this as soon as it merges rather than waiting for the next regular deploy window, given it's an active data-exposure fix.

https://claude.ai/code/session_01K852zqbBonRF8BqgLenZw4


---
_Generated by [Claude Code](https://claude.ai/code/session_01K852zqbBonRF8BqgLenZw4)_