### PR TITLE
Marcación offline por celular personal — Fases 2 y 3: cliente offline + integración con mark.js

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,29 @@
 /**
  * =============================================================================
- * SERVICE WORKER — KIOSKO DE MARCACIÓN (offline shell)
+ * SERVICE WORKER — MARCACIÓN DE ASISTENCIA (offline shell)
  * =============================================================================
  *
- * Hand-rolled, sin Workbox/vite-plugin-pwa — alcance acotado a una sola página
- * (/terminal/*), registrado con scope explícito en terminal.blade.php.
+ * Hand-rolled, sin Workbox/vite-plugin-pwa. Un mismo script compartido entre
+ * dos flujos con scope de registro distinto:
+ * - Kiosko de sucursal: /terminal/* (registrado en terminal.blade.php).
+ * - Celular personal del empleado: /marcar (registrado en mark.blade.php,
+ *   Parte C Fase 2 — la vinculación en /vincular-celular NO se cachea, es
+ *   una acción intrínsecamente online).
  *
- * Responsabilidad de esta fase: que el shell del kiosko, sus assets de Vite y
- * los modelos de face-api.js queden disponibles offline. NO incluye todavía
- * matching client-side ni cola de eventos (fases posteriores) — los POST a
- * /marcar/* siguen requiriendo red en esta fase.
+ * Responsabilidad: que el shell de cada página, sus assets de Vite y los
+ * modelos de face-api.js queden disponibles offline. El matching client-side
+ * y la cola de eventos viven en JS (terminal-offline/ y mobile-offline/), no acá.
  */
 
-const CACHE_VERSION = 'nominapp-terminal-v1';
+const CACHE_VERSION = 'nominapp-attendance-v1';
 
 /**
  * Contenido estático que nunca cambia sin un deploy — cache-first.
- * `/build/assets/` se cachea completo (no solo `terminal-*`): Vite separa en
- * chunks compartidos los módulos importados por varios entrypoints (ej.
- * face-capture-core.js, usado también por mark.js/capture-face.js), así que
- * filtrar por nombre del entrypoint deja afuera esos chunks y rompe el offline.
+ * `/build/assets/` se cachea completo (no solo `terminal-*`/`mark-*`): Vite
+ * separa en chunks compartidos los módulos importados por varios entrypoints
+ * (ej. face-capture-core.js, usado tanto por terminal.js como por mark.js),
+ * así que filtrar por nombre del entrypoint deja afuera esos chunks y rompe
+ * el offline.
  */
 const CACHE_FIRST_PATTERNS = [
     /^\/models\//, // modelos de face-api.js (tinyFaceDetector, faceLandmark68, faceRecognition)
@@ -27,10 +31,11 @@ const CACHE_FIRST_PATTERNS = [
     /^\/build\/assets\//, // todos los bundles JS/CSS de Vite (nombres con hash de contenido — seguros de cachear indefinidamente)
 ];
 
-/** Shell HTML del kiosko — stale-while-revalidate para que un reload offline funcione. */
+/** Shell HTML del kiosko y del celular — stale-while-revalidate para que un reload offline funcione. */
 const SHELL_PATTERNS = [
     /^\/terminal\/?$/,
     /^\/terminal\/[a-z0-9]+\/?$/,
+    /^\/marcar\/?$/,
 ];
 
 self.addEventListener('install', () => {

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -945,6 +945,18 @@ select#eventType { display: none; }
 }
 .modal-meta-time  { font-size: .875rem; color: var(--c-muted); }
 
+/* Aviso de marcación guardada offline (sin confirmar todavía con el servidor) */
+.success-queued-notice {
+    font-size: .75rem;
+    font-weight: 600;
+    color: var(--c-warning);
+    background: var(--c-warning-bg);
+    border: 1px solid var(--c-warning-ring);
+    border-radius: var(--r-md);
+    padding: var(--sp-2) var(--sp-3);
+    margin-bottom: var(--sp-4);
+}
+
 .modal-actions { display: flex; flex-direction: column; gap: var(--sp-2); }
 .btn-modal-retry   { background: var(--c-primary); color: #fff; }
 .btn-modal-retry:hover { background: var(--c-primary-h); }

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1,5 +1,9 @@
 import L from 'leaflet';
 import { captureFaceSamples } from '../shared/face-capture-core.js';
+import { migrateTokenFromLocalStorage, getMeta, getOwnEmployee } from './mobile-offline/db.js';
+import { identifyEmployee as matchDescriptor } from './mobile-offline/matcher.js';
+import { heartbeat, getFaceConfig, MobileAuthError } from './mobile-offline/sync.js';
+import { getOwnStatus, enqueueMark, flushQueue } from './mobile-offline/queue.js';
 
 /**
  * =============================================================================
@@ -97,17 +101,6 @@ const statusBar           = document.getElementById("statusBar");
     // ==========================================================================
     // CONFIGURACIÓN Y CONSTANTES
     // ==========================================================================
-
-    /**
-     * Token CSRF para las peticiones POST
-     * @type {string}
-     */
-    const csrfToken = document.querySelector("meta[name=csrf-token]");
-    const CSRF = csrfToken ? csrfToken.content : "";
-
-    if (!CSRF) {
-        logWarn("Token CSRF no encontrado. Esto puede causar errores en las peticiones POST.");
-    }
 
     /**
      * URI donde se encuentran los modelos de face-api.js
@@ -334,9 +327,6 @@ const statusBar           = document.getElementById("statusBar");
             return !navigator.onLine
                 ? "Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar."
                 : "Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.";
-        }
-        if (msg.includes("csrf") || msg.includes("419")) {
-            return "La sesión expiró. Por favor, recargue la página para continuar.";
         }
         if (msg.includes("event") || msg.includes("evento") || msg.includes("allowed")) {
             return "No hay tipos de marcación disponibles para este empleado en este momento. Consulte con el departamento de RRHH.";
@@ -803,8 +793,76 @@ const statusBar           = document.getElementById("statusBar");
         return;
     }
 
-    // Iniciar el sistema con pantalla de carga
-    initializeSystem();
+    /**
+     * Confirma que el celular ya fue vinculado (CI + fecha de nacimiento en
+     * /vincular-celular, ver MobileLinkController) antes de arrancar la
+     * cámara — sin token no hay nada que identificar localmente. Migra
+     * primero el token que mobile-link.blade.php deja en localStorage tras
+     * una vinculación exitosa (mismo patrón que terminal.js con el kiosko).
+     * @returns {Promise<boolean>}
+     */
+    async function ensureLinkedDevice() {
+        await migrateTokenFromLocalStorage();
+        const token = await getMeta("api_token");
+        if (!token) {
+            window.location.href = "/vincular-celular";
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Sincroniza la configuración de reconocimiento facial y el descriptor
+     * facial propio (heartbeat) antes de identificar — sin esto no hay nada
+     * contra qué comparar localmente. Si el token fue revocado (empleado
+     * desvinculado o baja), redirige a vincular de nuevo. Un fallo de red
+     * simple no bloquea el arranque: se sigue con lo que ya estaba cacheado
+     * de una sesión anterior (o, si nunca hubo una, la identificación
+     * fallará con un mensaje claro hasta que haya conexión al menos una vez).
+     */
+    async function initializeOfflineSync() {
+        try {
+            await heartbeat();
+        } catch (error) {
+            if (error instanceof MobileAuthError) {
+                window.location.href = "/vincular-celular";
+                return;
+            }
+            logWarn("No se pudo sincronizar con el servidor (heartbeat):", error.message);
+        }
+    }
+
+    /**
+     * Reintenta heartbeat y vaciar la cola de marcaciones pendientes en
+     * segundo plano — mismo patrón que terminal.js del kiosko, adaptado sin
+     * sync de empleados (acá no existe, ver mobile-offline/sync.js).
+     */
+    function startBackgroundSync() {
+        const runHeartbeat = () => {
+            if (!navigator.onLine) return;
+            heartbeat().catch((error) => logWarn("Heartbeat en segundo plano falló:", error.message));
+        };
+        const runQueueFlush = () => {
+            if (!navigator.onLine) return;
+            flushQueue().catch((error) => logWarn("Sincronización de cola en segundo plano falló:", error.message));
+        };
+
+        setInterval(runHeartbeat, 90 * 1000);
+        setInterval(runQueueFlush, 30 * 1000);
+
+        window.addEventListener("online", () => {
+            runHeartbeat();
+            runQueueFlush();
+        });
+    }
+
+    // Iniciar el sistema con pantalla de carga — solo si el celular ya está vinculado.
+    (async () => {
+        if (!(await ensureLinkedDevice())) return;
+        await initializeOfflineSync();
+        await initializeSystem();
+        startBackgroundSync();
+    })();
 
     // ==========================================================================
     // FUNCIONES DE CÁMARA Y MODELOS
@@ -1132,8 +1190,9 @@ const statusBar           = document.getElementById("statusBar");
             const isEmployeeSelected = !!(state.employee && state.employee.id);
             const isEventSelected = !!eventTypeEl.value;
             const isLocationSet = !!state.location;
-            const isOnline = navigator.onLine;
-            const canMark = isEmployeeSelected && isEventSelected && isLocationSet && isOnline;
+            // Sin conexión ya no bloquea: la marcación se guarda en el dispositivo (cola
+            // offline, ver mobile-offline/queue.js) y se sincroniza cuando haya señal.
+            const canMark = isEmployeeSelected && isEventSelected && isLocationSet;
 
             btnMark.disabled = !canMark;
             btnMark.setAttribute("aria-disabled", canMark ? "false" : "true");
@@ -1142,9 +1201,6 @@ const statusBar           = document.getElementById("statusBar");
                 if (canMark) {
                     markHint.textContent = "";
                     markHint.classList.add("hidden");
-                } else if (!isOnline) {
-                    markHint.textContent = "Sin conexión — la marcación no puede registrarse ahora";
-                    markHint.classList.remove("hidden");
                 } else if (isEmployeeSelected && !isEventSelected) {
                     markHint.textContent = "Seleccioná el tipo de marcación para continuar";
                     markHint.classList.remove("hidden");
@@ -1232,10 +1288,6 @@ const statusBar           = document.getElementById("statusBar");
      */
     async function runIdentification(fromDwell = false) {
         if (isIdentifying) return;
-        if (!navigator.onLine) {
-            setStatusBar("Sin conexión — no se puede identificar ahora", "error");
-            return;
-        }
         isIdentifying = true;
 
         cancelAutoIdentifyDwell();
@@ -1255,28 +1307,41 @@ const statusBar           = document.getElementById("statusBar");
                 updateCaptureProgress(count);
             });
 
-            logStatus("Enviando datos para identificación...");
+            logStatus("Identificando...");
             setStatusBar("Identificando empleado...", "found");
 
-            if (!CSRF) throw new Error("Token CSRF no disponible");
+            // Matching 100% local contra el único descriptor cacheado (el propio, sincronizado
+            // vía heartbeat) — sin esto no hay red de contingencia: el celular solo conoce a su dueño.
+            const { threshold, minGap } = await getFaceConfig();
+            const ownEmployee = await getOwnEmployee();
 
-            const resp = await fetch("/marcar/identificar", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Accept: "application/json",
-                    "X-CSRF-TOKEN": CSRF,
-                },
-                body: JSON.stringify({ face_descriptor: descriptor, source: "mobile" }),
-            });
+            if (threshold == null || minGap == null || !ownEmployee) {
+                throw new Error("Todavía no se sincronizó tu perfil — conectate a internet al menos una vez.");
+            }
 
-            if (resp.status === 419) throw Object.assign(new Error("session_expired"), { is419: true });
+            const { employee: matched, reason } = matchDescriptor(descriptor, [ownEmployee], threshold, minGap);
 
-            const json = await resp.json();
-            if (!json.ok) throw new Error(json.message || "No identificado");
+            if (!matched) {
+                const messages = {
+                    no_match: "No se pudo identificar el rostro. Intente nuevamente.",
+                    ambiguous: "Rostro ambiguo. Por favor, reposicione su cara e intente de nuevo.",
+                };
+                throw new Error(messages[reason] || "No identificado");
+            }
 
-            state.employee = json.employee;
-            state.allowed  = json.allowed_events || [];
+            const employee = {
+                id: matched.id,
+                first_name: matched.first_name,
+                last_name: matched.last_name,
+                ci: matched.ci,
+            };
+
+            // Estado del día: intenta consulta en línea (y la cachea); si no hay red, cae a lo
+            // que el propio celular ya sabe (ver mobile-offline/queue.js).
+            const status = await getOwnStatus();
+
+            state.employee = employee;
+            state.allowed  = status.allowed_events || [];
 
             await finishCaptureProgress("success");
 
@@ -1287,7 +1352,7 @@ const statusBar           = document.getElementById("statusBar");
                 faceInFrameState = null;
                 if (video) video.srcObject = null;
 
-                const fullName = `${json.employee.first_name || ""} ${json.employee.last_name || ""}`.trim();
+                const fullName = `${employee.first_name || ""} ${employee.last_name || ""}`.trim();
                 const titleEl = document.getElementById("successModalTitle");
                 const descEl  = document.getElementById("successModalDesc");
                 if (titleEl) titleEl.textContent = "¡Jornada completada!";
@@ -1301,7 +1366,7 @@ const statusBar           = document.getElementById("statusBar");
 
             enableStep2(state.allowed);
             checkEnableMark();
-            transitionToStep2(json.employee, json.last_event, json.last_event_time);
+            transitionToStep2(employee, status.last_event, status.last_event_time);
             navigator.vibrate?.(80);
             logStatus("Empleado identificado ✓");
 
@@ -1321,13 +1386,13 @@ const statusBar           = document.getElementById("statusBar");
 
         } catch (e) {
             logError("Error en la identificación:", e);
-            if (e.is419) {
+            if (e instanceof MobileAuthError) {
                 await finishCaptureProgress("error");
                 playBeep("error");
                 showErrorModal(
-                    "Sesión expirada",
-                    "La sesión ha caducado. Recargue la página para continuar.",
-                    false
+                    "Celular desvinculado",
+                    "Este celular ya no está vinculado a tu cuenta. Volvé a identificarte con tu CI y fecha de nacimiento.",
+                    () => { window.location.href = "/vincular-celular"; }
                 );
                 return;
             }
@@ -1547,7 +1612,7 @@ const statusBar           = document.getElementById("statusBar");
      *              y configura eventos para cerrarlo (botón, backdrop, tecla ESC)
      * @returns {void}
      */
-    function showSuccessModal(name, eventType, time) {
+    function showSuccessModal(name, eventType, time, { queued = false } = {}) {
         const modal = document.getElementById("successModal");
         const closeModal = document.getElementById("closeModal");
 
@@ -1561,6 +1626,7 @@ const statusBar           = document.getElementById("statusBar");
         const nameEl    = document.getElementById("successModalMetaName");
         const eventEl   = document.getElementById("successModalMetaEvent");
         const timeEl    = document.getElementById("successModalMetaTime");
+        const queuedEl  = document.getElementById("successModalQueuedNotice");
 
         if (metaEl && name && eventType && time) {
             if (nameEl)  nameEl.textContent  = name;
@@ -1570,6 +1636,10 @@ const statusBar           = document.getElementById("statusBar");
         } else if (metaEl) {
             metaEl.classList.add("hidden");
         }
+
+        // Marcación guardada en el dispositivo pero todavía no confirmada por el servidor
+        // (sin red en el momento) — avisar sin asustar: no se perdió, se sincroniza sola.
+        if (queuedEl) queuedEl.style.display = queued ? "" : "none";
 
         previousActiveElement = document.activeElement;
 
@@ -1924,9 +1994,6 @@ const statusBar           = document.getElementById("statusBar");
                 if (!state.location) {
                     throw new Error("Ubicación no válida.");
                 }
-                if (!CSRF) {
-                    throw new Error("Token CSRF no disponible");
-                }
 
                 // Ventana anti-duplicados: bloquear el mismo empleado + evento dentro de 60s
                 const DUPLICATE_WINDOW_MS = 60000;
@@ -1964,50 +2031,56 @@ const statusBar           = document.getElementById("statusBar");
                     }
                 }
 
-                const payload = {
-                    employee_id: state.employee.id,
-                    event_type: eventTypeEl.value,
-                    source: "mobile",
-                    location: {
-                        lat: state.location.lat,
-                        lng: state.location.lng,
-                    },
-                };
-
-                logStatus("Enviando marcación al servidor...");
+                logStatus("Registrando marcación...");
                 btnMark.classList.add("btn-loading");
                 btnMark.innerHTML = `${SPINNER_SVG} Registrando...`;
 
-                const resp = await fetch("/marcar", {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "X-CSRF-TOKEN": CSRF,
-                    },
-                    body: JSON.stringify(payload),
-                });
+                // Encolar SIEMPRE primero — la marcación queda a salvo en el dispositivo
+                // aunque el envío falle o no haya red (ver mobile-offline/queue.js).
+                const { client_event_id: clientEventId, recorded_at: recordedAt } = await enqueueMark(
+                    eventTypeEl.value,
+                    { lat: state.location.lat, lng: state.location.lng },
+                );
 
-                if (resp.status === 419) throw Object.assign(new Error("session_expired"), { is419: true });
+                let queued = true;
+                let rejectedMessage = null;
 
-                const json = await resp.json();
-                if (!resp.ok || !json.ok) {
-                    throw new Error(json.message || "No se pudo registrar la marcación.");
+                if (navigator.onLine) {
+                    try {
+                        const { results } = await flushQueue();
+                        const ownResult = results.find((r) => r.client_event_id === clientEventId);
+
+                        if (ownResult && ownResult.status !== "synced" && ownResult.status !== "duplicate") {
+                            // El servidor ya respondió que esta marcación puntual es inválida (ej.
+                            // secuencia rota) — no tiene sentido dejarla "pendiente", se informa directo.
+                            rejectedMessage = ownResult.message || "La marcación fue rechazada por el servidor.";
+                        } else {
+                            // Sincronizada (ownResult existe y es synced/duplicate) o todavía en cola
+                            // porque la red falló a mitad de camino (ownResult ausente) — a salvo en ambos casos.
+                            queued = !ownResult;
+                        }
+                    } catch (flushError) {
+                        if (flushError instanceof MobileAuthError) throw flushError;
+                        logWarn("No se pudo sincronizar de inmediato, queda en cola:", flushError.message);
+                    }
                 }
 
-                logStatus("Marcación registrada correctamente");
+                if (rejectedMessage) throw new Error(rejectedMessage);
+
+                logStatus(queued ? "Marcación guardada — pendiente de sincronizar" : "Marcación registrada correctamente");
                 lastMark = { employeeId: state.employee.id, eventType: eventTypeEl.value, time: Date.now() };
                 playBeep("success");
                 navigator.vibrate?.(120);
                 const fullName = `${state.employee.first_name || ""} ${state.employee.last_name || ""}`.trim();
-                showSuccessModal(fullName, eventTypeEl.value, new Date());
+                showSuccessModal(fullName, eventTypeEl.value, new Date(recordedAt), { queued });
             } catch (e) {
                 logError("Error en la marcación:", e);
-                if (e.is419) {
+                if (e instanceof MobileAuthError) {
                     playBeep("error");
                     showErrorModal(
-                        "Sesión expirada",
-                        "La sesión ha caducado. Recargue la página para continuar.",
-                        false
+                        "Celular desvinculado",
+                        "Este celular ya no está vinculado a tu cuenta. Volvé a identificarte con tu CI y fecha de nacimiento.",
+                        () => { window.location.href = "/vincular-celular"; }
                     );
                     return;
                 }

--- a/resources/js/attendances/mobile-offline/db.js
+++ b/resources/js/attendances/mobile-offline/db.js
@@ -1,0 +1,231 @@
+/**
+ * =============================================================================
+ * INDEXEDDB — CACHÉ LOCAL DEL CELULAR PERSONAL
+ * =============================================================================
+ *
+ * @fileoverview Wrapper delgado sobre `idb` para la base local del celular.
+ *               Base de datos separada de `terminal-offline/db.js`
+ *               (`nominapp-mobile` vs `nominapp-terminal`) para que ambos
+ *               flujos puedan coexistir sin chocar si algún dispositivo
+ *               llegara a usarse en los dos modos.
+ *
+ * Diferencia clave con el kiosko: acá NO existe un store de `employees_cache`
+ * — el celular vinculado cachea el descriptor facial de un único empleado (el
+ * dueño del dispositivo), guardado directamente en `mobile_meta` bajo la key
+ * `own_employee`. Todo lo demás (cola de eventos, caché de estado, log de
+ * sync) sigue el mismo diseño que `terminal-offline/db.js`.
+ *
+ * Stores:
+ * - mobile_meta            — key/value: api_token, own_employee (id/nombre/CI/
+ *                             descriptor), config de reconocimiento facial,
+ *                             offset de reloj, timestamps de sync.
+ * - outbound_events        — keyPath 'client_event_id': cola de marcaciones
+ *                             capturadas localmente. `status`: 'pending'
+ *                             (por sincronizar) | 'conflict' (el servidor la
+ *                             rechazó — no se reintenta, queda para revisión).
+ *                             Las sincronizadas con éxito se eliminan del store.
+ * - employee_status_cache  — keyPath 'employee_id': último estado de marcación
+ *                             conocido del servidor (last_event/allowed_events)
+ *                             para el propio empleado — un único registro.
+ * - sync_log               — autoIncrement: historial breve de intentos de
+ *                             sync, para diagnóstico en pantalla.
+ */
+
+import { openDB } from 'idb';
+
+const DB_NAME = 'nominapp-mobile';
+const DB_VERSION = 1;
+
+/** @type {Promise<import('idb').IDBPDatabase>|null} */
+let dbPromise = null;
+
+/** @returns {Promise<import('idb').IDBPDatabase>} */
+export function getDb() {
+    if (!dbPromise) {
+        dbPromise = openDB(DB_NAME, DB_VERSION, {
+            upgrade(db) {
+                if (!db.objectStoreNames.contains('mobile_meta')) {
+                    db.createObjectStore('mobile_meta');
+                }
+                if (!db.objectStoreNames.contains('outbound_events')) {
+                    db.createObjectStore('outbound_events', { keyPath: 'client_event_id' });
+                }
+                if (!db.objectStoreNames.contains('employee_status_cache')) {
+                    db.createObjectStore('employee_status_cache', { keyPath: 'employee_id' });
+                }
+                if (!db.objectStoreNames.contains('sync_log')) {
+                    db.createObjectStore('sync_log', { keyPath: 'id', autoIncrement: true });
+                }
+            },
+        });
+    }
+    return dbPromise;
+}
+
+/**
+ * Lee un valor de `mobile_meta`.
+ * @param {string} key
+ * @returns {Promise<any>}
+ */
+export async function getMeta(key) {
+    const db = await getDb();
+    return db.get('mobile_meta', key);
+}
+
+/**
+ * Escribe un valor en `mobile_meta`.
+ * @param {string} key
+ * @param {any} value
+ */
+export async function setMeta(key, value) {
+    const db = await getDb();
+    return db.put('mobile_meta', value, key);
+}
+
+/**
+ * Migración única del token guardado en localStorage por la pantalla de
+ * vinculación (mobile-link.blade.php) hacia IndexedDB. Se puede llamar en
+ * cada carga: es un no-op si ya no queda nada en localStorage.
+ * @returns {Promise<void>}
+ */
+export async function migrateTokenFromLocalStorage() {
+    const legacyToken = localStorage.getItem('nominapp_mobile_token');
+    if (!legacyToken) return;
+
+    const legacyEmployeeId = localStorage.getItem('nominapp_mobile_employee_id');
+    await setMeta('api_token', legacyToken);
+    if (legacyEmployeeId) await setMeta('employee_id', Number(legacyEmployeeId));
+
+    localStorage.removeItem('nominapp_mobile_token');
+    localStorage.removeItem('nominapp_mobile_employee_id');
+}
+
+/**
+ * Registra una entrada en `sync_log`, recortando el historial a las últimas 50.
+ * @param {string} type
+ * @param {boolean} ok
+ * @param {string|null} [detail]
+ */
+export async function logSync(type, ok, detail = null) {
+    const db = await getDb();
+    await db.add('sync_log', { type, ok, detail, at: Date.now() });
+
+    const allKeys = await db.getAllKeys('sync_log');
+    if (allKeys.length > 50) {
+        const tx = db.transaction('sync_log', 'readwrite');
+        for (const key of allKeys.slice(0, allKeys.length - 50)) {
+            await tx.store.delete(key);
+        }
+        await tx.done;
+    }
+}
+
+/**
+ * Empleado dueño del dispositivo, con su descriptor facial cacheado — el
+ * único "candidato" contra el que el matcher local compara.
+ * @returns {Promise<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}|undefined>}
+ */
+export async function getOwnEmployee() {
+    return getMeta('own_employee');
+}
+
+/**
+ * Actualiza el empleado propio cacheado (llamado tras cada heartbeat exitoso
+ * — propaga automáticamente una re-inscripción facial sin que el empleado
+ * tenga que re-vincular el dispositivo).
+ * @param {{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}} employee
+ */
+export async function setOwnEmployee(employee) {
+    await setMeta('own_employee', employee);
+    await setMeta('employee_id', employee.id);
+}
+
+// =========================================================================
+// COLA DE EVENTOS OFFLINE (outbound_events)
+// =========================================================================
+
+/**
+ * Encola una marcación capturada localmente. `date` es la fecha local del
+ * dispositivo (YYYY-MM-DD) al momento de la captura — se usa solo para
+ * filtrar "eventos de hoy" del lado del cliente; la fecha real de negocio
+ * (con el timezone de la app) la decide el servidor al sincronizar.
+ * @param {{client_event_id: string, employee_id: number, event_type: string, recorded_at: string, date: string, location?: object|null}} event
+ */
+export async function queueEvent(event) {
+    const db = await getDb();
+    await db.put('outbound_events', { ...event, status: 'pending', attempts: 0, created_at: Date.now() });
+}
+
+/** @returns {Promise<Array<object>>} Eventos pendientes de sincronizar (no incluye los marcados 'conflict'). */
+export async function getPendingEvents() {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.status === 'pending');
+}
+
+/**
+ * Eventos (pendientes o en conflicto) para la fecha local indicada — usado
+ * para resolver localmente el último evento del día cuando no hay red para
+ * consultar al servidor (ver queue.js).
+ * @param {string} date - YYYY-MM-DD local.
+ */
+export async function getEventsOnDate(date) {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.date === date);
+}
+
+/** Marca un evento encolado como sincronizado — se elimina del store (ya vive en el servidor). */
+export async function removeQueuedEvent(clientEventId) {
+    const db = await getDb();
+    await db.delete('outbound_events', clientEventId);
+}
+
+/** Marca un evento encolado como rechazado por el servidor — no se reintenta más, queda para revisión manual. */
+export async function markQueuedEventConflict(clientEventId, message) {
+    const db = await getDb();
+    const event = await db.get('outbound_events', clientEventId);
+    if (!event) return;
+    await db.put('outbound_events', { ...event, status: 'conflict', server_message: message ?? null });
+}
+
+/** Incrementa el contador de intentos de un evento encolado (diagnóstico, no afecta el reintento en sí). */
+export async function incrementQueuedEventAttempts(clientEventId) {
+    const db = await getDb();
+    const event = await db.get('outbound_events', clientEventId);
+    if (!event) return;
+    await db.put('outbound_events', { ...event, attempts: (event.attempts ?? 0) + 1 });
+}
+
+/** @returns {Promise<number>} Cantidad de eventos pendientes de sincronizar. */
+export async function countPendingEvents() {
+    return (await getPendingEvents()).length;
+}
+
+/** @returns {Promise<number>} Cantidad de eventos en conflicto (requieren revisión manual en Filament). */
+export async function countConflictEvents() {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.status === 'conflict').length;
+}
+
+// =========================================================================
+// CACHÉ DE ESTADO (employee_status_cache)
+// =========================================================================
+
+/**
+ * Guarda el último estado de marcación conocido del servidor para el propio
+ * empleado (se actualiza cada vez que fetchStatus() tiene éxito).
+ * @param {number} employeeId
+ * @param {{last_event: string|null, last_event_time: string|null, allowed_events: string[]}} status
+ */
+export async function setEmployeeStatusCache(employeeId, status) {
+    const db = await getDb();
+    await db.put('employee_status_cache', { employee_id: employeeId, ...status, cached_at: Date.now() });
+}
+
+/** @param {number} employeeId @returns {Promise<object|undefined>} */
+export async function getEmployeeStatusCache(employeeId) {
+    const db = await getDb();
+    return db.get('employee_status_cache', employeeId);
+}

--- a/resources/js/attendances/mobile-offline/matcher.js
+++ b/resources/js/attendances/mobile-offline/matcher.js
@@ -1,0 +1,78 @@
+/**
+ * =============================================================================
+ * MATCHING FACIAL CLIENT-SIDE (celular personal offline)
+ * =============================================================================
+ *
+ * @fileoverview Idéntico a `terminal-offline/matcher.js` — mismo algoritmo de
+ *               distancia euclidiana + umbral/gap de confianza que el backend
+ *               (`AttendanceFaceMarkController::identifyEmployeeByDescriptor()`).
+ *               Se duplica en vez de importarse desde `terminal-offline/` para
+ *               mantener ambos módulos de captura offline independientes — acá
+ *               `candidates` normalmente tiene un solo elemento (el propio
+ *               descriptor cacheado), pero la función funciona igual con N: el
+ *               gap de confianza simplemente no se evalúa si no hay un segundo
+ *               candidato.
+ */
+
+/**
+ * Distancia euclidiana entre dos descriptores faciales (arrays de 128 floats).
+ * @param {number[]} a
+ * @param {number[]} b
+ * @returns {number}
+ */
+export function euclideanDistance(a, b) {
+    let sum = 0;
+    for (let i = 0; i < 128; i++) {
+        const diff = (a[i] ?? 0) - (b[i] ?? 0);
+        sum += diff * diff;
+    }
+    return Math.sqrt(sum);
+}
+
+/**
+ * Identifica al candidato más cercano a un descriptor "en vivo" dentro de la
+ * caché local (normalmente un único empleado — el dueño del celular),
+ * aplicando el mismo criterio de umbral + gap de confianza que el backend.
+ *
+ * @param {number[]} liveDescriptor - Descriptor capturado en el momento.
+ * @param {Array<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}>} candidates - Normalmente un solo empleado (el propio dueño del celular).
+ * @param {number} threshold - Distancia máxima para aceptar un match (face_threshold).
+ * @param {number} minGap - Diferencia mínima requerida con el segundo candidato (face_min_confidence_gap).
+ * @returns {{employee: object|null, distance: number, reason: 'no_match'|'ambiguous'|'no_candidates'|null}}
+ */
+export function identifyEmployee(liveDescriptor, candidates, threshold, minGap) {
+    if (!candidates || candidates.length === 0) {
+        return { employee: null, distance: Infinity, reason: 'no_candidates' };
+    }
+
+    let best = null;
+    let bestDist = Infinity;
+    let secondBestDist = Infinity;
+
+    for (const candidate of candidates) {
+        if (!Array.isArray(candidate.face_descriptor) || candidate.face_descriptor.length !== 128) continue;
+
+        const dist = euclideanDistance(liveDescriptor, candidate.face_descriptor);
+
+        if (dist < bestDist) {
+            secondBestDist = bestDist;
+            bestDist = dist;
+            best = candidate;
+        } else if (dist < secondBestDist) {
+            secondBestDist = dist;
+        }
+    }
+
+    if (!best || bestDist > threshold) {
+        return { employee: null, distance: bestDist, reason: 'no_match' };
+    }
+
+    if (secondBestDist !== Infinity) {
+        const gap = secondBestDist - bestDist;
+        if (gap < minGap) {
+            return { employee: null, distance: bestDist, reason: 'ambiguous' };
+        }
+    }
+
+    return { employee: best, distance: bestDist, reason: null };
+}

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -1,0 +1,225 @@
+/**
+ * =============================================================================
+ * COLA DE EVENTOS OFFLINE (celular personal)
+ * =============================================================================
+ *
+ * @fileoverview Orquesta la resolución de estado y sincronización en segundo
+ *               plano de las marcaciones del celular. Mismo diseño que
+ *               `terminal-offline/queue.js` — toda marcación se guarda primero
+ *               en `outbound_events` (durable) y recién después se intenta
+ *               sincronizar — pero acá no hace falta un `employeeId` explícito
+ *               en cada función: el celular está vinculado a un único
+ *               empleado, resuelto internamente desde `mobile_meta`.
+ */
+
+import {
+    getMeta,
+    queueEvent,
+    getPendingEvents,
+    getEventsOnDate,
+    removeQueuedEvent,
+    markQueuedEventConflict,
+    incrementQueuedEventAttempts,
+    countPendingEvents,
+    countConflictEvents,
+    getEmployeeStatusCache,
+    setEmployeeStatusCache,
+} from './db.js';
+import { submitEvents, fetchStatus } from './sync.js';
+
+/**
+ * Máquina de estados de marcación diaria — mismo criterio que
+ * AttendanceEvent::allowedNextEventTypes() en el backend. Se necesita acá
+ * (además de en el servidor) para poder resolver localmente qué botones
+ * mostrar cuando no hay red para preguntarle al servidor.
+ * @param {string|null} lastEventType
+ * @returns {string[]}
+ */
+export function allowedNextEventTypes(lastEventType) {
+    switch (lastEventType) {
+        case null:
+        case undefined:
+            return ['check_in'];
+        case 'check_in':
+            return ['break_start', 'check_out'];
+        case 'break_start':
+            return ['break_end'];
+        case 'break_end':
+            return ['break_start', 'check_out'];
+        case 'check_out':
+            return [];
+        default:
+            return ['check_in'];
+    }
+}
+
+/**
+ * Hora actual corregida con el offset de reloj del último heartbeat exitoso
+ * (`server_clock_offset_ms`, ver sync.js) — un celular con el reloj desviado
+ * (o con la hora del sistema manipulada) arrastraría el error a cada
+ * marcación capturada offline. Sin heartbeat previo el offset es 0.
+ * @returns {Promise<Date>}
+ */
+async function correctedNow() {
+    const offsetMs = (await getMeta('server_clock_offset_ms')) || 0;
+    return new Date(Date.now() + offsetMs);
+}
+
+/** @returns {string} Fecha local del dispositivo en formato YYYY-MM-DD. */
+function localDateString(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+/**
+ * Resuelve el estado de marcación del propio empleado para hoy, combinando:
+ * 1) el último estado que el servidor confirmó (cacheado en la última
+ *    consulta online exitosa), con
+ * 2) los eventos que este mismo celular ya encoló hoy pero el servidor
+ *    todavía no confirmó — para no repetir ni saltear pasos mientras está
+ *    offline.
+ * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
+ */
+export async function resolveOwnStatus() {
+    const employeeId = await getMeta('employee_id');
+    const cached = employeeId ? await getEmployeeStatusCache(employeeId) : undefined;
+    const today = localDateString(await correctedNow());
+    const localEvents = (await getEventsOnDate(today))
+        .filter((event) => event.status === 'pending') // los en conflicto no cuentan como "ya registrados"
+        .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+
+    let lastEvent = cached?.last_event ?? null;
+    let lastEventTime = cached?.last_event_time ?? null;
+
+    for (const event of localEvents) {
+        lastEvent = event.event_type;
+        lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+    }
+
+    return {
+        last_event: lastEvent,
+        last_event_time: lastEventTime,
+        allowed_events: allowedNextEventTypes(lastEvent),
+    };
+}
+
+/**
+ * Estado de marcación del propio empleado: intenta la consulta en línea (y
+ * cachea el resultado para uso offline futuro); si falla por falta de red,
+ * cae a resolveOwnStatus() con lo que el celular ya sabe.
+ * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
+ */
+export async function getOwnStatus() {
+    try {
+        const status = await fetchStatus();
+        const employeeId = await getMeta('employee_id');
+        if (employeeId) await setEmployeeStatusCache(employeeId, status);
+        return status;
+    } catch (error) {
+        console.warn('No se pudo consultar el estado en línea del empleado, usando estado local:', error.message);
+        return resolveOwnStatus();
+    }
+}
+
+/**
+ * Encola una marcación capturada localmente. Debe llamarse ANTES de intentar
+ * sincronizar — así la marcación queda a salvo aunque el envío falle o la
+ * pestaña se cierre a mitad de camino.
+ *
+ * `recorded_at` se corrige con el offset de reloj calculado en el último
+ * heartbeat exitoso (`server_clock_offset_ms`, ver sync.js). Sin heartbeat
+ * previo el offset es 0 (no hay corrección posible).
+ * @param {string} eventType
+ * @param {{lat: number, lng: number}|null} [location] - GPS real del celular (a diferencia del kiosko, que solo tiene fallback a coordenadas de sucursal).
+ * @returns {Promise<{client_event_id: string, recorded_at: string}>}
+ */
+export async function enqueueMark(eventType, location = null) {
+    const employeeId = await getMeta('employee_id');
+    const clientEventId = crypto.randomUUID();
+    const recordedAt = await correctedNow();
+
+    await queueEvent({
+        client_event_id: clientEventId,
+        employee_id: employeeId,
+        event_type: eventType,
+        recorded_at: recordedAt.toISOString(),
+        date: localDateString(recordedAt),
+        location,
+    });
+
+    return { client_event_id: clientEventId, recorded_at: recordedAt.toISOString() };
+}
+
+/** @type {boolean} Evita que dos flush corran en simultáneo (ej. reintento manual + timer de fondo). */
+let flushInProgress = false;
+
+/**
+ * Máximo de eventos por request de sincronización — debe coincidir con el
+ * límite del servidor (`MobileEventSyncController`: `'events' => [...,
+ * 'max:200']`). En la práctica un celular personal difícilmente acumule
+ * tantas marcaciones (a diferencia de un kiosko con muchos empleados), pero
+ * se mantiene el mismo chunking por las dudas y por paridad con el kiosko.
+ */
+const MAX_BATCH_SIZE = 200;
+
+/**
+ * Intenta sincronizar todos los eventos pendientes, en lotes de a lo sumo
+ * `MAX_BATCH_SIZE`. Los `synced`/`duplicate` se eliminan de la cola; los
+ * `conflict`/`rejected` se marcan como tal (no se reintentan más) para
+ * revisión manual en Filament. Si un lote falla por red, ese lote y los
+ * siguientes quedan `pending` para el próximo intento.
+ *
+ * @returns {Promise<{synced: number, conflicts: number, stillPending: number, results: Array<object>}>}
+ */
+export async function flushQueue() {
+    if (flushInProgress) return { synced: 0, conflicts: 0, stillPending: await countPendingEvents(), results: [] };
+    flushInProgress = true;
+
+    try {
+        const pending = await getPendingEvents();
+        if (pending.length === 0) return { synced: 0, conflicts: 0, stillPending: 0, results: [] };
+
+        let synced = 0;
+        let conflicts = 0;
+        const allResults = [];
+
+        for (let offset = 0; offset < pending.length; offset += MAX_BATCH_SIZE) {
+            const batch = pending.slice(offset, offset + MAX_BATCH_SIZE);
+
+            let results;
+            try {
+                results = await submitEvents(batch.map(({ client_event_id, event_type, recorded_at, location }) => ({
+                    client_event_id,
+                    event_type,
+                    recorded_at,
+                    location: location ?? undefined,
+                })));
+            } catch (error) {
+                // Sin red o el servidor no respondió — este lote y los restantes (todavía no
+                // enviados) quedan pendientes para el próximo intento.
+                for (const event of pending.slice(offset)) await incrementQueuedEventAttempts(event.client_event_id);
+                console.warn(`flushQueue: no se pudo sincronizar el lote (${batch.length} de ${pending.length - offset} restantes):`, error.message);
+                break;
+            }
+
+            for (const result of results) {
+                if (result.status === 'synced' || result.status === 'duplicate') {
+                    await removeQueuedEvent(result.client_event_id);
+                    synced++;
+                } else {
+                    await markQueuedEventConflict(result.client_event_id, result.message);
+                    conflicts++;
+                }
+            }
+            allResults.push(...results);
+        }
+
+        return { synced, conflicts, stillPending: await countPendingEvents(), results: allResults };
+    } finally {
+        flushInProgress = false;
+    }
+}
+
+export { countPendingEvents, countConflictEvents };

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -25,7 +25,7 @@ import {
     getEmployeeStatusCache,
     setEmployeeStatusCache,
 } from './db.js';
-import { submitEvents, fetchStatus } from './sync.js';
+import { submitEvents, fetchStatus, MobileAuthError } from './sync.js';
 
 /**
  * Máquina de estados de marcación diaria — mismo criterio que
@@ -118,6 +118,9 @@ export async function getOwnStatus() {
         if (employeeId) await setEmployeeStatusCache(employeeId, status);
         return status;
     } catch (error) {
+        // Token revocado — no es un fallo de red recuperable con el estado local, el
+        // caller (mark.js) debe mandar al empleado a re-vincular el dispositivo.
+        if (error instanceof MobileAuthError) throw error;
         console.warn('No se pudo consultar el estado en línea del empleado, usando estado local:', error.message);
         return resolveOwnStatus();
     }
@@ -197,6 +200,12 @@ export async function flushQueue() {
                     location: location ?? undefined,
                 })));
             } catch (error) {
+                // Token revocado — no es un fallo de red recuperable, el caller (mark.js)
+                // debe mandar al empleado a re-vincular el dispositivo. Los eventos de este
+                // lote y los restantes quedan `pending` tal cual (se reintentan solos una
+                // vez que el empleado se re-vincule).
+                if (error instanceof MobileAuthError) throw error;
+
                 // Sin red o el servidor no respondió — este lote y los restantes (todavía no
                 // enviados) quedan pendientes para el próximo intento.
                 for (const event of pending.slice(offset)) await incrementQueuedEventAttempts(event.client_event_id);

--- a/resources/js/attendances/mobile-offline/sync.js
+++ b/resources/js/attendances/mobile-offline/sync.js
@@ -1,0 +1,115 @@
+/**
+ * =============================================================================
+ * SINCRONIZACIÓN CON LA API MÓVIL (routes/api.php, Sanctum)
+ * =============================================================================
+ *
+ * @fileoverview Cliente delgado para /api/v1/mobile/* — heartbeat (que además
+ *               devuelve el descriptor facial propio, no hay endpoint de
+ *               "sync de empleados" separado como en el kiosko), estado del
+ *               propio empleado, y envío de eventos. Requiere que el celular
+ *               ya haya sido vinculado (token en mobile_meta.api_token, ver
+ *               MobileLinkController / mobile-link.blade.php).
+ */
+
+import { getMeta, setMeta, setOwnEmployee, logSync } from './db.js';
+
+const API_BASE = '/api/v1/mobile';
+
+/** Error específico de token ausente/inválido — el caller decide cómo mostrarlo. */
+export class MobileAuthError extends Error {}
+
+/**
+ * fetch autenticado con el token Sanctum del celular.
+ * @param {string} path - Path relativo a /api/v1/mobile (ej. '/heartbeat').
+ * @param {RequestInit} [options]
+ * @returns {Promise<any>} Cuerpo JSON de la respuesta.
+ */
+export async function apiFetch(path, options = {}) {
+    const token = await getMeta('api_token');
+    if (!token) {
+        throw new MobileAuthError('Este celular no está vinculado — falta identificarse en /vincular-celular.');
+    }
+
+    const response = await fetch(`${API_BASE}${path}`, {
+        ...options,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            ...(options.headers || {}),
+        },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+        throw new MobileAuthError('El token de este celular fue revocado o expiró — necesita vincularse de nuevo.');
+    }
+
+    return response.json();
+}
+
+/**
+ * Heartbeat: refresca la configuración de reconocimiento facial (umbral/gap)
+ * y el descriptor facial propio (propaga automáticamente una re-inscripción
+ * sin que el empleado tenga que re-vincular el dispositivo) — no existe un
+ * endpoint separado de "sync de empleados" como en el kiosko, porque acá solo
+ * hace falta cachear un único descriptor: el del dueño del celular.
+ * @returns {Promise<void>}
+ */
+export async function heartbeat() {
+    try {
+        const data = await apiFetch('/heartbeat', { method: 'POST' });
+        if (!data.ok) throw new Error(data.message || 'Error en heartbeat');
+
+        await setOwnEmployee(data.employee);
+        await setMeta('face_threshold', data.config.face_threshold);
+        await setMeta('face_min_confidence_gap', data.config.face_min_confidence_gap);
+        await setMeta('server_clock_offset_ms', new Date(data.server_time).getTime() - Date.now());
+        await setMeta('last_heartbeat_at', Date.now());
+
+        await logSync('heartbeat', true);
+    } catch (error) {
+        await logSync('heartbeat', false, error.message);
+        throw error;
+    }
+}
+
+/**
+ * Config de reconocimiento facial vigente (sincronizada vía heartbeat).
+ * @returns {Promise<{threshold: number|null, minGap: number|null}>} null si todavía no hubo un heartbeat exitoso.
+ */
+export async function getFaceConfig() {
+    const threshold = await getMeta('face_threshold');
+    const minGap = await getMeta('face_min_confidence_gap');
+    return { threshold: threshold ?? null, minGap: minGap ?? null };
+}
+
+/**
+ * Estado del día (último evento / eventos permitidos) del propio empleado —
+ * a diferencia del kiosko, no recibe `employeeId` por parámetro: el servidor
+ * lo resuelve implícitamente del token. Requiere red — el caller (`queue.js`,
+ * `getOwnStatus()`) cae a una resolución local si esta consulta falla.
+ * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
+ */
+export async function fetchStatus() {
+    const data = await apiFetch('/status');
+    if (!data.ok) throw new Error(data.message || 'No se pudo obtener el estado de marcación.');
+    return data;
+}
+
+/**
+ * Envía un lote de eventos de marcación — uno solo si se llama justo tras
+ * capturar la marcación con red disponible, o varios si se está vaciando la
+ * cola offline acumulada (ver mobile-offline/queue.js). A diferencia del
+ * kiosko, cada evento NO lleva `employee_id` — el empleado es implícito (el
+ * dueño del token).
+ * @param {Array<{client_event_id: string, event_type: string, recorded_at: string, location?: object|null}>} events
+ * @returns {Promise<Array<{client_event_id: string, status: string, event_id?: number, message?: string}>>}
+ */
+export async function submitEvents(events) {
+    const data = await apiFetch('/events/sync', {
+        method: 'POST',
+        body: JSON.stringify({ events }),
+    });
+    if (!data.ok) throw new Error(data.message || 'No se pudo registrar la marcación.');
+    return data.results;
+}

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -73,7 +73,7 @@
             <path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
             <circle cx="12" cy="20" r="1" fill="currentColor"/>
         </svg>
-        <span>Sin conexión — las marcaciones no pueden registrarse</span>
+        <span>Sin conexión — la marcación se guarda en el dispositivo y se sincroniza al reconectar</span>
     </div>
 
     <main id="main-content" class="page-wrapper">

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -114,6 +114,15 @@
     </div>
 
     <script defer src="{{ asset('js/face-api.min.js') }}"></script>
+
+    {{-- Service worker offline — scope acotado a /marcar (sin barra final: la ruta
+    real no la tiene), no afecta /vincular-celular ni el resto de la app. --}}
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/sw.js', { scope: '/marcar' })
+                .catch((error) => console.warn('No se pudo registrar el service worker:', error));
+        }
+    </script>
 </body>
 
 </html>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -54,6 +54,11 @@
             <span id="{{ $id }}MetaEvent" class="modal-meta-badge"></span>
             <span id="{{ $id }}MetaTime"  class="modal-meta-time"></span>
         </div>
+
+        {{-- Aviso de marcación guardada offline (sin confirmar todavía con el servidor) --}}
+        <p id="{{ $id }}QueuedNotice" class="success-queued-notice" style="display:none" role="status">
+            Guardado en el dispositivo — se sincronizará cuando haya conexión.
+        </p>
         @endif
 
         <div class="modal-actions">


### PR DESCRIPTION
## Resumen

Este PR agrupa dos fases de "Parte C" (marcación offline por celular personal), sobre el backend de PR #84. Se sumó la Fase 3 como commit adicional mientras el PR seguía abierto (mismo patrón que PR #83).

### Fase 2 — Cliente offline (IndexedDB + service worker)

- Nuevo módulo `resources/js/attendances/mobile-offline/{db,matcher,queue,sync}.js`, adaptado de `terminal-offline/` del kiosko (Parte B). Diferencia estructural clave: el celular cachea el descriptor facial de **un único empleado** (el dueño del dispositivo) en vez de toda la sucursal.
- `public/sw.js` se generaliza para cubrir también el shell de `/marcar` (scope `/marcar`, sin barra final — verificado que coincide con la ruta real). `/vincular-celular` no se cachea — es una acción intrínsecamente online.

### Fase 3 — Integrar mark.js al flujo offline

- **Decisión previa acordada con el usuario**: editar `mark.js` (2171 líneas) en el lugar, sin extraer primero la UI a un módulo separado — mismo enfoque que ya funcionó con `terminal.js` del kiosko.
- **Identificación**: reemplaza el POST a `/marcar/identificar` (descriptor crudo + CSRF) por matching 100% local contra el descriptor cacheado.
- **Registro de marcación**: reemplaza el POST directo a `/marcar` por `enqueueMark()` + `flushQueue()` — la marcación se guarda primero en el dispositivo (nunca se pierde) y se sincroniza si hay red, con un aviso `#successModalQueuedNotice` cuando queda pendiente.
- **Gate de vinculación**: sin token (migrado desde `localStorage` tras pasar por `/vincular-celular`), redirige ahí antes de cargar cámara/modelos. Un `MobileAuthError` (token revocado) en cualquiera de los dos flujos también redirige a re-vincular.
- **Fix**: `getOwnStatus()`/`flushQueue()` en `mobile-offline/queue.js` tragaban `MobileAuthError` silenciosamente (encontrado al escribir el manejo de "celular desvinculado" en `mark.js` y notar que nunca se alcanzaba) — ahora lo repropagan sin afectar el fallback normal ante fallos de red.

## Test plan

- [x] Fase 2: 27 aserciones vía Playwright + Vite dev server + IndexedDB real (matcher, máquina de estados, migración de token, heartbeat, `401`→`MobileAuthError`, cola con sync/conflicto, fallback offline). Scope del service worker verificado con un servidor mínimo que replica la ruta exacta.
- [x] Fase 3: 5 aserciones nuevas para la repropagación de `MobileAuthError` (mismo arnés). End-to-end contra servidor real (BD SQLite de scratch): navegador sin vincular → redirige a `/vincular-celular`; navegador vinculado (claim real + localStorage simulado) → sin redirect, heartbeat sincroniza `own_employee`/`face_threshold` en IndexedDB, splash se muestra sin errores.
- [x] **No cubierto**: captura de rostro vía cámara real y tap del botón de marcar — este sandbox no tiene hardware de cámara ni un asset de video con rostro detectable. Las funciones que esos flujos invocan (`matchDescriptor`, `getOwnStatus`, `enqueueMark`, `flushQueue`, etc.) están extensamente probadas de forma aislada; recomendado un smoke test manual en un celular real antes de dar el rollout por cerrado.
- [x] `npm run build` sin errores en ambos commits.
- [x] Sin cambios PHP — no aplica Pest/Pint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH
