### PR TITLE
Revisión manual de conflictos de sync + foto real en el kiosko offline

### DIFF
--- a/app/Filament/Resources/AttendanceMarkFailureResource.php
+++ b/app/Filament/Resources/AttendanceMarkFailureResource.php
@@ -3,22 +3,38 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\AttendanceMarkFailureResource\Pages;
+use App\Models\AttendanceEvent;
 use App\Models\AttendanceMarkFailure;
+use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Form;
+use Filament\Infolists\Components\Grid as InfoGrid;
 use Filament\Infolists\Components\KeyValueEntry;
 use Filament\Infolists\Components\Section as InfoSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\Indicator;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
-/** Resource de solo lectura para inspeccionar intentos fallidos de marcación de asistencia. */
+/**
+ * Resource para inspeccionar y revisar manualmente intentos fallidos de
+ * marcación de asistencia. Sin creación/edición manual de registros (los
+ * fallos solo se generan desde el flujo de marcación), pero sí admite
+ * revisión vía `approve()`/`dismiss()` para los fallos que traen datos
+ * suficientes para reconstruir la marcación — ver `getApproveAction()`.
+ */
 class AttendanceMarkFailureResource extends Resource
 {
     protected static ?string $model = AttendanceMarkFailure::class;
@@ -37,8 +53,8 @@ class AttendanceMarkFailureResource extends Resource
 
     protected static ?int $navigationSort = 5;
 
-    /** Este resource es de solo lectura — no expone formulario de creación/edición. */
-    public static function form(\Filament\Forms\Form $form): \Filament\Forms\Form
+    /** Sin formulario de creación/edición manual — los fallos solo se generan desde el flujo de marcación. */
+    public static function form(Form $form): Form
     {
         return $form->schema([]);
     }
@@ -111,6 +127,12 @@ class AttendanceMarkFailureResource extends Resource
                     })
                     ->toggleable(isToggledHiddenByDefault: false),
 
+                TextColumn::make('resolution_status')
+                    ->label('Revisión')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => AttendanceMarkFailure::getResolutionStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => AttendanceMarkFailure::getResolutionStatusColors()[$state] ?? 'gray'),
+
                 TextColumn::make('failure_message')
                     ->label('Mensaje')
                     ->limit(60)
@@ -139,6 +161,10 @@ class AttendanceMarkFailureResource extends Resource
                 SelectFilter::make('branch_id')
                     ->label('Sucursal')
                     ->relationship('branch', 'name'),
+
+                SelectFilter::make('resolution_status')
+                    ->label('Revisión')
+                    ->options(AttendanceMarkFailure::getResolutionStatusOptions()),
 
                 Filter::make('occurred_at')
                     ->label('Período')
@@ -170,20 +196,114 @@ class AttendanceMarkFailureResource extends Resource
                     }),
             ])
             ->actions([
-                Action::make('diagnose')
-                    ->label('Diagnóstico')
-                    ->icon('heroicon-o-light-bulb')
-                    ->color('warning')
-                    ->modalHeading(fn (AttendanceMarkFailure $record) => 'Diagnóstico: '.AttendanceMarkFailure::getFailureTypeLabel($record->failure_type))
-                    ->modalContent(fn (AttendanceMarkFailure $record) => view(
-                        'filament.modals.attendance-mark-failure-diagnosis',
-                        ['record' => $record]
-                    ))
-                    ->modalSubmitAction(false)
-                    ->modalCancelActionLabel('Cerrar'),
+                ActionGroup::make([
+                    Action::make('diagnose')
+                        ->label('Diagnóstico')
+                        ->icon('heroicon-o-light-bulb')
+                        ->color('warning')
+                        ->modalHeading(fn (AttendanceMarkFailure $record) => 'Diagnóstico: '.AttendanceMarkFailure::getFailureTypeLabel($record->failure_type))
+                        ->modalContent(fn (AttendanceMarkFailure $record) => view(
+                            'filament.modals.attendance-mark-failure-diagnosis',
+                            ['record' => $record]
+                        ))
+                        ->modalSubmitAction(false)
+                        ->modalCancelActionLabel('Cerrar'),
+
+                    static::getApproveAction(),
+                ]),
             ])
             ->bulkActions([])
             ->paginated([25, 50, 100]);
+    }
+
+    /**
+     * Acción "Aprobar" — reconstruye el `AttendanceEvent` a partir de los
+     * datos del fallo, permitiendo ajustar el tipo de evento y la hora antes
+     * de confirmar (ej. si el admin determina que en realidad correspondía
+     * otro tipo de marcación). Solo visible si `canBeResolved()`.
+     */
+    public static function getApproveAction(): Action
+    {
+        return Action::make('approve')
+            ->label('Aprobar')
+            ->icon('heroicon-o-check-circle')
+            ->color('success')
+            ->visible(fn (AttendanceMarkFailure $record) => $record->canBeResolved())
+            ->modalHeading('Aprobar marcación')
+            ->modalDescription('Se creará la marcación de asistencia correspondiente. Podés ajustar el tipo de evento y la hora antes de confirmar.')
+            ->modalSubmitActionLabel('Aprobar y registrar')
+            ->form([
+                Select::make('event_type')
+                    ->label('Tipo de evento')
+                    ->options([
+                        'check_in' => AttendanceEvent::getEventTypeLabel('check_in'),
+                        'break_start' => AttendanceEvent::getEventTypeLabel('break_start'),
+                        'break_end' => AttendanceEvent::getEventTypeLabel('break_end'),
+                        'check_out' => AttendanceEvent::getEventTypeLabel('check_out'),
+                    ])
+                    ->default(fn (AttendanceMarkFailure $record) => $record->attempted_event_type)
+                    ->native(false)
+                    ->required(),
+
+                DateTimePicker::make('recorded_at')
+                    ->label('Fecha y hora')
+                    ->default(fn (AttendanceMarkFailure $record) => filled($record->metadata['recorded_at'] ?? null)
+                        ? Carbon::parse($record->metadata['recorded_at'])
+                        : $record->occurred_at)
+                    ->seconds(false)
+                    ->native(false)
+                    ->required(),
+
+                Textarea::make('notes')
+                    ->label('Notas (opcional)')
+                    ->rows(2),
+            ])
+            ->action(function (AttendanceMarkFailure $record, array $data) {
+                $result = $record->approve(
+                    Auth::id(),
+                    $data['event_type'],
+                    Carbon::parse($data['recorded_at']),
+                    $data['notes'] ?? null,
+                );
+
+                if ($result['success']) {
+                    Notification::make()->success()->title('Marcación aprobada')->body($result['message'])->send();
+                } else {
+                    Notification::make()->danger()->title('No se pudo aprobar')->body($result['message'])->send();
+                }
+            });
+    }
+
+    /**
+     * Acción "Descartar" — marca el fallo como revisado sin crear ninguna
+     * marcación. Transición irreversible (sin undo), por eso solo vive en
+     * los header actions del ViewRecord, nunca como row action de la tabla.
+     */
+    public static function getDismissAction(): Action
+    {
+        return Action::make('dismiss')
+            ->label('Descartar')
+            ->icon('heroicon-o-x-circle')
+            ->color('gray')
+            ->visible(fn (AttendanceMarkFailure $record) => $record->isPending())
+            ->requiresConfirmation()
+            ->modalHeading('Descartar fallo')
+            ->modalDescription('Se marcará este fallo como revisado sin crear ninguna marcación de asistencia. Usalo cuando el conflicto ya no aplica — por ejemplo, si la marcación se cargó manualmente desde otro lado.')
+            ->modalSubmitActionLabel('Sí, descartar')
+            ->form([
+                Textarea::make('notes')
+                    ->label('Notas (opcional)')
+                    ->rows(2),
+            ])
+            ->action(function (AttendanceMarkFailure $record, array $data) {
+                $result = $record->dismiss(Auth::id(), $data['notes'] ?? null);
+
+                if ($result['success']) {
+                    Notification::make()->success()->title('Fallo descartado')->send();
+                } else {
+                    Notification::make()->danger()->title('No se pudo descartar')->body($result['message'])->send();
+                }
+            });
     }
 
     /**
@@ -249,6 +369,42 @@ class AttendanceMarkFailureResource extends Resource
                         TextEntry::make('branch.name')
                             ->label('Sucursal')
                             ->default('—'),
+                    ]),
+
+                InfoSection::make('Revisión')
+                    ->icon('heroicon-o-clipboard-document-check')
+                    ->schema([
+                        InfoGrid::make(3)->schema([
+                            TextEntry::make('resolution_status')
+                                ->label('Estado')
+                                ->badge()
+                                ->formatStateUsing(fn (string $state) => AttendanceMarkFailure::getResolutionStatusLabels()[$state] ?? $state)
+                                ->color(fn (string $state) => AttendanceMarkFailure::getResolutionStatusColors()[$state] ?? 'gray'),
+
+                            TextEntry::make('resolvedBy.name')
+                                ->label('Revisado por')
+                                ->placeholder('Sin revisar'),
+
+                            TextEntry::make('resolved_at')
+                                ->label('Revisado el')
+                                ->dateTime('d/m/Y H:i')
+                                ->placeholder('—'),
+                        ]),
+
+                        TextEntry::make('resolvedEvent.id')
+                            ->label('Marcación creada')
+                            ->placeholder('Ninguna')
+                            ->getStateUsing(fn (AttendanceMarkFailure $record) => $record->resolvedEvent
+                                ? AttendanceEvent::getEventTypeLabel($record->resolvedEvent->event_type).' — '.$record->resolvedEvent->recorded_at->format('d/m/Y H:i')
+                                : null
+                            )
+                            ->visible(fn (AttendanceMarkFailure $record) => $record->isApproved()),
+
+                        TextEntry::make('resolution_notes')
+                            ->label('Notas de revisión')
+                            ->placeholder('Sin notas')
+                            ->columnSpanFull()
+                            ->visible(fn (AttendanceMarkFailure $record) => ! $record->isPending()),
                     ]),
 
                 InfoSection::make('Red y Ubicación')

--- a/app/Filament/Resources/AttendanceMarkFailureResource/Pages/ViewAttendanceMarkFailure.php
+++ b/app/Filament/Resources/AttendanceMarkFailureResource/Pages/ViewAttendanceMarkFailure.php
@@ -12,6 +12,9 @@ class ViewAttendanceMarkFailure extends ViewRecord
 
     protected function getHeaderActions(): array
     {
-        return [];
+        return [
+            AttendanceMarkFailureResource::getApproveAction(),
+            AttendanceMarkFailureResource::getDismissAction(),
+        ];
     }
 }

--- a/app/Models/AttendanceMarkFailure.php
+++ b/app/Models/AttendanceMarkFailure.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Registro de intentos fallidos de marcación de asistencia.
@@ -11,6 +13,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * Persiste en BD todos los fallos del proceso de marcación (facial, terminal y móvil)
  * para permitir auditoría, diagnóstico y visualización en el panel de administración.
  * Los registros se retienen 30 días y se limpian automáticamente.
+ *
+ * Los fallos con `employee_id` y `attempted_event_type` presentes (ver
+ * `canBeResolved()`) admiten revisión manual desde Filament: un admin puede
+ * `approve()` (reconstruye el `AttendanceEvent` correspondiente, revalidando
+ * la secuencia contra el estado actual) o `dismiss()` (lo marca como
+ * revisado sin crear ningún evento).
  */
 class AttendanceMarkFailure extends Model
 {
@@ -25,12 +33,28 @@ class AttendanceMarkFailure extends Model
         'ip_address',
         'location',
         'occurred_at',
+        'resolution_status',
+        'resolved_at',
+        'resolved_by_id',
+        'resolution_notes',
+        'resolved_event_id',
     ];
 
     protected $casts = [
         'metadata' => 'array',
         'location' => 'array',
         'occurred_at' => 'datetime',
+        'resolved_at' => 'datetime',
+    ];
+
+    /**
+     * Default en PHP (no solo en la migración): `create()` no vuelve a leer
+     * la fila insertada, así que sin esto la instancia recién creada queda
+     * con `resolution_status` en `null` en memoria hasta que se recarga —
+     * `isPending()`/`canBeResolved()` fallarían justo después de `record()`.
+     */
+    protected $attributes = [
+        'resolution_status' => 'pending',
     ];
 
     // ──────────────────────────────────────────
@@ -47,6 +71,18 @@ class AttendanceMarkFailure extends Model
     public function branch(): BelongsTo
     {
         return $this->belongsTo(Branch::class);
+    }
+
+    /** Admin que aprobó o descartó el fallo. */
+    public function resolvedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'resolved_by_id');
+    }
+
+    /** Evento creado al aprobar el fallo (solo si `resolution_status === 'approved'`). */
+    public function resolvedEvent(): BelongsTo
+    {
+        return $this->belongsTo(AttendanceEvent::class, 'resolved_event_id');
     }
 
     // ──────────────────────────────────────────
@@ -151,5 +187,184 @@ class AttendanceMarkFailure extends Model
             ['occurred_at' => now()],
             $data,
         ));
+    }
+
+    /**
+     * Opciones de estado de revisión para filtros.
+     *
+     * @return array<string, string>
+     */
+    public static function getResolutionStatusOptions(): array
+    {
+        return [
+            'pending' => 'Pendiente',
+            'approved' => 'Aprobado',
+            'dismissed' => 'Descartado',
+        ];
+    }
+
+    /**
+     * Labels cortos para badges de estado de revisión.
+     *
+     * @return array<string, string>
+     */
+    public static function getResolutionStatusLabels(): array
+    {
+        return [
+            'pending' => 'Pendiente',
+            'approved' => 'Aprobado',
+            'dismissed' => 'Descartado',
+        ];
+    }
+
+    /**
+     * Colores semánticos para badges de estado de revisión.
+     *
+     * @return array<string, string>
+     */
+    public static function getResolutionStatusColors(): array
+    {
+        return [
+            'pending' => 'warning',
+            'approved' => 'success',
+            'dismissed' => 'gray',
+        ];
+    }
+
+    // ──────────────────────────────────────────
+    // Revisión manual (aprobar / descartar)
+    // ──────────────────────────────────────────
+
+    /** Indica si el fallo todavía no fue revisado. */
+    public function isPending(): bool
+    {
+        return $this->resolution_status === 'pending';
+    }
+
+    /** Indica si el fallo fue aprobado (se creó un AttendanceEvent). */
+    public function isApproved(): bool
+    {
+        return $this->resolution_status === 'approved';
+    }
+
+    /** Indica si el fallo fue descartado sin crear ningún evento. */
+    public function isDismissed(): bool
+    {
+        return $this->resolution_status === 'dismissed';
+    }
+
+    /**
+     * Indica si hay datos suficientes para reconstruir la marcación
+     * intentada — requiere saber quién (`employee_id`) y qué tipo de evento
+     * (`attempted_event_type`) se intentó. Sin esto (ej. `face_no_match`,
+     * donde nunca se identificó a nadie) no hay nada que "aprobar".
+     */
+    public function canBeResolved(): bool
+    {
+        return $this->isPending()
+            && $this->employee_id !== null
+            && $this->attempted_event_type !== null;
+    }
+
+    /**
+     * Aprueba el fallo y crea el `AttendanceEvent` correspondiente,
+     * revalidando la secuencia contra el estado *actual* del empleado (puede
+     * haber cambiado desde que se registró el fallo — ej. otra marcación
+     * manual ya cubrió ese evento). Permite ajustar el tipo de evento y la
+     * hora antes de reinsertar; sin overrides, usa lo que se intentó
+     * originalmente (`attempted_event_type` + `recorded_at`/`occurred_at`).
+     *
+     * @return array{success: bool, message: string, event?: AttendanceEvent}
+     */
+    public function approve(
+        int $approvedById,
+        ?string $eventType = null,
+        ?Carbon $recordedAt = null,
+        ?string $notes = null,
+    ): array {
+        if (! $this->canBeResolved()) {
+            return ['success' => false, 'message' => 'Este fallo ya fue revisado o no tiene datos suficientes para reconstruir la marcación.'];
+        }
+
+        $employee = $this->employee;
+
+        if (! $employee || $employee->status !== 'active') {
+            return ['success' => false, 'message' => 'El empleado no existe o no está activo.'];
+        }
+
+        $eventType ??= $this->attempted_event_type;
+
+        if ($recordedAt === null) {
+            $metadataRecordedAt = $this->metadata['recorded_at'] ?? null;
+            $recordedAt = $metadataRecordedAt ? Carbon::parse($metadataRecordedAt) : $this->occurred_at->copy();
+        }
+
+        $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
+
+        return DB::transaction(function () use ($employee, $eventType, $recordedAt, $date, $approvedById, $notes) {
+            $day = AttendanceDay::firstOrCreate(
+                ['employee_id' => $employee->id, 'date' => $date],
+                ['status' => 'present']
+            );
+
+            $last = AttendanceEvent::where('attendance_day_id', $day->id)
+                ->lockForUpdate()
+                ->latest('recorded_at')
+                ->first();
+
+            $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
+
+            if (! in_array($eventType, $allowed, true)) {
+                $lastLabel = $last ? AttendanceEvent::getEventTypeLabel($last->event_type) : 'ninguno';
+
+                return ['success' => false, 'message' => "La secuencia sigue sin ser válida (último evento registrado: {$lastLabel}). Elegí otro tipo de evento."];
+            }
+
+            if ($day->status !== 'present') {
+                $day->update(['status' => 'present']);
+            }
+
+            $event = $day->events()->create([
+                'event_type' => $eventType,
+                'recorded_at' => $recordedAt,
+                'synced_at' => $this->mode === 'terminal' ? now() : null,
+                'source' => $this->mode === 'terminal' ? 'terminal' : 'manual',
+                'location' => $this->metadata['location'] ?? $this->location,
+                'terminal_id' => $this->metadata['terminal_id'] ?? null,
+                'branch_mismatch' => false,
+            ]);
+
+            $this->update([
+                'resolution_status' => 'approved',
+                'resolved_at' => now(),
+                'resolved_by_id' => $approvedById,
+                'resolution_notes' => $notes,
+                'resolved_event_id' => $event->id,
+            ]);
+
+            return ['success' => true, 'message' => 'Marcación registrada correctamente.', 'event' => $event];
+        });
+    }
+
+    /**
+     * Descarta el fallo sin crear ningún evento — para cuando el conflicto
+     * ya no aplica (ej. la marcación se cargó manualmente desde otro lado).
+     *
+     * @return array{success: bool, message: string}
+     */
+    public function dismiss(int $dismissedById, ?string $notes = null): array
+    {
+        if (! $this->isPending()) {
+            return ['success' => false, 'message' => 'Este fallo ya fue revisado.'];
+        }
+
+        $this->update([
+            'resolution_status' => 'dismissed',
+            'resolved_at' => now(),
+            'resolved_by_id' => $dismissedById,
+            'resolution_notes' => $notes,
+        ]);
+
+        return ['success' => true, 'message' => 'Fallo marcado como revisado.'];
     }
 }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Settings\PayrollSettings;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +23,7 @@ class Employee extends Model
 
     protected $fillable = [
         'photo',
+        'photo_thumbnail',
         'first_name',
         'last_name',
         'ci',
@@ -959,7 +961,7 @@ class Employee extends Model
             return null;
         }
 
-        $percent = app(\App\Settings\PayrollSettings::class)->advance_max_percent;
+        $percent = app(PayrollSettings::class)->advance_max_percent;
 
         return round($reference * $percent / 100, 2);
     }

--- a/app/Observers/EmployeeObserver.php
+++ b/app/Observers/EmployeeObserver.php
@@ -3,11 +3,24 @@
 namespace App\Observers;
 
 use App\Models\Employee;
+use App\Services\EmployeePhotoThumbnailService;
 use App\Services\ScheduleAssignmentService;
 use Carbon\Carbon;
 
 class EmployeeObserver
 {
+    /**
+     * Regenera `photo_thumbnail` en la misma escritura que cambia `photo` —
+     * en `saving()` (no `updated()`/`created()`) para que quede en el mismo
+     * INSERT/UPDATE, sin una segunda query.
+     */
+    public function saving(Employee $employee): void
+    {
+        if ($employee->isDirty('photo')) {
+            $employee->photo_thumbnail = EmployeePhotoThumbnailService::generate($employee->photo);
+        }
+    }
+
     public function created(Employee $employee): void
     {
         if (! Employee::$skipMandatoryDeductions) {

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -164,6 +164,11 @@ class AttendanceEventSyncService
                     'attempted_event' => $eventData['event_type'],
                     'last_event' => $last?->event_type,
                     'allowed_events' => $allowed,
+                    // Necesario para que AttendanceMarkFailure::approve() pueda reconstruir el
+                    // AttendanceEvent con la hora/ubicación/terminal originales, no con "ahora".
+                    'recorded_at' => $recordedAt->toIso8601String(),
+                    'location' => $eventData['location'] ?? $this->resolveFallbackLocation($terminal, $employee),
+                    'terminal_id' => $terminal->id,
                 ],
                 $employee,
                 $eventData['event_type'],

--- a/app/Services/EmployeeDescriptorSyncService.php
+++ b/app/Services/EmployeeDescriptorSyncService.php
@@ -16,7 +16,7 @@ class EmployeeDescriptorSyncService
 {
     /**
      * @return array{
-     *     employees: array<int, array{id: int, first_name: string, last_name: string, ci: string|null, face_descriptor: array}>,
+     *     employees: array<int, array{id: int, first_name: string, last_name: string, ci: string|null, face_descriptor: array, photo_thumbnail: string|null}>,
      *     tombstones: array<int, int>,
      *     server_time: string,
      *     sync_version: string,
@@ -33,16 +33,20 @@ class EmployeeDescriptorSyncService
             ->where('status', 'active')
             ->whereNotNull('face_descriptor')
             ->when($since, fn ($query) => $query->where('updated_at', '>', $since))
-            ->select(['id', 'first_name', 'last_name', 'ci', 'face_descriptor'])
+            ->select(['id', 'first_name', 'last_name', 'ci', 'face_descriptor', 'photo_thumbnail'])
             ->get();
 
         return [
+            // `photo_thumbnail` viaja como data URI ya pre-generado (ver
+            // EmployeePhotoThumbnailService / EmployeeObserver) — la foto
+            // original (potencialmente varios MB) nunca se sincroniza.
             'employees' => $employees->map(fn (Employee $employee) => [
                 'id' => $employee->id,
                 'first_name' => $employee->first_name,
                 'last_name' => $employee->last_name,
                 'ci' => $employee->ci,
                 'face_descriptor' => $employee->face_descriptor,
+                'photo_thumbnail' => $employee->photo_thumbnail,
             ])->values()->all(),
             'tombstones' => $since ? $this->tombstonesSince($terminal, $since) : [],
             'server_time' => now()->toIso8601String(),

--- a/app/Services/EmployeePhotoThumbnailService.php
+++ b/app/Services/EmployeePhotoThumbnailService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Genera un thumbnail cuadrado de baja resolución de la foto de un empleado,
+ * codificado como data URI base64. Se persiste en `Employee::photo_thumbnail`
+ * (ver EmployeeObserver) para poder viajar embebido en el payload JSON de
+ * sincronización offline del kiosko (ver EmployeeDescriptorSyncService) sin
+ * depender de que el dispositivo tenga red para pedir la imagen original por
+ * separado — la foto completa (potencialmente varios MB) nunca se sincroniza.
+ *
+ * Usa GD directo (ya disponible como extensión PHP) en vez de agregar una
+ * dependencia nueva tipo intervention/image, ya que el único uso es este
+ * recorte cuadrado + reescalado puntual.
+ */
+class EmployeePhotoThumbnailService
+{
+    /** Lado del thumbnail cuadrado, en píxeles. */
+    private const SIZE = 64;
+
+    /** Calidad JPEG (0-100) — 60 mantiene el payload chico sin artefactos visibles a este tamaño. */
+    private const QUALITY = 60;
+
+    /**
+     * @param  string|null  $photoPath  Path relativo en el disco `public` (ej. `employees/photos/foo.jpg`).
+     * @return string|null Data URI (`data:image/jpeg;base64,...`), o null si la foto no existe o no se pudo procesar.
+     */
+    public static function generate(?string $photoPath): ?string
+    {
+        if (! $photoPath || ! Storage::disk('public')->exists($photoPath)) {
+            return null;
+        }
+
+        $source = @imagecreatefromstring(Storage::disk('public')->get($photoPath));
+
+        if ($source === false) {
+            return null;
+        }
+
+        $width = imagesx($source);
+        $height = imagesy($source);
+        $cropSize = min($width, $height);
+        $cropX = (int) (($width - $cropSize) / 2);
+        $cropY = (int) (($height - $cropSize) / 2);
+
+        $thumbnail = imagecreatetruecolor(self::SIZE, self::SIZE);
+        imagecopyresampled(
+            $thumbnail,
+            $source,
+            0,
+            0,
+            $cropX,
+            $cropY,
+            self::SIZE,
+            self::SIZE,
+            $cropSize,
+            $cropSize
+        );
+
+        ob_start();
+        imagejpeg($thumbnail, null, self::QUALITY);
+        $jpegData = ob_get_clean();
+
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        return 'data:image/jpeg;base64,'.base64_encode($jpegData);
+    }
+}

--- a/database/migrations/2026_08_19_154630_add_resolution_fields_to_attendance_mark_failures_table.php
+++ b/database/migrations/2026_08_19_154630_add_resolution_fields_to_attendance_mark_failures_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega el flujo de revisión manual a los fallos de marcación: hasta ahora
+ * `AttendanceMarkFailureResource` era de solo lectura — un `sync_conflict`
+ * (kiosko offline, ver AttendanceEventSyncService) quedaba registrado pero
+ * sin ninguna acción posible desde Filament. Permite que un admin apruebe
+ * (reconstruye el `AttendanceEvent`), o descarte el fallo como revisado.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attendance_mark_failures', function (Blueprint $table) {
+            $table->string('resolution_status', 20)
+                ->default('pending')
+                ->after('metadata')
+                ->comment('pending, approved, dismissed');
+
+            $table->timestamp('resolved_at')->nullable()->after('resolution_status');
+
+            $table->foreignId('resolved_by_id')
+                ->nullable()
+                ->after('resolved_at')
+                ->constrained('users')
+                ->nullOnDelete();
+
+            $table->text('resolution_notes')->nullable()->after('resolved_by_id');
+
+            $table->foreignId('resolved_event_id')
+                ->nullable()
+                ->after('resolution_notes')
+                ->constrained('attendance_events')
+                ->nullOnDelete()
+                ->comment('AttendanceEvent creado al aprobar la marcación');
+
+            $table->index(['resolution_status', 'occurred_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attendance_mark_failures', function (Blueprint $table) {
+            // El índice compuesto debe eliminarse antes que la columna que lo compone —
+            // en SQLite (a diferencia de MySQL, que lo maneja implícitamente) dropColumn()
+            // falla si el índice todavía la referencia.
+            $table->dropIndex(['resolution_status', 'occurred_at']);
+            $table->dropConstrainedForeignId('resolved_by_id');
+            $table->dropConstrainedForeignId('resolved_event_id');
+            $table->dropColumn(['resolution_status', 'resolved_at', 'resolution_notes']);
+        });
+    }
+};

--- a/database/migrations/2026_08_19_160134_add_photo_thumbnail_to_employees_table.php
+++ b/database/migrations/2026_08_19_160134_add_photo_thumbnail_to_employees_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega `photo_thumbnail` a employees: un data URI base64 (JPEG 64x64,
+ * generado por EmployeePhotoThumbnailService) para que el kiosko offline
+ * pueda mostrar la foto real del empleado en la pantalla de éxito sin
+ * depender de red — se sincroniza embebido en el payload JSON de
+ * EmployeeDescriptorSyncService, igual que `face_descriptor`.
+ *
+ * No se sincroniza la foto original (potencialmente varios MB): el
+ * thumbnail se recalcula en EmployeeObserver cada vez que `photo` cambia.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->text('photo_thumbnail')->nullable()->after('photo');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('photo_thumbnail');
+        });
+    }
+};

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -630,7 +630,10 @@ document.addEventListener("DOMContentLoaded", () => {
                     first_name: employee.first_name,
                     last_name: employee.last_name,
                     ci: employee.ci,
-                    photo_url: "/images/default-avatar.png", // la caché offline no incluye fotos (ver EmployeeDescriptorSyncService)
+                    // Thumbnail 64x64 pre-generado (ver EmployeePhotoThumbnailService), sincronizado
+                    // como data URI junto al descriptor facial — funciona 100% offline. Sin foto
+                    // propia (empleado sin foto cargada), cae al ícono genérico.
+                    photo_url: employee.photo_thumbnail || "/images/default-avatar.png",
                 },
                 distance,
                 last_event: status.last_event,

--- a/tests/Feature/AttendanceMarkFailureResolutionTest.php
+++ b/tests/Feature/AttendanceMarkFailureResolutionTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Models\AttendanceEvent;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeResolutionEmployee(): Employee
+{
+    static $ci = 6000000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Res {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Res {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Res {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Res {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Res',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'email' => "res{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('sin employee_id o attempted_event_type no se puede resolver', function () {
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'mobile',
+        'failure_type' => 'face_no_match',
+        'failure_message' => 'No se pudo identificar el rostro.',
+    ]);
+
+    expect($failure->canBeResolved())->toBeFalse();
+});
+
+it('con employee_id y attempted_event_type se puede resolver', function () {
+    $employee = makeResolutionEmployee();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'attempted_event_type' => 'check_in',
+        'failure_message' => 'Secuencia inválida.',
+    ]);
+
+    expect($failure->canBeResolved())->toBeTrue();
+});
+
+it('approve() crea el AttendanceEvent usando el recorded_at del metadata', function () {
+    $admin = User::factory()->create();
+    $employee = makeResolutionEmployee();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'branch_id' => $employee->branch_id,
+        'attempted_event_type' => 'check_in',
+        'failure_message' => 'Secuencia inválida.',
+        'metadata' => ['recorded_at' => '2026-08-19 08:00:00'],
+    ]);
+
+    $result = $failure->approve($admin->id);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['event']->event_type)->toBe('check_in')
+        ->and($result['event']->recorded_at->format('Y-m-d H:i'))->toBe('2026-08-19 08:00');
+
+    $failure->refresh();
+    expect($failure->isApproved())->toBeTrue()
+        ->and($failure->resolved_by_id)->toBe($admin->id)
+        ->and($failure->resolved_event_id)->toBe($result['event']->id);
+});
+
+it('approve() revalida la secuencia contra el estado actual, no el de cuando se registró el fallo', function () {
+    $admin = User::factory()->create();
+    $employee = makeResolutionEmployee();
+
+    // El empleado nunca tuvo un check_in — break_start no es una secuencia válida.
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'attempted_event_type' => 'break_start',
+        'failure_message' => 'Secuencia inválida.',
+        'metadata' => ['recorded_at' => '2026-08-19 12:00:00'],
+    ]);
+
+    $result = $failure->approve($admin->id);
+
+    expect($result['success'])->toBeFalse();
+    expect($failure->fresh()->isPending())->toBeTrue();
+});
+
+it('approve() permite editar el tipo de evento y la hora antes de reinsertar', function () {
+    $admin = User::factory()->create();
+    $employee = makeResolutionEmployee();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'attempted_event_type' => 'break_start',
+        'failure_message' => 'Secuencia inválida.',
+    ]);
+
+    $result = $failure->approve($admin->id, 'check_in', now()->setTime(8, 0), 'Ajustado: en realidad fue entrada');
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['event']->event_type)->toBe('check_in');
+    expect($failure->fresh()->resolution_notes)->toBe('Ajustado: en realidad fue entrada');
+});
+
+it('dismiss() marca el fallo como revisado sin crear ningún evento', function () {
+    $admin = User::factory()->create();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'employee_not_found',
+        'failure_message' => 'Empleado no encontrado.',
+    ]);
+
+    $result = $failure->dismiss($admin->id, 'Ya se cargó manualmente.');
+
+    expect($result['success'])->toBeTrue();
+    expect($failure->fresh()->isDismissed())->toBeTrue();
+    expect(AttendanceEvent::count())->toBe(0);
+});
+
+it('no se puede aprobar ni descartar un fallo que ya fue revisado', function () {
+    $admin = User::factory()->create();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'employee_not_found',
+        'failure_message' => 'Empleado no encontrado.',
+    ]);
+    $failure->dismiss($admin->id);
+
+    $approveResult = $failure->approve($admin->id);
+    $dismissResult = $failure->dismiss($admin->id);
+
+    expect($approveResult['success'])->toBeFalse()
+        ->and($dismissResult['success'])->toBeFalse();
+});

--- a/tests/Feature/EmployeePhotoThumbnailTest.php
+++ b/tests/Feature/EmployeePhotoThumbnailTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\Terminal;
+use App\Services\EmployeeDescriptorSyncService;
+use App\Services\EmployeePhotoThumbnailService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makePhotoEmployee(array $attributes = []): Employee
+{
+    static $ci = 5000000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Photo {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Photo {$n}", 'company_id' => $company->id]);
+
+    return Employee::create(array_merge([
+        'first_name' => 'Foto',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'email' => "photo{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ], $attributes));
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('genera un thumbnail cuadrado de 64x64 a partir de una foto rectangular', function () {
+    Storage::fake('public');
+    $image = UploadedFile::fake()->image('foto.jpg', 300, 200);
+    $path = $image->store('employees/photos', 'public');
+
+    $dataUri = EmployeePhotoThumbnailService::generate($path);
+
+    expect($dataUri)->toStartWith('data:image/jpeg;base64,');
+
+    $decoded = base64_decode(substr($dataUri, strlen('data:image/jpeg;base64,')));
+    $gdImage = imagecreatefromstring($decoded);
+
+    expect(imagesx($gdImage))->toBe(64)
+        ->and(imagesy($gdImage))->toBe(64);
+});
+
+it('devuelve null si la foto no existe o el path es null', function () {
+    Storage::fake('public');
+
+    expect(EmployeePhotoThumbnailService::generate('employees/photos/no-existe.jpg'))->toBeNull()
+        ->and(EmployeePhotoThumbnailService::generate(null))->toBeNull();
+});
+
+it('el observer genera photo_thumbnail automáticamente al crear un empleado con foto', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('foto.jpg', 300, 200)->store('employees/photos', 'public');
+
+    $employee = makePhotoEmployee(['photo' => $path]);
+
+    expect($employee->photo_thumbnail)->not->toBeNull()
+        ->and($employee->photo_thumbnail)->toStartWith('data:image/jpeg;base64,');
+});
+
+it('el observer limpia photo_thumbnail cuando se quita la foto', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('foto.jpg', 300, 200)->store('employees/photos', 'public');
+    $employee = makePhotoEmployee(['photo' => $path]);
+
+    $employee->update(['photo' => null]);
+
+    expect($employee->fresh()->photo_thumbnail)->toBeNull();
+});
+
+it('un update que no toca la foto no regenera ni borra el thumbnail existente', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('foto.jpg', 300, 200)->store('employees/photos', 'public');
+    $employee = makePhotoEmployee(['photo' => $path]);
+    $originalThumbnail = $employee->photo_thumbnail;
+
+    $employee->update(['first_name' => 'Otro Nombre']);
+
+    expect($employee->fresh()->photo_thumbnail)->toBe($originalThumbnail);
+});
+
+it('el delta de sincronización del kiosko incluye photo_thumbnail', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('foto.jpg', 300, 200)->store('employees/photos', 'public');
+    $employee = makePhotoEmployee([
+        'photo' => $path,
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ]);
+    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+
+    $delta = app(EmployeeDescriptorSyncService::class)->deltaSince($terminal, null);
+
+    expect($delta['employees'])->toHaveCount(1)
+        ->and($delta['employees'][0]['photo_thumbnail'])->not->toBeNull();
+});


### PR DESCRIPTION
## Resumen

Dos mejoras de seguimiento tras cerrar las 6 fases de marcación offline (PR #77–#82), scopeadas con el usuario. Van en un solo PR porque comparten la misma rama designada de la sesión, pero son independientes — dos commits separados.

### 1. Revisión manual de fallos de marcación en conflicto

`AttendanceMarkFailureResource` era de solo lectura — un `sync_conflict` del kiosko offline (Fase 4) quedaba registrado pero sin ninguna acción posible desde Filament.

- Nuevo flujo `AttendanceMarkFailure::approve()`/`dismiss()`: **aprobar** reconstruye el `AttendanceEvent`, revalidando la secuencia contra el estado *actual* del empleado (puede haber cambiado desde que se registró el fallo), con opción de ajustar tipo de evento y hora antes de confirmar; **descartar** marca el fallo como revisado sin crear ningún evento. Solo disponible para fallos con `employee_id` + `attempted_event_type` presentes (`canBeResolved()`).
- Se agrega `recorded_at`/`location`/`terminal_id` a la metadata de `sync_conflict` (faltaba) — sin esto no había forma de reconstruir el evento con la hora real capturada por el kiosko.
- Nueva columna/filtro "Revisión" en la tabla, sección "Revisión" en el detalle, acción "Aprobar" como row action (bajo riesgo, permitida por convención) + "Aprobar"/"Descartar" en el header del `ViewRecord` ("descartar" es irreversible, por eso no vive en la tabla).

### 2. Foto real del empleado en la pantalla de éxito del kiosko

La caché offline del kiosko nunca incluyó fotos (decisión de la Fase 1, para no inflar el payload con archivos de varios MB) — se mostraba un ícono genérico.

- Nuevo `EmployeePhotoThumbnailService`: genera un thumbnail cuadrado de 64x64 (recorte centrado + reescalado, GD directo — sin agregar `intervention/image` ni otra dependencia nueva) codificado como data URI.
- `EmployeeObserver::saving()` lo regenera automáticamente cada vez que `photo` cambia (misma escritura, sin query extra).
- `EmployeeDescriptorSyncService` lo incluye en el mismo delta que ya sincroniza el descriptor facial — viaja embebido, funciona 100% offline.

## Test plan

- [x] `tests/Feature/AttendanceMarkFailureResolutionTest.php` (nuevo): `canBeResolved()`, `approve()` con/sin overrides, revalidación de secuencia contra el estado actual, `dismiss()`, doble revisión rechazada.
- [x] Misma lógica corrida como script standalone contra una BD SQLite de scratch — 18/18 aserciones OK.
- [x] `tests/Feature/EmployeePhotoThumbnailTest.php` (nuevo): generación del thumbnail (64x64 desde una foto rectangular), casos sin foto, regeneración/limpieza automática vía observer, inclusión en el delta de sync.
- [x] Misma lógica verificada con una imagen real (300x200 → recorte centrado 64x64) contra BD de scratch — 13/13 aserciones OK.
- [x] Las dos migraciones nuevas se corrieron (`up()`/`down()`, incluyendo rollback) contra esquemas de scratch — encontré y corregí un bug real en el rollback (SQLite exige borrar el índice compuesto antes que la columna; también correcto en MySQL, no solo un artefacto de test).
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin errores.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_