### PR TITLE
Agregar instancia nextup al workflow de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: 'Instancia a la que desplegar'
         type: choice
-        options: [bar777, arca]
+        options: [bar777, arca, nextup]
         required: true
 
 jobs:
@@ -26,6 +26,28 @@ jobs:
       SSH_PRIVATE_KEY: ${{ secrets.BAR777_SSH_PRIVATE_KEY }}
       DEPLOY_PATH: ${{ secrets.BAR777_DEPLOY_PATH }}
       APP_URL: ${{ secrets.BAR777_APP_URL }}
+      SMTP_HOST: ${{ secrets.SMTP_HOST }}
+      SMTP_PORT: ${{ secrets.SMTP_PORT }}
+      SMTP_USER: ${{ secrets.SMTP_USER }}
+      SMTP_PASS: ${{ secrets.SMTP_PASS }}
+      NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
+
+  deploy-nextup:
+    if: ${{ inputs.environment == 'nextup' }}
+    permissions:
+      contents: write
+    uses: nextup-py/deploy-actions/.github/workflows/laravel-deploy.yml@9fc64c40637a060f8c1ac7c792c44d0717244b03 # v1.2.0
+    with:
+      environment_name: nextup
+      run_tests: true
+      run_migrations: true
+    secrets:
+      SSH_HOST: ${{ secrets.NEXTUP_SSH_HOST }}
+      SSH_PORT: ${{ secrets.NEXTUP_SSH_PORT }}
+      SSH_USER: ${{ secrets.NEXTUP_SSH_USER }}
+      SSH_PRIVATE_KEY: ${{ secrets.NEXTUP_SSH_PRIVATE_KEY }}
+      DEPLOY_PATH: ${{ secrets.NEXTUP_DEPLOY_PATH }}
+      APP_URL: ${{ secrets.NEXTUP_APP_URL }}
       SMTP_HOST: ${{ secrets.SMTP_HOST }}
       SMTP_PORT: ${{ secrets.SMTP_PORT }}
       SMTP_USER: ${{ secrets.SMTP_USER }}


### PR DESCRIPTION
## Resumen

Nueva instancia de deploy para un VPS de NextUp (CloudPanel ya instalado, con `laravet.nextup.com.py` e `itassets.nextup.com.py` corriendo ahí) — se va a agregar `nominapp.nextup.com.py` como tercer site. Mismo mecanismo que Bar777/Arca: GitHub Actions se conecta directo por SSH al servidor y ejecuta el deploy usando el workflow reusable de `nextup-py/deploy-actions`.

- `workflow_dispatch` gana la opción `nextup` en el choice de instancia.
- Nuevo job `deploy-nextup`, calcado de `deploy-bar777`/`deploy-arca`, apuntando a secrets prefijados `NEXTUP_*`.

## Pendiente (fuera de este PR, del lado de infraestructura)

Antes de poder disparar el deploy hace falta, del lado del VPS/CloudPanel:
1. Crear el site `nominapp.nextup.com.py` en CloudPanel (PHP 8.4).
2. Crear un usuario SSH de deploy dedicado (`nextup-deploy`), en el grupo Unix del site user (mismo patrón que `bar777-deploy`/`arca-deploy`).
3. Generar una Deploy Key de solo lectura del repo para ese usuario (`~/.ssh/id_ed25519`).
4. Crear la base de datos MySQL y el `.env` de producción (incluyendo `GOOGLE_MAPS_API_KEY`).
5. Configurar DNS + SSL (Let's Encrypt) para el dominio.
6. Configurar el crontab del scheduler (`php artisan schedule:run` cada minuto).

Y en la configuración del repositorio (Settings → Secrets):
- `NEXTUP_SSH_HOST`, `NEXTUP_SSH_PORT`, `NEXTUP_SSH_USER`, `NEXTUP_SSH_PRIVATE_KEY`, `NEXTUP_DEPLOY_PATH`, `NEXTUP_APP_URL`.

## Test plan

- [x] YAML validado con `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Primer deploy real — no se puede probar hasta que los secrets `NEXTUP_*` estén cargados y el site exista en CloudPanel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_