### PR TITLE
Marcación offline por celular personal — Fase 4: hardening

### DIFF
--- a/app/Filament/Resources/EmployeeResource.php
+++ b/app/Filament/Resources/EmployeeResource.php
@@ -778,6 +778,13 @@ class EmployeeResource extends Resource
                     ->tooltip(fn (Employee $record) => $record->mobile_linked_at?->format('d/m/Y H:i'))
                     ->toggleable(isToggledHiddenByDefault: true),
 
+                TextColumn::make('mobile_last_heartbeat_at')
+                    ->label('Último sync celular')
+                    ->since()
+                    ->placeholder('Sin sincronizar')
+                    ->tooltip(fn (Employee $record) => $record->mobile_last_heartbeat_at?->format('d/m/Y H:i'))
+                    ->toggleable(isToggledHiddenByDefault: true),
+
                 TextColumn::make('created_at')
                     ->label('Registrado')
                     ->dateTime('d/m/Y H:i')

--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -36,6 +36,8 @@ class MobileHeartbeatController extends Controller
             ], 403);
         }
 
+        $employee->forceFill(['mobile_last_heartbeat_at' => now()])->save();
+
         return response()->json([
             'ok' => true,
             'server_time' => now()->toIso8601String(),

--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -32,7 +32,9 @@ class MobileLinkController extends Controller
      * Valida CI + fecha de nacimiento y emite el token Sanctum del empleado.
      * El mensaje de error es deliberadamente genérico (no distingue "CI no
      * existe" de "fecha incorrecta") para no facilitar enumeración de CIs
-     * válidos — la ruta ya está limitada por `throttle:10,1`.
+     * válidos — la ruta ya está limitada por `throttle:5,1` + `throttle:15,1440`
+     * (más estricto que otros enlaces públicos del proyecto: CI+fecha de
+     * nacimiento es una credencial de baja entropía).
      */
     public function claim(Request $request): JsonResponse
     {
@@ -49,8 +51,11 @@ class MobileLinkController extends Controller
             ->first();
 
         if (! $employee) {
+            // Se loguea el CI intentado (no la fecha) para poder correlacionar en logs
+            // si un mismo CI está siendo atacado desde distintas IPs, o viceversa.
             Log::warning('Intento de vinculación de celular con datos inválidos', [
                 'ip' => $request->ip(),
+                'ci' => $data['ci'],
             ]);
 
             return response()->json([

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\MobileDeviceRelinkedNotification;
 use App\Settings\PayrollSettings;
 use Carbon\Carbon;
 use Illuminate\Auth\Authenticatable;
@@ -53,6 +54,7 @@ class Employee extends Model implements AuthenticatableContract
         'status',
         'face_descriptor',
         'mobile_linked_at',
+        'mobile_last_heartbeat_at',
     ];
 
     protected $casts = [
@@ -60,6 +62,7 @@ class Employee extends Model implements AuthenticatableContract
         'maternity_protection_until' => 'date',
         'face_descriptor' => 'array',
         'mobile_linked_at' => 'datetime',
+        'mobile_last_heartbeat_at' => 'datetime',
     ];
 
     // ───────────────────────────────────────────
@@ -1188,9 +1191,19 @@ class Employee extends Model implements AuthenticatableContract
      */
     public function claimMobileToken(): string
     {
+        // Se evalúa antes de pisar mobile_linked_at — distingue una vinculación
+        // nueva (sin aviso, es el flujo normal) de una re-vinculación (ver
+        // MobileDeviceRelinkedNotification: CI+fecha es una credencial débil,
+        // esto da visibilidad a un admin ante un posible acoso/DoS dirigido).
+        $isRelink = $this->hasMobileLinked();
+
         $this->tokens()->where('name', 'like', 'mobile:%')->delete();
 
         $this->forceFill(['mobile_linked_at' => now()])->save();
+
+        if ($isRelink) {
+            User::all()->each(fn (User $user) => $user->notify(new MobileDeviceRelinkedNotification($this)));
+        }
 
         return $this->createToken('mobile:'.$this->id, [self::MOBILE_SYNC_ABILITY])->plainTextToken;
     }
@@ -1199,7 +1212,7 @@ class Employee extends Model implements AuthenticatableContract
     public function revokeMobileToken(): void
     {
         $this->tokens()->where('name', 'like', 'mobile:%')->delete();
-        $this->forceFill(['mobile_linked_at' => null])->save();
+        $this->forceFill(['mobile_linked_at' => null, 'mobile_last_heartbeat_at' => null])->save();
     }
 
     /** Indica si el empleado tiene un celular vinculado actualmente. */

--- a/app/Notifications/MobileDeviceRelinkedNotification.php
+++ b/app/Notifications/MobileDeviceRelinkedNotification.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Employee;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notificación a los admins cuando el celular vinculado de un empleado se
+ * re-vincula (había un dispositivo ya vinculado y se reemplazó por otro).
+ *
+ * CI + fecha de nacimiento es una credencial débil (baja entropía) — alguien
+ * con esos datos de otro empleado podría re-vincular su propio celular y así
+ * revocar silenciosamente el dispositivo legítimo (denegación de servicio
+ * dirigida). Esta notificación no previene el ataque, pero da visibilidad
+ * para que un admin investigue una re-vinculación que el empleado no
+ * reconoce (ver runbook de vinculación/revocación de celulares).
+ */
+class MobileDeviceRelinkedNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Employee $employee,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'title' => 'Celular re-vinculado',
+            'body' => "El celular vinculado de {$this->employee->full_name} (CI: {$this->employee->ci}) fue reemplazado por uno nuevo. Si el empleado no reconoce este cambio, revocá el acceso desde su ficha.",
+            'icon' => 'heroicon-o-device-phone-mobile',
+            'color' => 'warning',
+            'actions' => [
+                [
+                    'label' => 'Ver empleado',
+                    'url' => "/admin/empleados/{$this->employee->id}",
+                ],
+            ],
+            'employee_id' => $this->employee->id,
+        ];
+    }
+}

--- a/database/migrations/2026_08_20_150000_add_mobile_last_heartbeat_at_to_employees_table.php
+++ b/database/migrations/2026_08_20_150000_add_mobile_last_heartbeat_at_to_employees_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Marcación offline desde el celular personal del empleado (Parte C, Fase 4):
+ * `mobile_last_heartbeat_at` registra el último heartbeat exitoso del celular
+ * vinculado — a diferencia de `mobile_linked_at` (fecha de vinculación, no
+ * cambia mientras el dispositivo siga siendo el mismo), este campo permite
+ * ver en `EmployeeResource` si el celular sigue sincronizando con normalidad.
+ * Menor prioridad que el heartbeat/staleness del kiosko (Terminal): acá es
+ * un dispositivo personal, no un activo físico de la empresa a monitorear
+ * activamente, así que no se agrega un sistema de umbral configurable como
+ * el de `Terminal::connectivity_status` — solo se muestra la fecha relativa.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->timestamp('mobile_last_heartbeat_at')->nullable()->after('mobile_linked_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('mobile_last_heartbeat_at');
+        });
+    }
+};

--- a/docs/runbook-celular-vinculacion-revocacion.md
+++ b/docs/runbook-celular-vinculacion-revocacion.md
@@ -1,0 +1,94 @@
+# Runbook: Vinculación y revocación de celulares personales
+
+Guía operativa para el equipo de soporte/administración de **Nominapp** ante la pérdida, robo, cambio de celular, o sospecha de vinculación no autorizada del dispositivo personal de un empleado usado para marcar asistencia offline.
+
+---
+
+## Cuándo aplica
+
+- El empleado perdió su celular o se lo robaron.
+- El empleado cambió de celular (nuevo dispositivo, mismo número o no).
+- Llega la notificación de campanita **"Celular re-vinculado"** (Filament) y hace falta confirmar con el empleado si el cambio fue legítimo.
+- Se sospecha que alguien vinculó su propio celular usando el CI + fecha de nacimiento de otro empleado (denegación de servicio dirigida — ver [Riesgos aceptados](#riesgos-aceptados)).
+- El empleado causa baja (aunque esto se revoca automáticamente — ver [Revocación automática](#revocación-automática-sin-intervención-manual)).
+
+A diferencia del kiosko de sucursal, acá **no hay enlace de un solo uso generado por un admin**: el propio empleado se vincula en `/vincular-celular` identificándose con su CI + fecha de nacimiento. El token Sanctum del celular (`ability: mobile:sync`) sigue siendo válido hasta que se revoque explícitamente — no expira solo.
+
+## Qué NO cubre este runbook
+
+- **Borrado remoto del celular perdido**: no existe hoy un mecanismo para borrar la caché de IndexedDB (el descriptor facial propio del empleado) de un dispositivo físico que ya no está bajo control. Revocar el token evita que ese dispositivo pueda seguir *sincronizando* o *marcando*, pero el descriptor que ya tenía cacheado localmente permanece en el dispositivo — mismo riesgo aceptado que en el kiosko, mitigado acá por el hecho de que solo se cachea el descriptor de UN empleado (no toda la sucursal).
+- Incidentes de seguridad más amplios (compromiso del servidor, credenciales de admin filtradas).
+
+---
+
+## Paso 1 — Revocar el celular afectado
+
+1. Ir a **Filament → Empleados**, ubicar al empleado (por nombre, CI, o filtrando por la columna **Celular vinculado**).
+2. Abrir la ficha del empleado y, en las acciones de fila (`⋮`) del listado o desde su vista, seleccionar **"Revocar sesión móvil"**.
+3. Confirmar en el modal. Esto invalida inmediatamente el token Sanctum del celular — el próximo intento de identificación o sincronización desde ese dispositivo recibirá `401`/`403`, y `mark.js` lo redirige automáticamente a `/vincular-celular`.
+
+**No hace falta desactivar al empleado** (`status: inactive`) para revocar el celular — son conceptos independientes. Si el empleado sigue activo y solo perdió el celular, revocar el token alcanza; el empleado puede re-vincular un celular nuevo apenas quiera.
+
+## Paso 2 — Confirmar que el celular quedó sin acceso
+
+En la ficha del empleado, la columna **Celular vinculado** debe pasar a "No vinculado" de inmediato (es síncrono, no depende de un heartbeat). La columna **Último sync celular** deja de actualizarse — es esperado, ya no puede completar heartbeats.
+
+## Paso 3 — Re-vincular (celular nuevo o el mismo ya recuperado)
+
+No hace falta que un admin genere nada — el propio empleado repite el flujo de auto-servicio:
+
+1. El empleado abre `/vincular-celular` desde el celular (nuevo o recuperado), **con conexión a internet**.
+2. Ingresa su CI y fecha de nacimiento (los mismos datos que usó la primera vez).
+3. Si los datos coinciden con un empleado activo con reconocimiento facial habilitado, se emite un token nuevo y el empleado es redirigido automáticamente a `/marcar`.
+4. El celular queda vinculado — el descriptor facial propio se sincroniza en el primer heartbeat.
+
+**Vincular un celular nuevo revoca automáticamente cualquier token anterior** (`Employee::claimMobileToken()`) — no hace falta un Paso 1 explícito si el empleado simplemente está reemplazando un celular que ya no tiene: re-vincular directamente alcanza. El Paso 1 (revocar desde Filament) es necesario cuando el celular perdido/robado **no está en manos del empleado** para que él mismo lo reemplace vinculando uno nuevo.
+
+## Paso 4 — Verificar que la vinculación funcionó
+
+En la ficha del empleado en Filament:
+
+- **Celular vinculado**: debe mostrar "Vinculado" con la fecha/hora reciente (tooltip).
+- **Último sync celular**: debe actualizarse a "hace unos segundos" tras el primer heartbeat (ocurre automáticamente al cargar `/marcar`).
+
+Si el empleado reporta que `/marcar` lo sigue mandando a `/vincular-celular` en un loop, o que la identificación facial falla repetidamente después de vincular, verificar:
+- Que el empleado tenga `face_descriptor` cargado (reconocimiento facial habilitado) — sin esto, la vinculación se rechaza con el mismo mensaje genérico que credenciales incorrectas.
+- Los logs del servidor (`storage/logs/laravel-*.log`) por el mensaje `Intento de vinculación de celular con datos inválidos` — incluye el CI intentado (no la fecha) para diagnosticar si el empleado está escribiendo mal su CI o su fecha de nacimiento.
+
+---
+
+## Revocación automática (sin intervención manual)
+
+El sistema revoca el token móvil solo, sin que un admin tenga que actuar, en estos casos:
+
+- **El empleado deja de estar activo** (`status !== 'active'`): tanto `MobileHeartbeatController` como `MobileEventSyncController` revocan el token en el primer intento de uso tras la baja/suspensión, y responden `403` con un mensaje pidiendo consultar a RRHH.
+- **Vincular un celular nuevo**: revoca automáticamente el anterior (ver Paso 3).
+
+## Ante la notificación "Celular re-vinculado"
+
+Cuando un empleado que **ya tenía** un celular vinculado vincula uno nuevo, todos los admins reciben una notificación de campanita en Filament (`MobileDeviceRelinkedNotification`). Esto puede significar dos cosas:
+
+1. **Legítimo**: el empleado cambió de celular y volvió a pasar por `/vincular-celular` él mismo — no hace falta ninguna acción, la notificación es solo informativa.
+2. **Sospechoso**: alguien con el CI + fecha de nacimiento del empleado (datos no siempre secretos — ver [Riesgos aceptados](#riesgos-aceptados)) vinculó su propio celular, revocando silenciosamente el del empleado legítimo.
+
+Ante la duda, contactar al empleado directamente (no por la app — su celular pudo haber sido desvinculado) y preguntar si reconoce el cambio. Si NO lo reconoce:
+
+1. Revocar el celular actual (Paso 1).
+2. Pedirle al empleado que vuelva a vincularse él mismo desde su celular (Paso 3).
+3. Si el patrón se repite (varias re-vinculaciones no reconocidas seguidas), escalar — puede tratarse de un intento dirigido de denegación de servicio contra ese empleado específico, y ameritaría revisar los logs de `Intento de vinculación de celular con datos inválidos` filtrando por ese CI.
+
+---
+
+## Riesgos aceptados
+
+- **CI + fecha de nacimiento como credencial de vinculación**: es débil por sí sola (datos semi-adivinables, no secretos como una contraseña) — el diseño la trata como "reclamar el dispositivo para cachear un descriptor", no como control de acceso completo. La marcación en sí sigue requiriendo un match facial exitoso contra el descriptor cacheado (segundo factor: algo que sos, no algo que sabés). Mitigado con throttling agresivo (`throttle:5,1` + `throttle:15,1440` en el POST de `/vincular-celular`) y la notificación de re-vinculación descrita arriba — no eliminado.
+- **Ventana entre la pérdida y la revocación**: mientras el token no se revoca, el celular puede seguir marcando e identificando con normalidad. No hay alerta automática de "celular reportado como perdido" — depende de que el empleado avise a RRHH/soporte apenas se entera del incidente.
+- **Sin borrado remoto**: ver [Qué NO cubre este runbook](#qué-no-cubre-este-runbook).
+
+## Checklist rápido
+
+- [ ] Revocar el celular afectado (Filament → Empleados → ficha del empleado → Revocar sesión móvil) — solo si el dispositivo perdido/robado NO está en manos del empleado
+- [ ] Empleado re-vincula desde el celular nuevo/recuperado en `/vincular-celular`, online
+- [ ] Confirmar "Vinculado" + "Último sync celular" reciente en la ficha del empleado
+- [ ] Ante la notificación de re-vinculación: confirmar con el empleado (fuera de la app) si reconoce el cambio
+- [ ] Si no lo reconoce: revocar + pedir que se re-vincule + evaluar si escalar por patrón de acoso

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,10 +62,19 @@ Route::prefix('terminal/{code}/setup/{setupToken}')->name('terminal.setup.')->mi
 // identifica con CI + fecha de nacimiento (sin enlace de un solo uso generado por
 // un admin, a diferencia del terminal: acá el dato personal ES la credencial).
 // Emite el token Sanctum que el celular usará contra la API de sincronización
-// (routes/api.php, prefijo v1/mobile).
-Route::prefix('vincular-celular')->name('mobile-link.')->middleware('throttle:10,1')->group(function () {
-    Route::get('/', [MobileLinkController::class, 'show'])->name('show');
-    Route::post('/', [MobileLinkController::class, 'claim'])->name('claim');
+// (routes/api.php, prefijo v1/mobile). El POST (intento de credencial) tiene
+// throttling más estricto que el GET (solo carga la página) — CI+fecha de
+// nacimiento es una credencial de baja entropía, más fácil de fuerza bruta
+// que el token random de 64 caracteres del setup de terminales.
+Route::prefix('vincular-celular')->name('mobile-link.')->group(function () {
+    Route::get('/', [MobileLinkController::class, 'show'])->name('show')->middleware('throttle:20,1,mobile-link-show');
+    // Prefijos distintos en cada throttle: sin esto, ambos comparten la misma clave de
+    // rate limit (dominio+IP — Laravel no distingue por maxAttempts/decayMinutes ni por
+    // ruta), y cada request cuenta doble contra un único bucket compartido.
+    Route::post('/', [MobileLinkController::class, 'claim'])->name('claim')->middleware([
+        'throttle:5,1,mobile-link-minute',
+        'throttle:15,1440,mobile-link-day',
+    ]);
 });
 
 /*

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -8,7 +8,10 @@ use App\Models\Department;
 use App\Models\Employee;
 use App\Models\Position;
 use App\Models\Terminal;
+use App\Models\User;
+use App\Notifications\MobileDeviceRelinkedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
 
@@ -213,4 +216,78 @@ it('un token de terminal no puede usar las rutas móviles (ability distinta)', f
     Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
 
     $this->postJson('/api/v1/mobile/heartbeat')->assertStatus(403);
+});
+
+// ─── Hardening (Fase 4) ─────────────────────────────────────────────────────
+
+it('no notifica a los admins en la primera vinculación', function () {
+    Notification::fake();
+    User::create(['name' => 'Admin', 'email' => 'admin-first@test.com', 'password' => bcrypt('secret')]);
+
+    $employee = makeLinkableEmployee();
+
+    $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ])->assertOk();
+
+    Notification::assertNothingSent();
+});
+
+it('notifica a todos los admins cuando un celular ya vinculado se re-vincula', function () {
+    $employee = makeLinkableEmployee();
+    $admin1 = User::create(['name' => 'Admin 1', 'email' => 'admin-relink1@test.com', 'password' => bcrypt('secret')]);
+    $admin2 = User::create(['name' => 'Admin 2', 'email' => 'admin-relink2@test.com', 'password' => bcrypt('secret')]);
+
+    // Primera vinculación — sin notificación (no hay nada previo que "reemplazar").
+    $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '1990-05-15'])->assertOk();
+
+    Notification::fake();
+
+    // Segunda vinculación del mismo empleado — el dispositivo anterior existía.
+    $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '1990-05-15'])->assertOk();
+
+    Notification::assertSentTo(
+        [$admin1, $admin2],
+        MobileDeviceRelinkedNotification::class,
+        fn ($notification) => $notification->employee->is($employee)
+    );
+});
+
+it('el heartbeat actualiza mobile_last_heartbeat_at', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    expect($employee->mobile_last_heartbeat_at)->toBeNull();
+
+    $this->postJson('/api/v1/mobile/heartbeat')->assertOk();
+
+    expect($employee->fresh()->mobile_last_heartbeat_at)->not->toBeNull();
+});
+
+it('revocar el celular limpia mobile_last_heartbeat_at además de mobile_linked_at', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $this->postJson('/api/v1/mobile/heartbeat')->assertOk();
+    expect($employee->fresh()->mobile_last_heartbeat_at)->not->toBeNull();
+
+    $employee->fresh()->revokeMobileToken();
+
+    $fresh = $employee->fresh();
+    expect($fresh->mobile_linked_at)->toBeNull()
+        ->and($fresh->mobile_last_heartbeat_at)->toBeNull();
+});
+
+it('el POST de vincular-celular tiene throttling más estricto que el GET', function () {
+    $employee = makeLinkableEmployee();
+
+    // 5 intentos permitidos por minuto (credenciales incorrectas a propósito, no importa el resultado).
+    for ($i = 0; $i < 5; $i++) {
+        $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '2000-01-01'])
+            ->assertStatus(422);
+    }
+
+    // El 6º intento en la misma ventana debe ser rechazado por el rate limiter.
+    $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '2000-01-01'])
+        ->assertStatus(429);
 });


### PR DESCRIPTION
## Resumen

Última fase de "Parte C" (marcación offline por celular personal), sobre PR #84 (backend) y PR #85 (cliente + integración). Con este PR, Parte C queda completa: backend, cliente offline, integración con `mark.js`, y hardening.

- **Throttling más estricto en `/vincular-celular`**: el POST (intento de credencial CI+fecha) pasa de `throttle:10,1` a `throttle:5,1` + `throttle:15,1440` — más agresivo que otros enlaces públicos del proyecto, porque CI+fecha de nacimiento es una credencial de baja entropía comparada con los tokens random de 64 caracteres que usa el setup de terminales.
- **Bug real encontrado y corregido**: apilar dos middlewares `throttle:X,Y` sin prefijo explícito hace que compartan la misma clave de rate limit (`Illuminate\Routing\Middleware\ThrottleRequests::resolveRequestSignature()` solo usa dominio+IP, no los parámetros del middleware). Sin prefijos, el límite de "5 por minuto" se agotaba en el 3er request en vez del 6º — confirmado con curl contra un servidor real antes y después del fix (`throttle:5,1,mobile-link-minute`, etc.).
- **Notificación a admins ante re-vinculación** (`MobileDeviceRelinkedNotification`): si un empleado que ya tenía un celular vinculado vincula uno nuevo, todos los admins reciben una notificación de campanita — da visibilidad ante un posible acoso/DoS dirigido (alguien con el CI+fecha de otro empleado podría revocar silenciosamente su dispositivo legítimo).
- **Heartbeat visible en Filament**: nueva columna `mobile_last_heartbeat_at`, estampada en cada heartbeat exitoso y limpiada al revocar — para saber si el celular vinculado sigue sincronizando.
- **Runbook**: `docs/runbook-celular-vinculacion-revocacion.md`.

## Test plan

- [x] Throttling verificado con curl contra un servidor real (BD SQLite de scratch, `CACHE_STORE=file` para persistir entre requests separadas de `php artisan serve`): confirmado el bug (bloqueo en el 3er intento) y confirmado el fix (5 permitidos, `429` en el 6º); vinculación legítima sigue funcionando con cuota fresca.
- [x] Notificación de re-vinculación verificada por tinker: sin aviso en la primera vinculación, notificación a todos los admins en la segunda (con `employee_id` correcto).
- [x] Heartbeat en Filament verificado end-to-end (HTTP real con token real → `mobile_last_heartbeat_at` estampado en la BD).
- [x] Tests Pest nuevos en `MobileAttendanceLinkTest.php` (5 casos) — no corren en este sandbox (sin MySQL), verificados equivalentemente contra el servidor real como se describe arriba; correrán en CI.
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin errores (sin cambios de frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_