### PR TITLE
Documentar la arquitectura de marcación offline (kiosko y celular)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Two separate axes that converge in `Contract`:
 | Schedules | `ScheduleAssignmentService` — asignación de horarios fijos con vigencia por fechas |
 | Rotations | `RotationService` — asignación de patrones rotativos y resolución de turno efectivo por fecha |
 | Attendance | `AttendanceDay`, `AttendanceEvent`, observers auto-calculate daily totals |
+| Attendance offline (kiosko/celular) | `Terminal`, `Employee` (Sanctum), `AttendanceMarkFailure` — ver "Módulo de Asistencia — Marcación Offline" más abajo |
 | Face Recognition | TensorFlow.js (128-element descriptors), `FaceEnrollment`, `FaceCaptureApp.js` |
 | Warnings | `Warning` — registro documental de amonestaciones laborales (sin impacto en nómina por ahora) |
 
@@ -299,6 +300,24 @@ Salario del mes 13, pagadero en diciembre. Se gestiona por `AguinaldoPeriod` (un
 ### Módulo de Vacaciones
 
 **Pago con nómina (`payment_method = 'with_payroll'`):** `PayrollService::resolveVacationPays()` paga la remuneración vacacional **completa como pago único** en el período de nómina que contiene el `start_date` de la vacación — **no se prorratea** aunque el `end_date` caiga en el período de nómina siguiente. Es una convención intencional (lump sum al inicio de la vacación), no un bug. `Vacation.payment_status` es un enum simple `unpaid`/`paid` — no rastrea montos parciales, así que implementar prorrateo real requeriría un cambio de modelo de datos, no solo de lógica.
+
+### Módulo de Asistencia — Marcación Offline (Kiosko y Celular)
+
+Documento completo con arquitectura, decisiones y deuda técnica: **`docs/marcacion-offline.md`**. Resumen:
+
+Dos dispositivos marcan asistencia por reconocimiento facial (face-api.js, 100% client-side), ambos con soporte offline vía PWA:
+- **Kiosko/terminal** (`Terminal`) — compartido por sucursal, cachea el descriptor de *todos* los empleados activos de esa sucursal. Provisión por enlace de un solo uso generado por un admin.
+- **Celular personal** (`Employee`) — individual, cachea *únicamente* el propio descriptor. Vinculación self-service en `/vincular-celular` con CI + fecha de nacimiento (no es un factor de auth completo — el match facial sigue siendo el control real). Un dispositivo vinculado a la vez: vincular uno nuevo revoca el anterior y notifica a los admins.
+
+**Auth:** un único guard `auth:sanctum` sirve tokens de `Terminal` (`ability: terminal:sync`) y `Employee` (`ability: mobile:sync`) — Sanctum resuelve el `tokenable` de forma polimórfica sin config adicional en `config/auth.php`. Ambos modelos usan `HasApiTokens` + `Illuminate\Auth\Authenticatable` (este último solo necesario para que `Sanctum::actingAs()` funcione en tests).
+
+**Cliente offline:** IndexedDB (`resources/js/attendances/terminal-offline/` y `mobile-offline/`, módulos `db.js`/`matcher.js`/`queue.js` compartidos en su mayoría) + cola de eventos con `client_event_id` idempotente + service worker (`public/sw.js`) cacheando modelos/assets/shell.
+
+**Conflictos de sync:** si un evento offline ya no es válido al sincronizar (otro origen registró algo mientras el dispositivo estaba desconectado), se rechaza puntualmente y se registra en `AttendanceMarkFailure` (`failure_type: sync_conflict`) — nunca se descarta silenciosamente. Un admin lo revisa en `AttendanceMarkFailureResource`: **aprobar** (reconstruye el evento, revalidando la secuencia contra el estado *actual*) o **descartar**.
+
+**Reconocimiento facial:** `face_threshold` (0.50) y `face_min_confidence_gap` (0.05) en `GeneralSettings`, ajustados con datos reales de `AttendanceMarkFailure`. Lógica de captura común en `resources/js/shared/face-capture-core.js`.
+
+**Runbooks:** `docs/runbook-terminal-revocacion-reprovision.md`, `docs/runbook-celular-vinculacion-revocacion.md`.
 
 ### Service Layer
 Business logic lives in `app/Services/`. Each domain has a `*Service` for orchestration and a `*Calculator` for isolated math. PDF generation is handled by dedicated generator classes in the same directory.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Sistema de gestión de recursos humanos y nómina, desarrollado con Laravel y Fi
 ## Características
 
 - Gestión de empleados y departamentos
-- Control de asistencia con reconocimiento facial
+- Control de asistencia con reconocimiento facial, con marcación offline vía PWA (kiosko de sucursal y celular personal)
 - Gestión de nóminas y períodos de pago
 - Administración de vacaciones y ausencias
 - Sistema de préstamos con cuotas

--- a/docs/marcacion-offline.md
+++ b/docs/marcacion-offline.md
@@ -1,0 +1,138 @@
+# Arquitectura: marcación de asistencia offline (kiosko y celular)
+
+Documento de referencia de la arquitectura de marcación de asistencia por reconocimiento facial con soporte offline, cubriendo tanto el kiosko/terminal de sucursal como el celular personal del empleado. Consolida el trabajo de tres iniciativas relacionadas: ajuste de reconocimiento facial, marcación offline vía PWA en el kiosko, y marcación offline vía PWA en el celular personal.
+
+Para el resumen corto orientado a desarrollo día a día, ver la sección "Módulo de Asistencia — Marcación Offline" en `CLAUDE.md`. Este documento tiene el detalle completo de arquitectura y decisiones.
+
+---
+
+## Contexto
+
+El reconocimiento facial corre 100% en el navegador (face-api.js, descriptores de 128 elementos) — lo único que originalmente dependía del servidor era comparar el descriptor capturado contra la base de empleados y guardar el evento. Esto habilitó llevar todo el flujo a una PWA con soporte offline real, sin necesitar una app nativa.
+
+Hay dos dispositivos distintos que marcan asistencia, con modelos de confianza y caché muy diferentes:
+
+| | Kiosko/terminal | Celular personal |
+|---|---|---|
+| Propiedad | De la empresa, en la sucursal | Del empleado |
+| Uso | Compartido, N empleados | Individual, 1 empleado |
+| Caché de descriptores | Todos los empleados activos de la sucursal | Únicamente el propio |
+| Vinculación | Enlace de un solo uso generado por un admin | Self-service (CI + fecha de nacimiento) |
+| Dispositivos simultáneos | N/A (es un dispositivo fijo) | 1 a la vez (vincular uno nuevo revoca el anterior) |
+
+---
+
+## Autenticación: Sanctum polimórfico
+
+Ambos flujos usan **Laravel Sanctum**, con un único guard `auth:sanctum` sirviendo tokens de dos modelos distintos (`Terminal` y `Employee`) sin ninguna configuración adicional en `config/auth.php`. `personal_access_tokens.tokenable_type` resuelve el modelo correcto por token — alcanza con que cada modelo tenga `HasApiTokens` (Sanctum) y, solo para que `Sanctum::actingAs()` funcione en tests, `Illuminate\Auth\Authenticatable` + `Illuminate\Contracts\Auth\Authenticatable`.
+
+- `Terminal::claimSanctumToken()` — ability `terminal:sync`.
+- `Employee::claimMobileToken()` — ability `mobile:sync`.
+
+Ambos siguen el mismo patrón de provisión: nunca se expone un token de larga vida en una URL. El terminal usa un enlace de configuración de un solo uso generado por un admin; el celular usa una credencial self-service (ver abajo). Los dos revocan cualquier token previo de ese tipo antes de emitir uno nuevo — un dispositivo activo a la vez.
+
+---
+
+## Parte A — Tuning de reconocimiento facial
+
+Ajustes basados en datos reales de fallos (`AttendanceMarkFailure`, 30 días, 2935 registros: 55% `face_no_match`, 43% `face_ambiguous`):
+
+- `face_threshold`: `0.45` → `0.50` (`GeneralSettings`).
+- `face_min_confidence_gap`: `0.1` → `0.05` (`GeneralSettings`).
+- Feedback en tiempo real durante la captura (cara muy chica / mala luz se avisa antes de completar el ciclo de 5 muestras), cooldown post-fallo reducido.
+- Lógica de captura común (muestreo, promediado, validación de tamaño mínimo) extraída a `resources/js/shared/face-capture-core.js`, compartida por `mark.js`, `terminal.js` y `FaceCaptureApp.js` — antes estaba duplicada con configuraciones que ya habían divergido.
+- Nuevo reporte de tasa de fallos por empleado en `AttendanceMarkFailureResource`, para detectar proactivamente a quién le conviene re-inscribirse.
+
+---
+
+## Parte B — Kiosko/terminal offline
+
+### Capa de API (`routes/api.php`, prefijo `v1/terminal`)
+
+- `GET /employees/sync?since=...` — sync incremental (delta) de empleados activos con descriptor facial de la sucursal del terminal, con tombstones para los que dejaron de calificar.
+- `GET /employees/{employee}/status` — último evento / eventos permitidos de un empleado puntual (el kiosko no tiene esto cacheado localmente para todos).
+- `POST /events/sync` — envío en lote (máx. 200) de eventos con `client_event_id` (UUID generado al capturar) para deduplicar reintentos.
+- `POST /heartbeat` — mantiene vivo `last_heartbeat_at`, devuelve config vigente (`face_threshold` etc.) y reporta contadores de cola (`pending_events`/`conflict_events`).
+
+### Cliente (`resources/js/attendances/terminal-offline/`)
+
+- `db.js` — IndexedDB `nominapp-terminal`, 4 stores: `terminal_meta`, `employees_cache`, `outbound_events`, `sync_log`.
+- `matcher.js` — port a JS de la comparación por distancia euclidiana + umbral + gap de confianza que antes solo existía en el servidor.
+- `sync.js` — cliente HTTP de `/api/v1/terminal/*`.
+- `queue.js` — máquina de estados local (port de `AttendanceEvent::allowedNextEventTypes()`), cola de eventos pendientes (`enqueueMark()`/`flushQueue()`), resolución de estado combinando lo confirmado por el servidor con lo encolado localmente.
+
+### Service worker (`public/sw.js`)
+
+Hand-rolled (sin Workbox) — cache-first para `/models/*` y `/build/assets/*`, stale-while-revalidate para el shell HTML del kiosko. `skipWaiting()` + `clients.claim()` en cada deploy, con caché versionada.
+
+### Resolución de conflictos
+
+Si el kiosko sincroniza un evento offline cuya secuencia ya no es válida en el servidor (ej. otro origen ya registró un evento posterior mientras estaba desconectado), el servidor lo rechaza puntualmente (`AttendanceEventSyncService::recordSyncFailure()`) y lo registra en `AttendanceMarkFailure` (`failure_type: sync_conflict`) — nunca se descarta silenciosamente ni se fuerza. Un admin lo revisa desde Filament (`AttendanceMarkFailureResource`) y puede **aprobar** (reconstruye el evento, revalidando la secuencia contra el estado *actual*, con opción de ajustar tipo/hora) o **descartar**.
+
+### Heartbeat / staleness (`Terminal`)
+
+`connectivity_status` (`never_connected` / `online` / `stale`, según `GeneralSettings->terminal_stale_threshold_hours`) y `sync_queue_status` (`ok` / `pending` / `conflict`), visibles en `TerminalResource` (columnas, filtros, infolist).
+
+### Hardening
+
+`navigator.storage.persist()`, corrección de deriva de reloj (`server_clock_offset_ms` calculado en cada heartbeat), chunking de `flushQueue()` a lotes de 200 (bug real encontrado con una prueba de carga: sin chunking, una cola de más de 200 eventos quedaba atascada indefinidamente porque el servidor rechazaba el batch completo).
+
+---
+
+## Parte C — Celular personal offline
+
+### Vinculación (`/vincular-celular`)
+
+El empleado se identifica una vez, online, con **CI + fecha de nacimiento** — ambos datos ya existen en `Employee`, sin necesitar un PIN nuevo que administrar ni una integración de SMS/magic-link. Es deliberadamente **no** un factor de autenticación completo: funciona como credencial para "reclamar" el dispositivo, mientras que la marcación en sí sigue exigiendo un match facial exitoso contra el descriptor cacheado (el segundo factor real). Mensaje de error genérico (no distingue CI inexistente de fecha incorrecta), throttling agresivo (`throttle:5,1` + `throttle:15,1440`, con prefijos explícitos por clave — ver nota de bug abajo).
+
+Al validar, `Employee::claimMobileToken()` revoca cualquier token `mobile:%` previo y cachea únicamente el descriptor facial del propio empleado.
+
+**Bug real encontrado en el throttling**: apilar dos middlewares `throttle:X,Y` sin prefijo explícito hace que ambos compartan la misma clave de rate limit (`ThrottleRequests::resolveRequestSignature()` solo usa dominio+IP, no los parámetros del middleware) — el límite más agresivo se agotaba antes de lo esperado. Se corrigió agregando prefijos explícitos (`throttle:5,1,mobile-link-minute`, etc.).
+
+### API (`routes/api.php`, prefijo `v1/mobile`)
+
+- `POST /heartbeat` — config vigente + descriptor facial propio actualizado (no existe "sync de empleados" separado: el celular solo cachea su propio descriptor, y una re-inscripción facial se propaga automáticamente en el próximo heartbeat).
+- `GET /status` — último evento / eventos permitidos del propio empleado (implícito vía `$request->user()`, sin parámetro de ruta).
+- `POST /events/sync` — mismo contrato que el del terminal pero sin `employee_id` por evento (el empleado es el dueño del token).
+
+Los tres endpoints revocan el token y responden `403` si el empleado ya no está `active` — autodesvinculación ante una baja, sin esperar acción manual de un admin.
+
+`MobileEventSyncService` es un servicio **paralelo** a `AttendanceEventSyncService`, deliberadamente no compartido: el acoplamiento de este último a `Terminal` (`terminal_id`, fallback de GPS a coordenadas de sucursal, `employee_id` por evento) no encaja con "un empleado ya autenticado, con GPS real, sin `employee_id` por evento". Misma idempotencia por `client_event_id` y misma revalidación de secuencia. Los conflictos van al mismo `AttendanceMarkFailure` (`mode: 'mobile'`), reusando el flujo de aprobar/descartar de Filament.
+
+### Cliente (`resources/js/attendances/mobile-offline/`)
+
+Reusa `db.js`/`matcher.js`/`queue.js` del kiosko con cambios mínimos (nombre de IndexedDB `nominapp-mobile`, para no chocar si algún día ambos flujos coexistieran en el mismo navegador — `matcher.js` funciona igual con un array de 1 solo candidato). `sync.js` es una variante propia apuntando a `/api/v1/mobile/*` (el original tenía `API_BASE` fijo a `/api/v1/terminal`).
+
+### Integración con `mark.js`
+
+`mark.js` (2171 líneas, UI de wizard con splash/mini-mapa GPS Leaflet/animaciones, sin modularizar) se editó **en el lugar** — mismo criterio que ya había funcionado con `terminal.js` — en dos puntos acotados: identificación (antes `POST /marcar/identificar` con el descriptor crudo al servidor; ahora matching local contra el único descriptor cacheado) y registro de marcación (antes `POST /marcar` síncrono con CSRF de sesión; ahora `enqueueMark()` + intento de `flushQueue()`, convergiendo a Sanctum). Se agregó la pantalla de "vincular este celular" para cuando no hay token.
+
+### Hardening
+
+Notificación a admins (`MobileDeviceRelinkedNotification`) cuando un empleado que ya tenía celular vinculado vincula uno nuevo — mitiga el riesgo de que alguien con el CI+fecha de otro empleado revoque silenciosamente su dispositivo legítimo (denegación de servicio dirigida). Columna `mobile_last_heartbeat_at` en `EmployeeResource` para saber si el celular vinculado sigue sincronizando.
+
+---
+
+## Riesgos aceptados / deuda técnica conocida
+
+- **Biometría sin cifrar en IndexedDB** — mismo nivel de exposición que el caché server-side previo (texto plano). Cifrado real requeriría PIN de dispositivo o clave de hardware.
+- **Borrado remoto de un dispositivo perdido no es posible** — revocar el token evita que siga *sincronizando*, pero no borra lo que ya tenía cacheado localmente. Ver los runbooks.
+- **CI + fecha de nacimiento como credencial de vinculación** es de baja entropía — mitigado con throttling agresivo y notificación de re-vinculación, no con un segundo factor real (ese rol lo cumple el match facial).
+- **Background Sync API no soportada en Safari/WebKit** — el fallback es que la sincronización ocurre mientras la pestaña/PWA sigue abierta.
+- **Heartbeat/staleness del celular tiene menor prioridad que el del kiosko** — son N:1 por empleado, no un activo físico de la empresa a monitorear activamente; hoy solo hay un timestamp visible en `EmployeeResource`, sin badge de "desconectado" ni alertas.
+- **`Employee::getAdvanceReferenceSalary()`** y otras áreas no relacionadas con asistencia no se tocaron en esta iniciativa.
+
+## Runbooks relacionados
+
+- `docs/runbook-terminal-revocacion-reprovision.md` — pérdida/robo/reemplazo de un kiosko.
+- `docs/runbook-celular-vinculacion-revocacion.md` — pérdida/robo/reemplazo del celular de un empleado, o revocación manual desde Filament.
+
+## Archivos clave
+
+**Backend compartido:** `app/Models/AttendanceEvent.php` (máquina de estados `allowedNextEventTypes()`), `app/Models/AttendanceMarkFailure.php` (registro y resolución de conflictos), `app/Filament/Resources/AttendanceMarkFailureResource.php`.
+
+**Kiosko:** `app/Models/Terminal.php`, `app/Http/Controllers/Api/Terminal{EmployeeSync,EventSync,Heartbeat}Controller.php`, `app/Services/{EmployeeDescriptorSyncService,AttendanceEventSyncService}.php`, `app/Filament/Resources/TerminalResource.php`, `resources/js/attendances/{terminal,terminal-offline/*}.js`, `public/sw.js`.
+
+**Celular:** `app/Models/Employee.php` (sección "Marcación offline por celular"), `app/Http/Controllers/MobileLinkController.php`, `app/Http/Controllers/Api/Mobile{Heartbeat,Status,EventSync}Controller.php`, `app/Services/MobileEventSyncService.php`, `resources/js/attendances/{mark,mobile-offline/*}.js`, `resources/views/attendances/mobile-link.blade.php`.
+
+**Configuración:** `app/Settings/GeneralSettings.php` (`face_threshold`, `face_min_confidence_gap`, `terminal_stale_threshold_hours`), `config/attendance.php`.


### PR DESCRIPTION
## Resumen

Documentación de las tres iniciativas relacionadas implementadas en esta serie de PRs (#77-#86): tuning de reconocimiento facial, kiosko offline vía PWA, y celular personal offline vía PWA.

- **`docs/marcacion-offline.md`** (nuevo): arquitectura completa — autenticación Sanctum polimórfica (`Terminal`/`Employee` en un mismo guard), cliente IndexedDB + service worker, resolución de conflictos de sync (`AttendanceMarkFailure`), diferencias de modelo de confianza entre kiosko (caché de toda la sucursal) y celular (caché del propio descriptor únicamente), riesgos aceptados y runbooks relacionados.
- **`CLAUDE.md`**: nueva sección "Módulo de Asistencia — Marcación Offline" siguiendo el patrón existente de las demás secciones de módulo (resumen corto, con link al documento completo) + fila nueva en la tabla de módulos.
- **`README.md`**: se suma la capacidad offline a la lista de características.

Sin cambios de código — solo documentación.

## Test plan

No aplica (cambio puramente documental). Se revisó que los nombres de clases/archivos referenciados coincidan con el código real mergeado en PRs #77-#86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_