### PR TITLE
Fixes y notificaciones al admin — hallazgos de la prueba en producción

### DIFF
--- a/app/Filament/Resources/AttendanceMarkFailureResource.php
+++ b/app/Filament/Resources/AttendanceMarkFailureResource.php
@@ -431,7 +431,12 @@ class AttendanceMarkFailureResource extends Resource
                         KeyValueEntry::make('metadata')
                             ->label('')
                             ->columnSpanFull()
-                            ->getStateUsing(fn (AttendanceMarkFailure $record) => $record->metadata ?? []),
+                            ->getStateUsing(fn (AttendanceMarkFailure $record) => collect($record->metadata ?? [])
+                                ->map(fn ($value) => is_array($value)
+                                    ? json_encode($value, JSON_UNESCAPED_UNICODE)
+                                    : $value)
+                                ->toArray()
+                            ),
                     ])
                     ->visible(fn (AttendanceMarkFailure $record) => ! empty($record->metadata)),
             ]);

--- a/app/Http/Controllers/FaceEnrollmentController.php
+++ b/app/Http/Controllers/FaceEnrollmentController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\FaceEnrollment;
+use App\Models\User;
+use App\Notifications\FaceEnrollmentPendingApprovalNotification;
 use App\Rules\FaceDescriptor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -109,6 +111,8 @@ class FaceEnrollmentController extends Controller
                 'enrollment_id' => $enrollment->id,
                 'employee_id' => $enrollment->employee_id,
             ]);
+
+            User::all()->each(fn (User $user) => $user->notify(new FaceEnrollmentPendingApprovalNotification($enrollment)));
 
             // Retornar una respuesta JSON indicando éxito
             return response()->json([

--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -64,7 +64,7 @@ class MobileLinkController extends Controller
             ], 422);
         }
 
-        $plainTextToken = $employee->claimMobileToken();
+        $plainTextToken = $employee->claimMobileToken($request->userAgent());
 
         Log::info("Celular vinculado para el empleado #{$employee->id} ({$employee->first_name} {$employee->last_name})", [
             'employee_id' => $employee->id,

--- a/app/Models/AttendanceMarkFailure.php
+++ b/app/Models/AttendanceMarkFailure.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\SyncConflictPendingNotification;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -177,16 +178,26 @@ class AttendanceMarkFailure extends Model
     }
 
     /**
-     * Crea y persiste un registro de fallo de marcación.
+     * Crea y persiste un registro de fallo de marcación. Los conflictos de
+     * sincronización (`sync_conflict`) además notifican a todos los admins —
+     * es el único tipo de fallo que requiere revisión manual obligatoria
+     * (ver `canBeResolved()`); el resto (`face_no_match`, etc.) son
+     * demasiado frecuentes en el uso normal como para notificar cada uno.
      *
      * @param  array<string, mixed>  $data
      */
     public static function record(array $data): static
     {
-        return static::create(array_merge(
+        $failure = static::create(array_merge(
             ['occurred_at' => now()],
             $data,
         ));
+
+        if ($failure->failure_type === 'sync_conflict') {
+            User::all()->each(fn (User $user) => $user->notify(new SyncConflictPendingNotification($failure)));
+        }
+
+        return $failure;
     }
 
     /**

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
 use App\Settings\PayrollSettings;
 use Carbon\Carbon;
@@ -1189,21 +1190,23 @@ class Employee extends Model implements AuthenticatableContract
      *
      * @return string Token Sanctum en texto plano — solo se retorna una vez, nunca se persiste en claro.
      */
-    public function claimMobileToken(): string
+    public function claimMobileToken(?string $userAgent = null): string
     {
         // Se evalúa antes de pisar mobile_linked_at — distingue una vinculación
-        // nueva (sin aviso, es el flujo normal) de una re-vinculación (ver
-        // MobileDeviceRelinkedNotification: CI+fecha es una credencial débil,
-        // esto da visibilidad a un admin ante un posible acoso/DoS dirigido).
+        // nueva (informativa) de una re-vinculación (ver MobileDeviceRelinkedNotification:
+        // CI+fecha es una credencial débil, esto da visibilidad a un admin ante un
+        // posible acoso/DoS dirigido).
         $isRelink = $this->hasMobileLinked();
 
         $this->tokens()->where('name', 'like', 'mobile:%')->delete();
 
         $this->forceFill(['mobile_linked_at' => now()])->save();
 
-        if ($isRelink) {
-            User::all()->each(fn (User $user) => $user->notify(new MobileDeviceRelinkedNotification($this)));
-        }
+        $notification = $isRelink
+            ? new MobileDeviceRelinkedNotification($this, $userAgent)
+            : new MobileDeviceLinkedNotification($this, $userAgent);
+
+        User::all()->each(fn (User $user) => $user->notify($notification));
 
         return $this->createToken('mobile:'.$this->id, [self::MOBILE_SYNC_ABILITY])->plainTextToken;
     }

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\TerminalProvisionedNotification;
 use App\Settings\GeneralSettings;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -382,6 +383,8 @@ class Terminal extends Model implements AuthenticatableContract
             'setup_token' => null,
             'setup_token_expires_at' => null,
         ])->save();
+
+        User::all()->each(fn (User $user) => $user->notify(new TerminalProvisionedNotification($this)));
 
         return $this->createToken('kiosk:'.$this->code, [self::SYNC_ABILITY])->plainTextToken;
     }

--- a/app/Notifications/FaceEnrollmentPendingApprovalNotification.php
+++ b/app/Notifications/FaceEnrollmentPendingApprovalNotification.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Filament\Resources\FaceEnrollmentResource;
+use App\Models\FaceEnrollment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notificación a los admins cuando un empleado completa el autoenrolamiento
+ * facial (`/registro-facial`) y el registro queda en `pending_approval`.
+ * Sin esto, la única forma de enterarse de que hay una solicitud esperando
+ * revisión era entrar a `FaceEnrollmentResource` a mirar manualmente.
+ */
+class FaceEnrollmentPendingApprovalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly FaceEnrollment $enrollment,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        $employee = $this->enrollment->employee;
+        $employeeLabel = $employee ? "{$employee->full_name} (CI: {$employee->ci})" : 'un empleado';
+
+        return [
+            'title' => 'Autoenrolamiento facial pendiente de aprobación',
+            'body' => "{$employeeLabel} completó la captura de su rostro y está esperando que apruebes o rechaces la solicitud.",
+            'icon' => 'heroicon-o-face-smile',
+            'color' => 'warning',
+            'actions' => [
+                [
+                    'label' => 'Revisar solicitud',
+                    'url' => FaceEnrollmentResource::getUrl('index'),
+                ],
+            ],
+            'enrollment_id' => $this->enrollment->id,
+        ];
+    }
+}

--- a/app/Notifications/MobileDeviceLinkedNotification.php
+++ b/app/Notifications/MobileDeviceLinkedNotification.php
@@ -8,17 +8,12 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
 /**
- * Notificación a los admins cuando el celular vinculado de un empleado se
- * re-vincula (había un dispositivo ya vinculado y se reemplazó por otro).
- *
- * CI + fecha de nacimiento es una credencial débil (baja entropía) — alguien
- * con esos datos de otro empleado podría re-vincular su propio celular y así
- * revocar silenciosamente el dispositivo legítimo (denegación de servicio
- * dirigida). Esta notificación no previene el ataque, pero da visibilidad
- * para que un admin investigue una re-vinculación que el empleado no
- * reconoce (ver runbook de vinculación/revocación de celulares).
+ * Notificación a los admins cuando un empleado vincula su celular por
+ * primera vez (sin dispositivo previo) para marcación offline. A diferencia
+ * de `MobileDeviceRelinkedNotification` (tono de advertencia, posible
+ * incidente de seguridad), esta es puramente informativa.
  */
-class MobileDeviceRelinkedNotification extends Notification
+class MobileDeviceLinkedNotification extends Notification
 {
     use Queueable;
 
@@ -40,17 +35,17 @@ class MobileDeviceRelinkedNotification extends Notification
      */
     public function toDatabase(object $notifiable): array
     {
-        $body = "El celular vinculado de {$this->employee->full_name} (CI: {$this->employee->ci}) fue reemplazado por uno nuevo. Si el empleado no reconoce este cambio, revocá el acceso desde su ficha.";
+        $body = "{$this->employee->full_name} (CI: {$this->employee->ci}) vinculó su celular para marcar asistencia offline.";
 
         if (filled($this->userAgent)) {
-            $body .= " Dispositivo nuevo: {$this->userAgent}";
+            $body .= " Dispositivo: {$this->userAgent}";
         }
 
         return [
-            'title' => 'Celular re-vinculado',
+            'title' => 'Celular vinculado',
             'body' => $body,
             'icon' => 'heroicon-o-device-phone-mobile',
-            'color' => 'warning',
+            'color' => 'success',
             'actions' => [
                 [
                     'label' => 'Ver empleado',

--- a/app/Notifications/SyncConflictPendingNotification.php
+++ b/app/Notifications/SyncConflictPendingNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Filament\Resources\AttendanceMarkFailureResource;
+use App\Models\AttendanceMarkFailure;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notificación a los admins cuando se registra un conflicto de
+ * sincronización offline (`AttendanceMarkFailure` con `failure_type:
+ * sync_conflict`) — kiosko o celular sincronizó una marcación que ya no es
+ * válida contra el estado actual del servidor. Sin esto, el registro queda
+ * en `AttendanceMarkFailureResource` sin que nadie se entere hasta que un
+ * admin entra a mirar manualmente — justo el gap identificado al probar en
+ * producción.
+ */
+class SyncConflictPendingNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly AttendanceMarkFailure $failure,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        $employee = $this->failure->employee;
+        $employeeLabel = $employee ? "{$employee->full_name} (CI: {$employee->ci})" : 'un empleado';
+        $modeLabel = AttendanceMarkFailure::getModeLabel($this->failure->mode);
+
+        return [
+            'title' => 'Conflicto al sincronizar una marcación offline',
+            'body' => "Una marcación de {$employeeLabel} desde {$modeLabel} no se pudo aplicar al reconectarse — la secuencia ya no era válida en el servidor. Requiere revisión manual.",
+            'icon' => 'heroicon-o-exclamation-triangle',
+            'color' => 'danger',
+            'actions' => [
+                [
+                    'label' => 'Revisar conflicto',
+                    'url' => AttendanceMarkFailureResource::getUrl('view', ['record' => $this->failure]),
+                ],
+            ],
+            'failure_id' => $this->failure->id,
+        ];
+    }
+}

--- a/app/Notifications/TerminalProvisionedNotification.php
+++ b/app/Notifications/TerminalProvisionedNotification.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Filament\Resources\TerminalResource;
+use App\Models\Terminal;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notificación a los admins cuando un kiosko/terminal completa su
+ * provisión (reclama el enlace de configuración de un solo uso y recibe
+ * su token Sanctum) — confirma que la instalación física salió bien sin
+ * que un admin tenga que entrar a revisar `last_heartbeat_at` a mano.
+ */
+class TerminalProvisionedNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Terminal $terminal,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'title' => 'Terminal provisionado',
+            'body' => "El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.",
+            'icon' => 'heroicon-o-computer-desktop',
+            'color' => 'success',
+            'actions' => [
+                [
+                    'label' => 'Ver terminal',
+                    'url' => TerminalResource::getUrl('view', ['record' => $this->terminal]),
+                ],
+            ],
+            'terminal_id' => $this->terminal->id,
+        ];
+    }
+}

--- a/tests/Feature/AdminNotificationsTest.php
+++ b/tests/Feature/AdminNotificationsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Filament\Resources\AttendanceMarkFailureResource;
+use App\Filament\Resources\EmployeeResource;
+use App\Filament\Resources\TerminalResource;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\FaceEnrollment;
+use App\Models\Position;
+use App\Models\Terminal;
+use App\Models\User;
+use App\Notifications\FaceEnrollmentPendingApprovalNotification;
+use App\Notifications\MobileDeviceLinkedNotification;
+use App\Notifications\MobileDeviceRelinkedNotification;
+use App\Notifications\SyncConflictPendingNotification;
+use App\Notifications\TerminalProvisionedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeNotifiableEmployee(): Employee
+{
+    static $ci = 9700000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Notif {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Notif {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Notif {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Notif {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Notif', 'last_name' => 'Test', 'ci' => (string) $n,
+        'birth_date' => '1990-05-15', 'email' => "notif{$n}@test.com",
+        'branch_id' => $branch->id, 'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id, 'type' => 'indefinido', 'start_date' => now()->subYear(),
+        'salary_type' => 'mensual', 'salary' => 2_550_000, 'position_id' => $position->id,
+        'department_id' => $department->id, 'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Terminal provisionado ──────────────────────────────────────────────────
+
+it('notifica a los admins cuando un terminal completa su provisión', function () {
+    $employee = makeNotifiableEmployee();
+    $admin = User::create(['name' => 'Admin', 'email' => 'admin-term@test.com', 'password' => bcrypt('secret')]);
+    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+
+    Notification::fake();
+    $terminal->claimSanctumToken();
+
+    Notification::assertSentTo(
+        $admin,
+        TerminalProvisionedNotification::class,
+        fn ($notification) => $notification->terminal->is($terminal)
+    );
+});
+
+it('la url de la notificación de terminal apunta al detalle real del recurso', function () {
+    $employee = makeNotifiableEmployee();
+    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+
+    $notification = new TerminalProvisionedNotification($terminal);
+    $data = $notification->toDatabase(new User);
+
+    expect($data['actions'][0]['url'])->toBe(TerminalResource::getUrl('view', ['record' => $terminal]));
+});
+
+// ─── Autoenrolamiento pendiente de aprobación ──────────────────────────────
+
+it('notifica a los admins cuando un empleado completa el autoenrolamiento facial', function () {
+    $employee = makeNotifiableEmployee();
+    $admin = User::create(['name' => 'Admin', 'email' => 'admin-enroll@test.com', 'password' => bcrypt('secret')]);
+
+    $enrollment = FaceEnrollment::create([
+        'employee_id' => $employee->id,
+        'token' => Str::random(40),
+        'status' => 'pending_capture',
+        'expires_at' => now()->addHours(48),
+    ]);
+
+    Notification::fake();
+
+    $this->postJson("/registro-facial/{$enrollment->token}", [
+        'face_descriptor' => array_fill(0, 128, 0.2),
+    ])->assertOk();
+
+    Notification::assertSentTo(
+        $admin,
+        FaceEnrollmentPendingApprovalNotification::class,
+        fn ($notification) => $notification->enrollment->is($enrollment->fresh())
+    );
+});
+
+// ─── Conflicto de sync pendiente ───────────────────────────────────────────
+
+it('notifica a los admins cuando se registra un conflicto de sincronización', function () {
+    $employee = makeNotifiableEmployee();
+    $admin = User::create(['name' => 'Admin', 'email' => 'admin-conflict@test.com', 'password' => bcrypt('secret')]);
+
+    Notification::fake();
+
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'mobile',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'branch_id' => $employee->branch_id,
+        'attempted_event_type' => 'break_start',
+        'failure_message' => 'test',
+    ]);
+
+    Notification::assertSentTo(
+        $admin,
+        SyncConflictPendingNotification::class,
+        fn ($notification) => $notification->failure->is($failure)
+    );
+});
+
+it('no notifica a los admins por fallos que no son conflictos de sincronización', function () {
+    User::create(['name' => 'Admin', 'email' => 'admin-noconflict@test.com', 'password' => bcrypt('secret')]);
+
+    Notification::fake();
+
+    AttendanceMarkFailure::record([
+        'mode' => 'terminal',
+        'failure_type' => 'face_no_match',
+        'failure_message' => 'test',
+    ]);
+
+    Notification::assertNothingSent();
+});
+
+it('la url de la notificación de conflicto apunta al detalle real del fallo', function () {
+    $employee = makeNotifiableEmployee();
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'mobile',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'branch_id' => $employee->branch_id,
+        'attempted_event_type' => 'break_start',
+    ]);
+
+    $notification = new SyncConflictPendingNotification($failure);
+    $data = $notification->toDatabase(new User);
+
+    expect($data['actions'][0]['url'])->toBe(AttendanceMarkFailureResource::getUrl('view', ['record' => $failure]));
+});
+
+// ─── Fix de URL en notificaciones de celular ───────────────────────────────
+
+it('las notificaciones de celular apuntan a la ficha real del empleado', function () {
+    $employee = makeNotifiableEmployee();
+
+    $linked = new MobileDeviceLinkedNotification($employee);
+    $relinked = new MobileDeviceRelinkedNotification($employee);
+
+    $expectedUrl = EmployeeResource::getUrl('view', ['record' => $employee]);
+
+    expect($linked->toDatabase(new User)['actions'][0]['url'])->toBe($expectedUrl)
+        ->and($relinked->toDatabase(new User)['actions'][0]['url'])->toBe($expectedUrl);
+});

--- a/tests/Feature/AdminNotificationsTest.php
+++ b/tests/Feature/AdminNotificationsTest.php
@@ -150,6 +150,7 @@ it('la url de la notificación de conflicto apunta al detalle real del fallo', f
         'employee_id' => $employee->id,
         'branch_id' => $employee->branch_id,
         'attempted_event_type' => 'break_start',
+        'failure_message' => 'test',
     ]);
 
     $notification = new SyncConflictPendingNotification($failure);

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -9,6 +9,7 @@ use App\Models\Employee;
 use App\Models\Position;
 use App\Models\Terminal;
 use App\Models\User;
+use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
@@ -220,9 +221,9 @@ it('un token de terminal no puede usar las rutas móviles (ability distinta)', f
 
 // ─── Hardening (Fase 4) ─────────────────────────────────────────────────────
 
-it('no notifica a los admins en la primera vinculación', function () {
+it('notifica a los admins (sin advertencia) en la primera vinculación', function () {
     Notification::fake();
-    User::create(['name' => 'Admin', 'email' => 'admin-first@test.com', 'password' => bcrypt('secret')]);
+    $admin = User::create(['name' => 'Admin', 'email' => 'admin-first@test.com', 'password' => bcrypt('secret')]);
 
     $employee = makeLinkableEmployee();
 
@@ -231,7 +232,12 @@ it('no notifica a los admins en la primera vinculación', function () {
         'birth_date' => '1990-05-15',
     ])->assertOk();
 
-    Notification::assertNothingSent();
+    Notification::assertSentTo(
+        $admin,
+        MobileDeviceLinkedNotification::class,
+        fn ($notification) => $notification->employee->is($employee)
+    );
+    Notification::assertNotSentTo($admin, MobileDeviceRelinkedNotification::class);
 });
 
 it('notifica a todos los admins cuando un celular ya vinculado se re-vincula', function () {


### PR DESCRIPTION
## Resumen

Dos cambios encontrados/priorizados probando la marcación offline en `nextup-demo`:

### 1. Fix — 500 al ver el detalle de un fallo de marcación en conflicto

`GET /fallos-marcacion/{id}` devolvía `500 Server Error` para cualquier fallo de tipo `sync_conflict`. `KeyValueEntry` de Filament renderiza cada valor con `{{ $value }}` (Blade llama `htmlspecialchars()`), que revienta si el valor no es un string — y el `metadata` de un `sync_conflict` incluye `allowed_events` (array) y `location` (array o `null`). Se serializan a JSON los valores no-escalares antes de pasarlos al componente.

### 2. Notificaciones al admin para 4 eventos de marcación offline

Cierra el gap de visibilidad detectado probando: varios eventos pasaban sin que ningún admin se enterara salvo entrando a revisar manualmente cada resource.

- **Terminal provisionado** — el kiosko completó su configuración inicial.
- **Autoenrolamiento facial pendiente de aprobación** — el empleado capturó su rostro vía `/registro-facial` y queda en `pending_approval`.
- **Celular vinculado por primera vez** — informativa, distinta en tono de la ya existente `MobileDeviceRelinkedNotification` (esa sigue siendo de advertencia/seguridad).
- **Conflicto de sincronización offline pendiente de revisión** — gatillada desde `AttendanceMarkFailure::record()`, filtrada a solo `failure_type: sync_conflict` (el resto de los tipos de fallo son demasiado frecuentes en el uso normal como para notificar cada uno).

De paso, un bug real preexistente: `MobileDeviceRelinkedNotification` apuntaba a `/admin/empleados/{id}`, una URL que nunca funcionó (el panel vive en la raíz del sitio, no en `/admin`, y el slug real del resource es `employees`). Las 5 notificaciones (las 4 nuevas + la corregida) ahora usan `Resource::getUrl()` en vez de rutas hardcodeadas.

## Test plan

- [x] Verificación end-to-end contra BD SQLite de scratch: los 5 disparadores (link, re-link, terminal, enrollment, conflicto) generan la notificación correcta con título/URL correctos; confirmado que `face_no_match` (no es conflicto) **no** dispara notificación.
- [x] Tests Pest nuevos en `tests/Feature/AdminNotificationsTest.php` (7 casos) usando `Notification::fake()` — mismo patrón que el test de re-vinculación ya existente.
- [x] Actualizado un test existente (`MobileAttendanceLinkTest.php`) que asumía "sin notificación en la primera vinculación" — ahora sí notifica (`MobileDeviceLinkedNotification`), se corrigió la aserción.
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin errores.
- [ ] No se pudo correr `php artisan test` en este sandbox (sin MySQL) — correrá en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH
