### PR TITLE
Marcación offline por celular personal — Fase 1: backend

### DIFF
--- a/app/Filament/Resources/EmployeeResource.php
+++ b/app/Filament/Resources/EmployeeResource.php
@@ -44,6 +44,7 @@ use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -769,6 +770,14 @@ class EmployeeResource extends Resource
                     ->color('info')
                     ->toggleable(isToggledHiddenByDefault: true),
 
+                TextColumn::make('mobile_linked_at')
+                    ->label('Celular vinculado')
+                    ->formatStateUsing(fn ($state) => $state ? 'Vinculado' : 'No vinculado')
+                    ->badge()
+                    ->color(fn ($state) => $state ? 'success' : 'gray')
+                    ->tooltip(fn (Employee $record) => $record->mobile_linked_at?->format('d/m/Y H:i'))
+                    ->toggleable(isToggledHiddenByDefault: true),
+
                 TextColumn::make('created_at')
                     ->label('Registrado')
                     ->dateTime('d/m/Y H:i')
@@ -862,7 +871,7 @@ class EmployeeResource extends Resource
                             );
                     }),
 
-                \Filament\Tables\Filters\TernaryFilter::make('has_face')
+                TernaryFilter::make('has_face')
                     ->label('Reconocimiento facial')
                     ->placeholder('Todos')
                     ->trueLabel('Con rostro registrado')
@@ -980,6 +989,26 @@ class EmployeeResource extends Resource
                                 ->success()
                                 ->title('Estado actualizado')
                                 ->body("El estado de {$record->full_name} cambió a: ".Employee::getStatusOptions()[$data['status']])
+                                ->send();
+                        }),
+
+                    Action::make('revoke_mobile_session')
+                        ->label('Revocar sesión móvil')
+                        ->icon('heroicon-o-device-phone-mobile')
+                        ->color('danger')
+                        ->tooltip('Desvincula el celular vinculado a este empleado para marcación offline — requerirá vincularse de nuevo desde /vincular-celular')
+                        ->visible(fn (Employee $record): bool => $record->hasMobileLinked())
+                        ->requiresConfirmation()
+                        ->modalHeading('Revocar sesión móvil')
+                        ->modalDescription(fn (Employee $record) => "El celular vinculado de {$record->first_name} {$record->last_name} perderá acceso a la marcación offline de inmediato. Deberá vincularse de nuevo con CI + fecha de nacimiento.")
+                        ->modalSubmitActionLabel('Sí, revocar')
+                        ->action(function (Employee $record) {
+                            $record->revokeMobileToken();
+
+                            Notification::make()
+                                ->success()
+                                ->title('Sesión móvil revocada')
+                                ->body('El empleado deberá vincular su celular de nuevo para volver a marcar offline.')
                                 ->send();
                         }),
                 ]),

--- a/app/Http/Controllers/Api/MobileEventSyncController.php
+++ b/app/Http/Controllers/Api/MobileEventSyncController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Employee;
+use App\Services\MobileEventSyncService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Recepción en lote de eventos de marcación del celular personal de un
+ * empleado — usado tanto en línea (lote de 1) como para volcar la cola
+ * acumulada tras un período offline. A diferencia del equivalente de
+ * terminal, no recibe `employee_id` por evento (el empleado es implícito:
+ * el dueño del token Sanctum). Autenticado vía Sanctum (ability `mobile:sync`).
+ */
+class MobileEventSyncController extends Controller
+{
+    public function __construct(private readonly MobileEventSyncService $syncService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        try {
+            $data = $request->validate([
+                'events' => ['required', 'array', 'min:1', 'max:200'],
+                'events.*.client_event_id' => ['required', 'string', 'size:36'],
+                'events.*.event_type' => ['required', 'string', 'in:check_in,break_start,break_end,check_out'],
+                'events.*.recorded_at' => ['required', 'date'],
+                'events.*.location' => ['nullable', 'array'],
+                'events.*.location.lat' => ['required_with:events.*.location', 'numeric', 'between:-90,90'],
+                'events.*.location.lng' => ['required_with:events.*.location', 'numeric', 'between:-180,180'],
+            ], [
+                'events.*.client_event_id.size' => 'client_event_id debe ser un UUID (36 caracteres).',
+            ]);
+        } catch (ValidationException $e) {
+            return response()->json([
+                'ok' => false,
+                'message' => 'Datos de entrada inválidos.',
+                'errors' => $e->errors(),
+            ], 422);
+        }
+
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        if ($employee->status !== 'active') {
+            $employee->revokeMobileToken();
+
+            return response()->json([
+                'ok' => false,
+                'message' => 'Tu acceso a la marcación por celular fue desactivado. Consultá con RRHH.',
+            ], 403);
+        }
+
+        $results = $this->syncService->syncBatch($employee, $data['events']);
+
+        return response()->json([
+            'ok' => true,
+            'results' => $results,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Employee;
+use App\Settings\GeneralSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Heartbeat del celular personal — a diferencia del heartbeat de terminal
+ * (Terminal), acá el propio empleado es el `tokenable`, así que además de
+ * la config vigente de reconocimiento facial también devuelve el
+ * `face_descriptor` actualizado del empleado: no existe un endpoint
+ * separado de "sync de empleados" porque el celular solo necesita cachear
+ * un único descriptor, el suyo. Esto además propaga automáticamente una
+ * re-inscripción facial (nuevo enrollment) sin que el empleado tenga que
+ * re-vincular el dispositivo.
+ */
+class MobileHeartbeatController extends Controller
+{
+    public function store(Request $request, GeneralSettings $settings): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        if ($employee->status !== 'active') {
+            // El empleado se desvinculó implícitamente (baja, licencia, etc.) — se revoca acá
+            // en vez de esperar a que un admin lo haga manualmente desde Filament.
+            $employee->revokeMobileToken();
+
+            return response()->json([
+                'ok' => false,
+                'message' => 'Tu acceso a la marcación por celular fue desactivado. Consultá con RRHH.',
+            ], 403);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'server_time' => now()->toIso8601String(),
+            'config' => [
+                'face_threshold' => (float) $settings->face_threshold,
+                'face_min_confidence_gap' => (float) $settings->face_min_confidence_gap,
+            ],
+            'employee' => [
+                'id' => $employee->id,
+                'first_name' => $employee->first_name,
+                'last_name' => $employee->last_name,
+                'ci' => $employee->ci,
+                'face_descriptor' => $employee->face_descriptor,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/MobileStatusController.php
+++ b/app/Http/Controllers/Api/MobileStatusController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Employee;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Estado de marcación del día en curso para el propio empleado autenticado
+ * (a diferencia de `TerminalEmployeeSyncController::status()`, que recibe el
+ * `employee_id` por ruta porque un terminal consulta por cualquiera de sus
+ * empleados — acá el empleado es implícito, siempre `$request->user()`).
+ * El celular prefiere esta consulta en línea; si falla, cae a una
+ * resolución local equivalente (ver mobile-offline/queue.js, igual que
+ * hace el kiosko desde la Fase 4).
+ */
+class MobileStatusController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        $today = now(config('app.timezone'))->toDateString();
+
+        $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today)->first();
+        $last = $day
+            ? AttendanceEvent::where('attendance_day_id', $day->id)->latest('recorded_at')->first()
+            : null;
+
+        return response()->json([
+            'ok' => true,
+            'last_event' => $last?->event_type,
+            'last_event_time' => $last?->recorded_at?->format('H:i'),
+            'allowed_events' => AttendanceEvent::allowedNextEventTypes($last?->event_type),
+        ]);
+    }
+}

--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Employee;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+/**
+ * Vinculación del celular personal del empleado para la marcación offline
+ * vía PWA. A diferencia de `TerminalSetupController` (enlace de un solo uso
+ * generado por un admin), acá el propio empleado se identifica con CI +
+ * fecha de nacimiento — ese par de datos funciona como credencial para
+ * "reclamar" el dispositivo, no como control de acceso completo: la
+ * marcación en sí sigue requiriendo un match facial exitoso contra el
+ * descriptor cacheado (segundo factor real).
+ *
+ * Vincular un celular nuevo revoca automáticamente el anterior — un solo
+ * dispositivo vinculado a la vez por empleado (`Employee::claimMobileToken()`).
+ */
+class MobileLinkController extends Controller
+{
+    /** Muestra el formulario de vinculación (CI + fecha de nacimiento). */
+    public function show(): View
+    {
+        return view('attendances.mobile-link');
+    }
+
+    /**
+     * Valida CI + fecha de nacimiento y emite el token Sanctum del empleado.
+     * El mensaje de error es deliberadamente genérico (no distingue "CI no
+     * existe" de "fecha incorrecta") para no facilitar enumeración de CIs
+     * válidos — la ruta ya está limitada por `throttle:10,1`.
+     */
+    public function claim(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'ci' => ['required', 'string', 'max:20'],
+            'birth_date' => ['required', 'date'],
+        ]);
+
+        $employee = Employee::query()
+            ->where('ci', $data['ci'])
+            ->whereDate('birth_date', $data['birth_date'])
+            ->where('status', 'active')
+            ->whereNotNull('face_descriptor')
+            ->first();
+
+        if (! $employee) {
+            Log::warning('Intento de vinculación de celular con datos inválidos', [
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'message' => 'CI o fecha de nacimiento incorrectos, o el empleado no está habilitado para marcar por celular.',
+            ], 422);
+        }
+
+        $plainTextToken = $employee->claimMobileToken();
+
+        Log::info("Celular vinculado para el empleado #{$employee->id} ({$employee->first_name} {$employee->last_name})", [
+            'employee_id' => $employee->id,
+            'ip' => $request->ip(),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'token' => $plainTextToken,
+            'employee' => [
+                'id' => $employee->id,
+                'first_name' => $employee->first_name,
+                'last_name' => $employee->last_name,
+                'ci' => $employee->ci,
+                'face_descriptor' => $employee->face_descriptor,
+            ],
+        ]);
+    }
+}

--- a/app/Models/AttendanceMarkFailure.php
+++ b/app/Models/AttendanceMarkFailure.php
@@ -327,8 +327,8 @@ class AttendanceMarkFailure extends Model
             $event = $day->events()->create([
                 'event_type' => $eventType,
                 'recorded_at' => $recordedAt,
-                'synced_at' => $this->mode === 'terminal' ? now() : null,
-                'source' => $this->mode === 'terminal' ? 'terminal' : 'manual',
+                'synced_at' => in_array($this->mode, ['terminal', 'mobile'], true) ? now() : null,
+                'source' => in_array($this->mode, ['terminal', 'mobile'], true) ? $this->mode : 'manual',
                 'location' => $this->metadata['location'] ?? $this->location,
                 'terminal_id' => $this->metadata['terminal_id'] ?? null,
                 'branch_mismatch' => false,

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -4,16 +4,29 @@ namespace App\Models;
 
 use App\Settings\PayrollSettings;
 use Carbon\Carbon;
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Laravel\Sanctum\HasApiTokens;
 
-class Employee extends Model
+/**
+ * Implementa `Authenticatable` (no solo `HasApiTokens`) por el mismo motivo
+ * que `Terminal`: el empleado es el "usuario" autenticado en la API de
+ * marcación offline por celular (`routes/api.php`, prefijo `v1/mobile`) — sin
+ * esto, `$request->user()` funciona en producción igual, pero el helper de
+ * test `Sanctum::actingAs()` exige el contrato con tipado estricto.
+ */
+class Employee extends Model implements AuthenticatableContract
 {
-    use HasFactory;
+    use Authenticatable, HasApiTokens, HasFactory;
+
+    /** Ability Sanctum requerida para consumir la API de sincronización móvil del propio empleado. */
+    public const MOBILE_SYNC_ABILITY = 'mobile:sync';
 
     /**
      * Cuando es true, el EmployeeObserver omite la asignación automática de deducciones obligatorias.
@@ -39,12 +52,14 @@ class Employee extends Model
         'schedule_id',
         'status',
         'face_descriptor',
+        'mobile_linked_at',
     ];
 
     protected $casts = [
         'birth_date' => 'date',
         'maternity_protection_until' => 'date',
         'face_descriptor' => 'array',
+        'mobile_linked_at' => 'datetime',
     ];
 
     // ───────────────────────────────────────────
@@ -1157,5 +1172,39 @@ class Employee extends Model
         }
 
         return $toAssignIds->count();
+    }
+
+    // =========================================================================
+    // MARCACIÓN OFFLINE POR CELULAR — VINCULACIÓN Y TOKEN SANCTUM
+    // =========================================================================
+
+    /**
+     * Emite un token Sanctum (ability `mobile:sync`) para el celular personal
+     * del empleado, tras validarse con CI + fecha de nacimiento (ver
+     * `MobileLinkController`). Revoca cualquier token móvil previo — un solo
+     * dispositivo vinculado a la vez, igual que `Terminal::claimSanctumToken()`.
+     *
+     * @return string Token Sanctum en texto plano — solo se retorna una vez, nunca se persiste en claro.
+     */
+    public function claimMobileToken(): string
+    {
+        $this->tokens()->where('name', 'like', 'mobile:%')->delete();
+
+        $this->forceFill(['mobile_linked_at' => now()])->save();
+
+        return $this->createToken('mobile:'.$this->id, [self::MOBILE_SYNC_ABILITY])->plainTextToken;
+    }
+
+    /** Revoca el token móvil del empleado (dispositivo perdido/robado, o desvinculación manual desde Filament). */
+    public function revokeMobileToken(): void
+    {
+        $this->tokens()->where('name', 'like', 'mobile:%')->delete();
+        $this->forceFill(['mobile_linked_at' => null])->save();
+    }
+
+    /** Indica si el empleado tiene un celular vinculado actualmente. */
+    public function hasMobileLinked(): bool
+    {
+        return $this->mobile_linked_at !== null;
     }
 }

--- a/app/Services/MobileEventSyncService.php
+++ b/app/Services/MobileEventSyncService.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Employee;
+use Carbon\Carbon;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Sincroniza en lote los eventos de marcación capturados por el celular
+ * personal de UN empleado ya autenticado (a diferencia de
+ * `AttendanceEventSyncService`, que sirve a un terminal con N empleados —
+ * acá no hace falta `employee_id` por evento ni resolver "a quién
+ * pertenece": el dueño del token Sanctum ES el empleado). Misma
+ * idempotencia por `client_event_id` y misma re-validación de secuencia
+ * contra el estado *actual* del servidor que el flujo de terminal.
+ */
+class MobileEventSyncService
+{
+    /**
+     * @param  array<int, array{client_event_id: string, event_type: string, recorded_at: string, location?: array|null}>  $events
+     * @return array<int, array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}>
+     */
+    public function syncBatch(Employee $employee, array $events): array
+    {
+        // Se procesa en orden cronológico de captura, para que varios eventos
+        // represados se repliquen en el orden en que realmente ocurrieron.
+        $ordered = collect($events)->sortBy('recorded_at')->values();
+
+        return $ordered->map(fn (array $eventData) => $this->syncOne($employee, $eventData))->all();
+    }
+
+    /**
+     * @param  array{client_event_id: string, event_type: string, recorded_at: string, location?: array|null}  $eventData
+     * @return array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}
+     */
+    private function syncOne(Employee $employee, array $eventData): array
+    {
+        $clientEventId = $eventData['client_event_id'];
+
+        // Idempotencia: reintentar el mismo lote (ej. la respuesta anterior se perdió
+        // en el camino) no debe duplicar el evento ya sincronizado.
+        $existing = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+        if ($existing) {
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'duplicate',
+                'event_id' => $existing->id,
+            ];
+        }
+
+        try {
+            $recordedAt = Carbon::parse($eventData['recorded_at']);
+        } catch (Throwable) {
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'rejected',
+                'conflict_reason' => 'invalid_timestamp',
+                'message' => 'Fecha/hora de marcación inválida.',
+            ];
+        }
+
+        $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
+
+        try {
+            return DB::transaction(fn () => $this->insertEvent($employee, $eventData, $clientEventId, $recordedAt, $date));
+        } catch (UniqueConstraintViolationException) {
+            // Carrera entre dos sync concurrentes con el mismo client_event_id — el otro ganó, tratar como duplicado.
+            $existing = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => $existing ? 'duplicate' : 'rejected',
+                'event_id' => $existing?->id,
+            ];
+        }
+    }
+
+    /**
+     * @param  array{client_event_id: string, event_type: string, recorded_at: string, location?: array|null}  $eventData
+     * @return array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}
+     */
+    private function insertEvent(
+        Employee $employee,
+        array $eventData,
+        string $clientEventId,
+        Carbon $recordedAt,
+        string $date,
+    ): array {
+        $day = AttendanceDay::firstOrCreate(
+            ['employee_id' => $employee->id, 'date' => $date],
+            ['status' => 'present']
+        );
+
+        $last = AttendanceEvent::where('attendance_day_id', $day->id)
+            ->lockForUpdate()
+            ->latest('recorded_at')
+            ->first();
+
+        $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
+
+        if (! in_array($eventData['event_type'], $allowed, true)) {
+            Log::warning("Sync de celular — evento '{$eventData['event_type']}' ya no es válido para el empleado {$employee->id} (último registrado: ".($last->event_type ?? 'ninguno').')', [
+                'employee_id' => $employee->id,
+                'client_event_id' => $clientEventId,
+                'attempted_event' => $eventData['event_type'],
+                'last_event' => $last?->event_type,
+                'allowed_events' => $allowed,
+            ]);
+
+            $this->recordSyncFailure(
+                $employee,
+                'La secuencia de marcación ya no es válida en el servidor al sincronizar (último evento registrado: '.($last->event_type ?? 'ninguno').').',
+                [
+                    'client_event_id' => $clientEventId,
+                    'attempted_event' => $eventData['event_type'],
+                    'last_event' => $last?->event_type,
+                    'allowed_events' => $allowed,
+                    'recorded_at' => $recordedAt->toIso8601String(),
+                    'location' => $eventData['location'] ?? null,
+                ],
+                $eventData['event_type'],
+            );
+
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'conflict',
+                'conflict_reason' => 'invalid_sequence',
+                'message' => 'La secuencia de marcación ya no es válida en el servidor — probablemente otro origen registró un evento mientras el celular estaba offline.',
+            ];
+        }
+
+        if ($day->status !== 'present') {
+            $day->update(['status' => 'present']);
+        }
+
+        $event = $day->events()->create([
+            'client_event_id' => $clientEventId,
+            'event_type' => $eventData['event_type'],
+            'recorded_at' => $recordedAt,
+            'synced_at' => now(),
+            'source' => 'mobile',
+            'location' => $eventData['location'] ?? null,
+        ]);
+
+        return [
+            'client_event_id' => $clientEventId,
+            'status' => 'synced',
+            'event_id' => $event->id,
+        ];
+    }
+
+    /**
+     * Persiste un intento fallido de sincronización para revisión en Filament
+     * (`AttendanceMarkFailureResource` — mismo flujo de aprobar/descartar que
+     * ya existe para los conflictos del kiosko).
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    private function recordSyncFailure(Employee $employee, string $message, array $metadata, string $eventType): void
+    {
+        try {
+            AttendanceMarkFailure::record([
+                'mode' => 'mobile',
+                'failure_type' => 'sync_conflict',
+                'employee_id' => $employee->id,
+                'branch_id' => $employee->branch_id,
+                'attempted_event_type' => $eventType,
+                'failure_message' => $message,
+                'metadata' => $metadata,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('No se pudo persistir el fallo de sincronización offline (celular)', [
+                'employee_id' => $employee->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/database/migrations/2026_08_19_174638_add_mobile_link_to_employees_table.php
+++ b/database/migrations/2026_08_19_174638_add_mobile_link_to_employees_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Marcación offline desde el celular personal del empleado (Parte C, Fase 1):
+ * `mobile_linked_at` registra cuándo el empleado vinculó su dispositivo
+ * (`Employee::claimMobileToken()`) — se usa en `EmployeeResource` para
+ * mostrar el estado sin necesidad de consultar `->tokens()->exists()` por
+ * fila en la tabla (evitaría un N+1). El token Sanctum en sí vive en
+ * `personal_access_tokens` (polimórfica, ya existente — sin migración
+ * nueva ahí, mismo mecanismo que usa `Terminal`).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->timestamp('mobile_linked_at')->nullable()->after('face_descriptor');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('mobile_linked_at');
+        });
+    }
+};

--- a/resources/views/attendances/mobile-link.blade.php
+++ b/resources/views/attendances/mobile-link.blade.php
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="es">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Vincular celular — Marcación de asistencia</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100dvh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+        }
+        .container { max-width: 420px; width: 100%; text-align: center; }
+        .icon {
+            width: 80px; height: 80px;
+            border-radius: 50%;
+            background: #1e293b;
+            display: flex; align-items: center; justify-content: center;
+            margin: 0 auto 1.5rem;
+            border: 2px solid #38bdf8;
+        }
+        .icon svg { width: 40px; height: 40px; color: #38bdf8; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.75rem; }
+        p { font-size: 1rem; color: #94a3b8; line-height: 1.6; margin-bottom: 1.5rem; }
+        form { text-align: left; }
+        label { display: block; font-size: 0.875rem; color: #94a3b8; margin-bottom: 0.35rem; }
+        input {
+            width: 100%;
+            font: inherit;
+            font-size: 1rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.6rem;
+            border: 1px solid #334155;
+            background: #1e293b;
+            color: #e2e8f0;
+            margin-bottom: 1.1rem;
+        }
+        input:focus { outline: none; border-color: #38bdf8; }
+        button {
+            width: 100%;
+            font: inherit;
+            font-weight: 600;
+            font-size: 1rem;
+            padding: 0.85rem 1.75rem;
+            border-radius: 0.75rem;
+            border: none;
+            background: #38bdf8;
+            color: #0f172a;
+            cursor: pointer;
+        }
+        button:disabled { opacity: 0.6; cursor: not-allowed; }
+        button:not(:disabled):hover { background: #7dd3fc; }
+        .status { margin-top: 1.25rem; font-size: 0.9rem; min-height: 1.5rem; text-align: center; }
+        .status--error { color: #f87171; }
+        .status--success { color: #4ade80; }
+        .hint { font-size: 0.8rem; color: #64748b; margin-top: 1.5rem; line-height: 1.5; }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75A2.25 2.25 0 0015.75 1.5H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+            </svg>
+        </div>
+        <h1>Vincular este celular</h1>
+        <p>Ingresá tu CI y fecha de nacimiento para vincular este dispositivo. Vas a poder marcar tu asistencia aunque no tengas conexión a internet.</p>
+
+        <form id="linkForm">
+            <label for="ci">CI</label>
+            <input type="text" id="ci" name="ci" inputmode="numeric" autocomplete="off" required>
+
+            <label for="birth_date">Fecha de nacimiento</label>
+            <input type="date" id="birth_date" name="birth_date" required>
+
+            <button type="submit" id="btnLink">Vincular este dispositivo</button>
+        </form>
+        <div id="status" class="status" role="status" aria-live="polite"></div>
+
+        <p class="hint">Solo se puede vincular un dispositivo a la vez. Si vinculás un celular nuevo, el anterior deja de funcionar automáticamente.</p>
+    </div>
+
+    <script>
+        const form = document.getElementById('linkForm');
+        const btn = document.getElementById('btnLink');
+        const statusEl = document.getElementById('status');
+        const csrf = document.querySelector('meta[name="csrf-token"]').content;
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            btn.disabled = true;
+            statusEl.textContent = 'Vinculando...';
+            statusEl.className = 'status';
+
+            try {
+                const response = await fetch(window.location.pathname.replace(/\/$/, ''), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
+                    body: JSON.stringify({
+                        ci: document.getElementById('ci').value.trim(),
+                        birth_date: document.getElementById('birth_date').value,
+                    }),
+                });
+                const data = await response.json();
+
+                if (!data.ok) {
+                    statusEl.textContent = data.message || 'No se pudo vincular el dispositivo.';
+                    statusEl.className = 'status status--error';
+                    btn.disabled = false;
+                    return;
+                }
+
+                // Almacenamiento provisorio del token — en la fase de sincronización offline
+                // (IndexedDB, módulo mobile-offline/) este valor pasa a vivir en su propio store,
+                // mismo patrón que usó terminal-setup.blade.php para el kiosko.
+                localStorage.setItem('nominapp_mobile_token', data.token);
+                localStorage.setItem('nominapp_mobile_employee_id', String(data.employee.id));
+
+                statusEl.textContent = `Dispositivo vinculado. ¡Hola, ${data.employee.first_name}! Redirigiendo...`;
+                statusEl.className = 'status status--success';
+
+                setTimeout(() => {
+                    window.location.href = '{{ route('mark.show') }}';
+                }, 1200);
+            } catch (error) {
+                statusEl.textContent = 'Error de conexión. Intente nuevamente.';
+                statusEl.className = 'status status--error';
+                btn.disabled = false;
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\Api\MobileEventSyncController;
+use App\Http\Controllers\Api\MobileHeartbeatController;
+use App\Http\Controllers\Api\MobileStatusController;
 use App\Http\Controllers\Api\TerminalEmployeeSyncController;
 use App\Http\Controllers\Api\TerminalEventSyncController;
 use App\Http\Controllers\Api\TerminalHeartbeatController;
@@ -7,16 +10,19 @@ use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
-| API Routes — Sincronización de Terminales (marcación offline vía PWA)
+| API Routes — Sincronización offline vía PWA (kiosko y celular personal)
 |--------------------------------------------------------------------------
 |
-| Autenticadas con Laravel Sanctum (bearer token emitido al provisionar el
-| terminal, ver TerminalSetupController). Ability requerida: 'terminal:sync'.
-| Solo consumidas por el kiosko/terminal — el flujo de celular personal
-| (mark.js) sigue usando las rutas de sesión en routes/web.php sin cambios.
+| Autenticadas con Laravel Sanctum. Sanctum resuelve el `tokenable` de forma
+| polimórfica (por `personal_access_tokens.tokenable_type`) — un mismo guard
+| `auth:sanctum` sirve tokens de `Terminal` (kiosko) y de `Employee`
+| (celular personal) sin necesidad de guards/providers separados en
+| config/auth.php. Cada grupo abajo exige su propia ability.
 |
 */
 
+// Kiosko de sucursal — bearer token emitido al provisionar el terminal (ver
+// TerminalSetupController). Ability requerida: 'terminal:sync'.
 Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum'])->group(function () {
     Route::get('/employees/sync', [TerminalEmployeeSyncController::class, 'index'])
         ->middleware('ability:terminal:sync')
@@ -33,4 +39,24 @@ Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum']
     Route::post('/heartbeat', [TerminalHeartbeatController::class, 'store'])
         ->middleware('ability:terminal:sync')
         ->name('heartbeat');
+});
+
+// Celular personal del empleado — bearer token emitido al vincular el
+// dispositivo (ver MobileLinkController). Ability requerida: 'mobile:sync'.
+// A diferencia del kiosko (N empleados por terminal), acá el token identifica
+// a un único empleado (el propio dueño del token vía $request->user()), por
+// eso no existe un endpoint de "sync de empleados" — el heartbeat ya
+// devuelve el descriptor facial actualizado del propio empleado.
+Route::prefix('v1/mobile')->name('api.mobile.')->middleware(['auth:sanctum'])->group(function () {
+    Route::post('/heartbeat', [MobileHeartbeatController::class, 'store'])
+        ->middleware('ability:mobile:sync')
+        ->name('heartbeat');
+
+    Route::get('/status', [MobileStatusController::class, 'show'])
+        ->middleware('ability:mobile:sync')
+        ->name('status');
+
+    Route::post('/events/sync', [MobileEventSyncController::class, 'store'])
+        ->middleware('ability:mobile:sync')
+        ->name('events.sync');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\LoanController;
 use App\Http\Controllers\LogController;
 use App\Http\Controllers\MerchandiseReportController;
 use App\Http\Controllers\MerchandiseWithdrawalController;
+use App\Http\Controllers\MobileLinkController;
 use App\Http\Controllers\OrgChartController;
 use App\Http\Controllers\PayrollController;
 use App\Http\Controllers\SalaryReportController;
@@ -55,6 +56,16 @@ Route::get('/terminal/{code}', [AttendanceFaceMarkController::class, 'terminalBy
 Route::prefix('terminal/{code}/setup/{setupToken}')->name('terminal.setup.')->middleware('throttle:10,1')->group(function () {
     Route::get('/', [TerminalSetupController::class, 'show'])->name('show');
     Route::post('/claim', [TerminalSetupController::class, 'claim'])->name('claim');
+});
+
+// Vinculación del celular personal para marcación offline — el propio empleado se
+// identifica con CI + fecha de nacimiento (sin enlace de un solo uso generado por
+// un admin, a diferencia del terminal: acá el dato personal ES la credencial).
+// Emite el token Sanctum que el celular usará contra la API de sincronización
+// (routes/api.php, prefijo v1/mobile).
+Route::prefix('vincular-celular')->name('mobile-link.')->middleware('throttle:10,1')->group(function () {
+    Route::get('/', [MobileLinkController::class, 'show'])->name('show');
+    Route::post('/', [MobileLinkController::class, 'claim'])->name('claim');
 });
 
 /*

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -1,0 +1,216 @@
+<?php
+
+use App\Models\AttendanceEvent;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Terminal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLinkableEmployee(array $overrides = []): Employee
+{
+    static $ci = 9500000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Link {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Link {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Link {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Link {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create(array_merge([
+        'first_name' => 'Link',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-05-15',
+        'email' => "link{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ], $overrides));
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Vinculación (/vincular-celular) ───────────────────────────────────────
+
+it('vincula el celular con CI y fecha de nacimiento correctos y emite un token', function () {
+    $employee = makeLinkableEmployee();
+
+    $response = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    expect($response->json('token'))->not->toBeNull()
+        ->and($response->json('employee.id'))->toBe($employee->id)
+        ->and($response->json('employee.face_descriptor'))->toHaveCount(128);
+
+    expect($employee->fresh()->hasMobileLinked())->toBeTrue();
+});
+
+it('rechaza CI o fecha de nacimiento incorrectos con un mensaje genérico', function () {
+    $employee = makeLinkableEmployee();
+
+    $response = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '2000-01-01',
+    ]);
+
+    $response->assertStatus(422)->assertJson(['ok' => false]);
+    expect($employee->fresh()->hasMobileLinked())->toBeFalse();
+});
+
+it('rechaza la vinculación de un empleado inactivo', function () {
+    $employee = makeLinkableEmployee(['status' => 'inactive']);
+
+    $response = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ]);
+
+    $response->assertStatus(422);
+});
+
+it('rechaza la vinculación de un empleado sin descriptor facial', function () {
+    $employee = makeLinkableEmployee(['face_descriptor' => null]);
+
+    $response = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ]);
+
+    $response->assertStatus(422);
+});
+
+it('vincular un celular nuevo revoca el token anterior — un solo dispositivo a la vez', function () {
+    $employee = makeLinkableEmployee();
+
+    $first = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ])->json('token');
+
+    $second = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ])->json('token');
+
+    expect($first)->not->toBe($second);
+
+    // El token viejo ya no autentica.
+    $this->withHeader('Authorization', "Bearer {$first}")
+        ->getJson('/api/v1/mobile/status')
+        ->assertStatus(401);
+
+    // El nuevo sí.
+    $this->withHeader('Authorization', "Bearer {$second}")
+        ->getJson('/api/v1/mobile/status')
+        ->assertOk();
+});
+
+// ─── API /api/v1/mobile/* ──────────────────────────────────────────────────
+
+it('el heartbeat devuelve la config vigente y el descriptor facial del empleado', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    expect($response->json('employee.id'))->toBe($employee->id)
+        ->and($response->json('config.face_threshold'))->not->toBeNull();
+});
+
+it('el heartbeat revoca el token y responde 403 si el empleado ya no está activo', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $employee->update(['status' => 'inactive']);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertStatus(403);
+    expect($employee->tokens()->count())->toBe(0);
+});
+
+it('status devuelve el último evento y los eventos permitidos para el propio empleado', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->getJson('/api/v1/mobile/status');
+
+    $response->assertOk()
+        ->assertJson([
+            'ok' => true,
+            'last_event' => null,
+            'allowed_events' => ['check_in'],
+        ]);
+});
+
+it('events/sync crea el evento con origen mobile para el empleado autenticado', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $clientEventId = (string) Str::uuid();
+
+    $response = $this->postJson('/api/v1/mobile/events/sync', [
+        'events' => [[
+            'client_event_id' => $clientEventId,
+            'event_type' => 'check_in',
+            'recorded_at' => now()->toDateTimeString(),
+            'location' => ['lat' => -25.28, 'lng' => -57.64],
+        ]],
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    expect($response->json('results.0.status'))->toBe('synced');
+
+    $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+    expect($event->source)->toBe('mobile');
+});
+
+it('events/sync revoca el token y responde 403 si el empleado ya no está activo', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $employee->update(['status' => 'inactive']);
+
+    $response = $this->postJson('/api/v1/mobile/events/sync', [
+        'events' => [[
+            'client_event_id' => (string) Str::uuid(),
+            'event_type' => 'check_in',
+            'recorded_at' => now()->toDateTimeString(),
+        ]],
+    ]);
+
+    $response->assertStatus(403);
+    expect($employee->tokens()->count())->toBe(0);
+});
+
+it('un token de terminal no puede usar las rutas móviles (ability distinta)', function () {
+    $employee = makeLinkableEmployee();
+    $terminal = Terminal::create([
+        'name' => 'Kiosko Test', 'branch_id' => $employee->branch_id,
+    ]);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $this->postJson('/api/v1/mobile/heartbeat')->assertStatus(403);
+});

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -95,7 +95,14 @@ it('rechaza como conflict un evento cuya secuencia ya no es válida en el servid
     $employee = makeMobileSyncEmployee();
     $service = app(MobileEventSyncService::class);
 
-    // El check_out ya llegó al servidor (ej. registrado manualmente mientras el celular estaba offline).
+    // El check_in y el check_out ya llegaron al servidor (ej. registrados manualmente
+    // mientras el celular estaba offline) — un check_out sin check_in previo también
+    // sería una secuencia inválida, por eso se establece el estado con ambos.
+    $service->syncBatch($employee, [[
+        'client_event_id' => (string) Str::uuid(),
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+    ]]);
     $service->syncBatch($employee, [[
         'client_event_id' => (string) Str::uuid(),
         'event_type' => 'check_out',
@@ -114,9 +121,11 @@ it('rechaza como conflict un evento cuya secuencia ya no es válida en el servid
         ->and($results[0]['conflict_reason'])->toBe('invalid_sequence')
         ->and(AttendanceEvent::where('client_event_id', $conflictingClientEventId)->exists())->toBeFalse();
 
-    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')->where('mode', 'mobile')->first();
+    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')
+        ->where('mode', 'mobile')
+        ->where('employee_id', $employee->id)
+        ->first();
     expect($failure)->not->toBeNull()
-        ->and($failure->employee_id)->toBe($employee->id)
         ->and($failure->branch_id)->toBe($employee->branch_id)
         ->and($failure->attempted_event_type)->toBe('break_start')
         ->and($failure->canBeResolved())->toBeTrue();
@@ -126,19 +135,28 @@ it('aprobar un conflicto mobile reconstruye el evento con source mobile', functi
     $employee = makeMobileSyncEmployee();
     $service = app(MobileEventSyncService::class);
 
+    // El check_in ya está en el servidor.
     $service->syncBatch($employee, [[
         'client_event_id' => (string) Str::uuid(),
-        'event_type' => 'check_out',
-        'recorded_at' => '2026-08-19 17:00:00',
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
     ]]);
 
+    // El celular sincroniza offline un segundo check_in (ej. capturado dos veces por
+    // un reintento de red) — ya no es válido, el servidor lo rechaza como conflicto.
     $service->syncBatch($employee, [[
         'client_event_id' => (string) Str::uuid(),
-        'event_type' => 'break_start',
-        'recorded_at' => '2026-08-19 12:00:00',
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:05:00',
     ]]);
 
-    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')->where('mode', 'mobile')->first();
+    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')
+        ->where('mode', 'mobile')
+        ->where('employee_id', $employee->id)
+        ->first();
+
+    // El admin revisa el conflicto y determina que en realidad correspondía un break_start
+    // (sigue siendo válido contra el estado actual: último evento = check_in).
 
     $admin = User::create([
         'name' => 'Admin', 'email' => 'admin-mobile@test.com', 'password' => bcrypt('secret'),

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Models\AttendanceEvent;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\User;
+use App\Services\MobileEventSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeMobileSyncEmployee(): Employee
+{
+    static $ci = 9000000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Mobile {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Mobile {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Mobile {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Mobile {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Mobile',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-05-15',
+        'email' => "mobile{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('sincroniza un evento nuevo y lo marca con origen mobile', function () {
+    $employee = makeMobileSyncEmployee();
+    $clientEventId = (string) Str::uuid();
+
+    $results = app(MobileEventSyncService::class)->syncBatch($employee, [[
+        'client_event_id' => $clientEventId,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+        'location' => ['lat' => -25.28, 'lng' => -57.64],
+    ]]);
+
+    expect($results[0]['status'])->toBe('synced');
+
+    $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+    expect($event)->not->toBeNull()
+        ->and($event->source)->toBe('mobile')
+        ->and($event->synced_at)->not->toBeNull()
+        ->and($event->terminal_id)->toBeNull();
+});
+
+it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {
+    $employee = makeMobileSyncEmployee();
+    $clientEventId = (string) Str::uuid();
+    $payload = [[
+        'client_event_id' => $clientEventId,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+    ]];
+
+    $service = app(MobileEventSyncService::class);
+    $service->syncBatch($employee, $payload);
+    $results = $service->syncBatch($employee, $payload);
+
+    expect($results[0]['status'])->toBe('duplicate')
+        ->and(AttendanceEvent::where('client_event_id', $clientEventId)->count())->toBe(1);
+});
+
+it('rechaza como conflict un evento cuya secuencia ya no es válida en el servidor y lo registra para revisión', function () {
+    $employee = makeMobileSyncEmployee();
+    $service = app(MobileEventSyncService::class);
+
+    // El check_out ya llegó al servidor (ej. registrado manualmente mientras el celular estaba offline).
+    $service->syncBatch($employee, [[
+        'client_event_id' => (string) Str::uuid(),
+        'event_type' => 'check_out',
+        'recorded_at' => '2026-08-19 17:00:00',
+    ]]);
+
+    // El celular recién ahora sincroniza un break_start que había capturado offline, antes del check_out.
+    $conflictingClientEventId = (string) Str::uuid();
+    $results = $service->syncBatch($employee, [[
+        'client_event_id' => $conflictingClientEventId,
+        'event_type' => 'break_start',
+        'recorded_at' => '2026-08-19 12:00:00',
+    ]]);
+
+    expect($results[0]['status'])->toBe('conflict')
+        ->and($results[0]['conflict_reason'])->toBe('invalid_sequence')
+        ->and(AttendanceEvent::where('client_event_id', $conflictingClientEventId)->exists())->toBeFalse();
+
+    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')->where('mode', 'mobile')->first();
+    expect($failure)->not->toBeNull()
+        ->and($failure->employee_id)->toBe($employee->id)
+        ->and($failure->branch_id)->toBe($employee->branch_id)
+        ->and($failure->attempted_event_type)->toBe('break_start')
+        ->and($failure->canBeResolved())->toBeTrue();
+});
+
+it('aprobar un conflicto mobile reconstruye el evento con source mobile', function () {
+    $employee = makeMobileSyncEmployee();
+    $service = app(MobileEventSyncService::class);
+
+    $service->syncBatch($employee, [[
+        'client_event_id' => (string) Str::uuid(),
+        'event_type' => 'check_out',
+        'recorded_at' => '2026-08-19 17:00:00',
+    ]]);
+
+    $service->syncBatch($employee, [[
+        'client_event_id' => (string) Str::uuid(),
+        'event_type' => 'break_start',
+        'recorded_at' => '2026-08-19 12:00:00',
+    ]]);
+
+    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')->where('mode', 'mobile')->first();
+
+    $admin = User::create([
+        'name' => 'Admin', 'email' => 'admin-mobile@test.com', 'password' => bcrypt('secret'),
+    ]);
+
+    $result = $failure->approve($admin->id, 'break_start');
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['event']->source)->toBe('mobile')
+        ->and($result['event']->synced_at)->not->toBeNull();
+});


### PR DESCRIPTION
## Resumen

Primera fase de "Parte C" (marcación offline por celular personal del empleado — el ítem que había quedado explícitamente fuera del MVP del kiosko/PWA). Esta fase es **100% backend**: no hay todavía cliente offline ni integración con `mark.js` (eso es Fase 2/3).

- `Employee` gana autenticación Sanctum (`HasApiTokens` + `Authenticatable`, ability `mobile:sync`) — mismo patrón ya usado por `Terminal`. Sanctum resuelve el `tokenable` de forma polimórfica, sin wiring adicional en `config/auth.php`.
- Nuevo flujo de vinculación self-service: `GET/POST /vincular-celular` (throttle 10/min). El empleado se identifica con **CI + fecha de nacimiento** — funciona como credencial para "reclamar" el dispositivo (no como control de acceso completo: la marcación en sí sigue requiriendo un match facial exitoso contra el descriptor cacheado). Mensaje de error deliberadamente genérico para no facilitar enumeración.
- El celular cachea **únicamente el descriptor facial propio** del empleado (a diferencia del kiosko, que cachea el de toda la sucursal) — reduce drásticamente el riesgo de un dispositivo personal perdido/robado.
- **Un dispositivo vinculado a la vez**: vincular un celular nuevo revoca automáticamente el token anterior.
- Nuevas rutas `/api/v1/mobile/*` (heartbeat, status, events/sync), autenticadas con Sanctum. `MobileEventSyncService` es un servicio paralelo a `AttendanceEventSyncService` (deliberadamente no compartido — su acoplamiento a `Terminal` no encaja con "un empleado ya autenticado, sin `employee_id` por evento, con GPS real"). Misma idempotencia por `client_event_id` y misma revalidación de secuencia contra el estado actual del servidor.
- Los conflictos de sync quedan registrados en `AttendanceMarkFailure` (`mode: 'mobile'`) para revisión manual en Filament, reusando el flujo de aprobar/descartar de PR #83.
- **Fix**: `AttendanceMarkFailure::approve()` tenía `mode === 'terminal'` hardcodeado para decidir `source`/`synced_at` — con el nuevo `mode: 'mobile'` un conflicto aprobado se etiquetaba incorrectamente `source: 'manual'`. Corregido.
- Nueva acción "Revocar sesión móvil" + columna de estado en `EmployeeResource`.

## Test plan

- [x] Verificación end-to-end por HTTP real (`php artisan serve` + curl, BD SQLite de scratch): vinculación con credenciales correctas/incorrectas, los 3 endpoints de la API con Bearer token real, conflicto de sync → `AttendanceMarkFailure` → `approve()` con `source: mobile`, guard de empleado inactivo (403 + revocación + 401 en el siguiente intento), re-vinculación revoca el token anterior.
- [x] `tests/Feature/MobileAttendanceLinkTest.php` y `tests/Feature/MobileEventSyncServiceTest.php` (Pest, nuevos) — cubren los mismos escenarios de forma permanente. No se pudieron correr en este sandbox (sin MySQL; las migraciones del proyecto usan `INFORMATION_SCHEMA`, MySQL-only), correrán en CI.
- [x] `vendor/bin/pint --dirty` sin hallazgos.
- [x] `npm run build` sin errores (no se tocó JS en esta fase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_