### PR TITLE
Alta de empleados — UX del form individual + creación masiva

### DIFF
--- a/app/Exports/EmployeesTemplateExport.php
+++ b/app/Exports/EmployeesTemplateExport.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * Genera la plantilla Excel en blanco para la creación masiva de empleados
+ * (v1: solo datos básicos — sin contrato ni enrolamiento facial, cada
+ * empleado importado queda listo para que un admin le complete el contrato
+ * después, igual que la sección opcional "Contrato Inicial" en el alta
+ * individual).
+ *
+ * Deliberadamente SIN fila de ejemplo: `EmployeesImport` arranca a leer en
+ * la fila 2 (después del encabezado) — una fila de ejemplo ahí se
+ * importaría como un empleado real si el admin se olvida de borrarla. El
+ * formato esperado se explica en el texto del modal de descarga, no en el
+ * archivo.
+ */
+class EmployeesTemplateExport implements FromCollection, ShouldAutoSize, WithHeadings, WithStyles
+{
+    /**
+     * @return Collection<int, array<int, string>>
+     */
+    public function collection(): Collection
+    {
+        return collect();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function headings(): array
+    {
+        return ['CI', 'Nombre(s)', 'Apellido(s)', 'Fecha de Nacimiento (DD/MM/AAAA)', 'Género', 'Sucursal', 'Teléfono', 'Email', 'Nacionalidad'];
+    }
+
+    /**
+     * Encabezado en negrita con fondo gris.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function styles(Worksheet $sheet): array
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true],
+                'fill' => [
+                    'fillType' => Fill::FILL_SOLID,
+                    'startColor' => ['rgb' => 'D9D9D9'],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Filament/Resources/EmployeeResource.php
+++ b/app/Filament/Resources/EmployeeResource.php
@@ -67,6 +67,35 @@ class EmployeeResource extends Resource
     protected static ?int $navigationSort = 1;
 
     /**
+     * Resuelve el `company_id` a partir de un `branch_id` — usado para
+     * filtrar departamento/cargo del contrato inicial por la empresa
+     * elegida, mismo criterio que ya aplica `ContractsRelationManager`
+     * al editar (ahí vía `$this->getOwnerRecord()->branch?->company_id`).
+     */
+    private static function companyIdFromBranch(mixed $branchId): ?int
+    {
+        return $branchId ? Branch::find($branchId)?->company_id : null;
+    }
+
+    /**
+     * Indica si la CI actualmente cargada en el form ya pertenece a otro
+     * empleado — usado para el aviso en vivo del campo `ci` (antes de que
+     * la validación `unique()` recién se dispare al hacer submit).
+     */
+    private static function ciDuplicateWarning(Get $get, ?Employee $record): bool
+    {
+        $ci = $get('ci');
+
+        if (blank($ci)) {
+            return false;
+        }
+
+        return Employee::where('ci', $ci)
+            ->when($record, fn ($q) => $q->where('id', '!=', $record->id))
+            ->exists();
+    }
+
+    /**
      * Define el formulario para crear y editar empleados.
      */
     public static function form(Form $form): Form
@@ -107,7 +136,11 @@ class EmployeeResource extends Resource
                                             ->step(1)
                                             ->required()
                                             ->unique(Employee::class, 'ci', ignoreRecord: true)
-                                            ->helperText('Número sin puntos ni guiones.'),
+                                            ->helperText('Número sin puntos ni guiones.')
+                                            ->live(onBlur: true)
+                                            ->hint(fn (Get $get, ?Employee $record) => static::ciDuplicateWarning($get, $record) ? 'Ya existe un empleado con esta CI' : null)
+                                            ->hintColor('danger')
+                                            ->hintIcon(fn (Get $get, ?Employee $record) => static::ciDuplicateWarning($get, $record) ? 'heroicon-o-exclamation-triangle' : null),
 
                                         TextInput::make('first_name')
                                             ->label('Nombre(s)')
@@ -196,6 +229,7 @@ class EmployeeResource extends Resource
                             ->native(false)
                             ->live()
                             ->dehydrated(false)
+                            ->default(fn () => Company::active()->count() === 1 ? Company::active()->value('id') : null)
                             ->afterStateUpdated(fn (callable $set) => $set('branch_id', null))
                             ->helperText('Seleccioná la empresa para filtrar las sucursales.')
                             ->afterStateHydrated(function (callable $set, callable $get) {
@@ -219,6 +253,12 @@ class EmployeeResource extends Resource
                             ->searchable()
                             ->native(false)
                             ->required()
+                            ->default(function (callable $get) {
+                                $companyId = $get('company_id');
+                                $query = Branch::when($companyId, fn ($q) => $q->where('company_id', $companyId));
+
+                                return $query->count() === 1 ? $query->value('id') : null;
+                            })
                             ->helperText('Sucursal donde trabaja el empleado.'),
 
                         Select::make('reports_to_id')
@@ -376,11 +416,18 @@ class EmployeeResource extends Resource
                         Grid::make(2)->schema([
                             Select::make('ic_department_id')
                                 ->label('Departamento')
-                                ->options(fn () => Department::orderBy('name')->pluck('name', 'id'))
+                                ->options(function (Get $get) {
+                                    $companyId = static::companyIdFromBranch($get('branch_id'));
+
+                                    return Department::when($companyId, fn ($q) => $q->where('company_id', $companyId))
+                                        ->orderBy('name')
+                                        ->pluck('name', 'id');
+                                })
                                 ->searchable()
                                 ->native(false)
                                 ->live()
                                 ->afterStateUpdated(fn (Set $set) => $set('ic_position_id', null))
+                                ->helperText('Solo se muestran los departamentos de la empresa seleccionada arriba.')
                                 ->dehydrated(false),
 
                             Select::make('ic_position_id')
@@ -388,9 +435,22 @@ class EmployeeResource extends Resource
                                 ->options(function (Get $get) {
                                     $deptId = $get('ic_department_id');
 
-                                    return $deptId
-                                        ? Position::where('department_id', $deptId)->orderBy('name')->pluck('name', 'id')->toArray()
-                                        : Position::getOptionsWithDepartment();
+                                    if ($deptId) {
+                                        return Position::where('department_id', $deptId)->orderBy('name')->pluck('name', 'id')->toArray();
+                                    }
+
+                                    $companyId = static::companyIdFromBranch($get('branch_id'));
+
+                                    return Position::query()
+                                        ->when($companyId, fn ($q) => $q->whereHas('department', fn ($d) => $d->where('company_id', $companyId)))
+                                        ->with('department')
+                                        ->get()
+                                        ->mapWithKeys(fn ($position) => [
+                                            $position->id => $position->department
+                                                ? "{$position->name} - {$position->department->name}"
+                                                : $position->name,
+                                        ])
+                                        ->toArray();
                                 })
                                 ->searchable()
                                 ->native(false)

--- a/app/Filament/Resources/EmployeeResource/Pages/ListEmployees.php
+++ b/app/Filament/Resources/EmployeeResource/Pages/ListEmployees.php
@@ -2,14 +2,23 @@
 
 namespace App\Filament\Resources\EmployeeResource\Pages;
 
+use App\Exports\EmployeesTemplateExport;
 use App\Filament\Pages\EmployeeReport;
 use App\Filament\Resources\EmployeeResource;
+use App\Imports\EmployeesImport;
 use App\Models\Employee;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\CreateAction;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Placeholder;
+use Filament\Notifications\Notification;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\HtmlString;
+use Maatwebsite\Excel\Facades\Excel;
 
 class ListEmployees extends ListRecords
 {
@@ -26,6 +35,90 @@ class ListEmployees extends ListRecords
                 ->icon('heroicon-o-chart-bar')
                 ->color('gray')
                 ->url(EmployeeReport::getUrl()),
+
+            ActionGroup::make([
+                Action::make('download_employees_template')
+                    ->label('Descargar Plantilla')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('gray')
+                    ->action(fn () => Excel::download(
+                        new EmployeesTemplateExport,
+                        'plantilla_empleados_'.now()->format('Y_m_d_H_i_s').'.xlsx'
+                    )),
+
+                Action::make('import_employees')
+                    ->label('Importar Empleados')
+                    ->icon('heroicon-o-arrow-up-tray')
+                    ->color('gray')
+                    ->modalHeading('Creación Masiva de Empleados')
+                    ->modalSubmitActionLabel('Importar')
+                    ->form([
+                        Placeholder::make('import_info')
+                            ->label('')
+                            ->content(new HtmlString(
+                                '<p class="text-sm text-gray-600 dark:text-gray-400">'.
+                                'Subí el archivo Excel completado a partir de la plantilla. '.
+                                'Se crearán empleados <strong>activos</strong> con los datos básicos para las filas válidas '.
+                                '(CI, nombre, apellido, fecha de nacimiento, género y sucursal son obligatorios). '.
+                                'El contrato, horario y enrolamiento facial se completan después desde la ficha de cada empleado. '.
+                                'La sucursal debe coincidir exactamente con el nombre registrado en el sistema.'.
+                                '</p>'
+                            )),
+
+                        FileUpload::make('file')
+                            ->label('Archivo Excel (.xlsx)')
+                            ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'])
+                            ->required()
+                            ->disk('local')
+                            ->directory('imports/employees')
+                            ->maxSize(5120),
+                    ])
+                    ->action(function (array $data) {
+                        $path = Storage::disk('local')->path($data['file']);
+
+                        $import = new EmployeesImport;
+                        Excel::import($import, $path);
+
+                        Storage::disk('local')->delete($data['file']);
+
+                        $created = $import->created;
+                        $failures = $import->failures;
+
+                        if ($created === 0 && count($failures) === 0) {
+                            Notification::make()
+                                ->warning()
+                                ->title('Sin datos')
+                                ->body('El archivo no contenía filas para procesar.')
+                                ->send();
+
+                            return;
+                        }
+
+                        $body = "Se crearon {$created} empleado(s) activo(s).";
+
+                        if (count($failures) > 0) {
+                            $lines = array_map(
+                                fn ($f) => "• Fila {$f['row']} ({$f['name']}): {$f['reason']}",
+                                array_slice($failures, 0, 10)
+                            );
+                            if (count($failures) > 10) {
+                                $lines[] = '… y '.(count($failures) - 10).' más.';
+                            }
+                            $body .= ' '.count($failures).' fila(s) con error:<br>'.implode('<br>', $lines);
+                        }
+
+                        Notification::make()
+                            ->title('Importación Completada')
+                            ->body(new HtmlString($body))
+                            ->{count($failures) > 0 ? 'warning' : 'success'}()
+                            ->send()
+                            ->persistent();
+                    }),
+            ])
+                ->label('Creación masiva')
+                ->icon('heroicon-o-square-3-stack-3d')
+                ->color('warning')
+                ->button(),
 
             CreateAction::make()
                 ->label('Nuevo Empleado')

--- a/app/Imports/EmployeesImport.php
+++ b/app/Imports/EmployeesImport.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Imports;
+
+use App\Models\Branch;
+use App\Models\Employee;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\ToCollection;
+use Maatwebsite\Excel\Concerns\WithStartRow;
+use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
+use Throwable;
+
+/**
+ * Procesa la creación masiva de empleados desde el Excel plantilla (v1:
+ * solo datos básicos — sin contrato inicial ni enrolamiento facial, ver
+ * `EmployeesTemplateExport`). Cada empleado se crea con `status: active`;
+ * el contrato se completa después desde la ficha del empleado, igual que
+ * si se hubiera creado sin la sección opcional "Contrato Inicial" en el
+ * alta individual.
+ */
+class EmployeesImport implements ToCollection, WithStartRow
+{
+    /** @var int Cantidad de empleados creados exitosamente. */
+    public int $created = 0;
+
+    /**
+     * Lista de filas fallidas con nombre de referencia y motivo.
+     *
+     * @var array<int, array{row: int, name: string, reason: string}>
+     */
+    public array $failures = [];
+
+    /**
+     * Comienza a leer desde la fila 2 (la 1 es el encabezado) — la plantilla
+     * generada por `EmployeesTemplateExport` no incluye fila de ejemplo,
+     * así que no hace falta saltear ninguna fila adicional.
+     */
+    public function startRow(): int
+    {
+        return 2;
+    }
+
+    /**
+     * Procesa cada fila del archivo y crea los empleados válidos.
+     *
+     * Columnas esperadas:
+     *  0 = CI, 1 = Nombre(s), 2 = Apellido(s), 3 = Fecha de nacimiento,
+     *  4 = Género, 5 = Sucursal, 6 = Teléfono, 7 = Email, 8 = Nacionalidad
+     *
+     * @param  Collection<int, Collection<int, mixed>>  $rows
+     */
+    public function collection(Collection $rows): void
+    {
+        foreach ($rows as $index => $row) {
+            $rowNum = $index + 2;
+
+            $ciRaw = trim((string) ($row[0] ?? ''));
+            $firstName = trim((string) ($row[1] ?? ''));
+            $lastName = trim((string) ($row[2] ?? ''));
+            $branchName = trim((string) ($row[5] ?? ''));
+
+            // Fila completamente vacía — se salta en silencio (no es un error de datos).
+            if ($ciRaw === '' && $firstName === '' && $lastName === '') {
+                continue;
+            }
+
+            $name = trim("{$firstName} {$lastName}") ?: ($ciRaw !== '' ? "CI {$ciRaw}" : "Fila {$rowNum}");
+
+            if ($ciRaw === '') {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => 'CI vacío'];
+
+                continue;
+            }
+
+            if ($firstName === '' || $lastName === '') {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => 'Nombre y apellido son obligatorios'];
+
+                continue;
+            }
+
+            // Se sanitiza recién acá (no antes) — sanitizeFormData() convierte una CI
+            // vacía en '0', lo que rompería el chequeo de "CI vacío" de arriba.
+            $sanitized = Employee::sanitizeFormData([
+                'ci' => $ciRaw,
+                'first_name' => $firstName,
+                'last_name' => $lastName,
+                'phone' => trim((string) ($row[6] ?? '')),
+                'email' => trim((string) ($row[7] ?? '')),
+            ], isCreating: true);
+
+            $ci = $sanitized['ci'];
+
+            if (Employee::where('ci', $ci)->exists()) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Ya existe un empleado con CI {$ci}"];
+
+                continue;
+            }
+
+            $birthDate = $this->parseDate($row[3] ?? null);
+
+            if (! $birthDate) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => 'Fecha de nacimiento inválida — usar formato DD/MM/AAAA'];
+
+                continue;
+            }
+
+            if ($birthDate->gt(now()->subYears(18))) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => 'El empleado debe ser mayor de 18 años'];
+
+                continue;
+            }
+
+            $gender = $this->resolveGender($row[4] ?? '');
+
+            if (! $gender) {
+                $genderRaw = trim((string) ($row[4] ?? ''));
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Género inválido: '{$genderRaw}' — usar Masculino o Femenino"];
+
+                continue;
+            }
+
+            $branch = Branch::whereRaw('LOWER(name) = ?', [mb_strtolower($branchName)])->first();
+
+            if (! $branch) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Sucursal no encontrada: '{$branchName}'"];
+
+                continue;
+            }
+
+            if (filled($sanitized['email']) && Employee::where('email', $sanitized['email'])->exists()) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Ya existe un empleado con el email {$sanitized['email']}"];
+
+                continue;
+            }
+
+            $nationality = trim((string) ($row[8] ?? ''));
+
+            Employee::create([
+                'ci' => $ci,
+                'first_name' => $sanitized['first_name'],
+                'last_name' => $sanitized['last_name'],
+                'birth_date' => $birthDate,
+                'gender' => $gender,
+                'branch_id' => $branch->id,
+                'phone' => $sanitized['phone'],
+                'email' => $sanitized['email'],
+                'nationality' => $nationality !== '' ? $nationality : 'Paraguaya',
+                'status' => 'active',
+                'face_descriptor' => null,
+            ]);
+
+            $this->created++;
+        }
+    }
+
+    /**
+     * Interpreta la celda de fecha de nacimiento — puede llegar como
+     * instancia de fecha (celda formateada como fecha en Excel), número de
+     * serie de Excel (celda sin formato de fecha), o texto DD/MM/AAAA
+     * (planillas CSV o pegadas como texto).
+     */
+    private function parseDate(mixed $raw): ?Carbon
+    {
+        if ($raw instanceof \DateTimeInterface) {
+            return Carbon::instance($raw)->startOfDay();
+        }
+
+        $raw = trim((string) $raw);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        if (is_numeric($raw)) {
+            try {
+                return Carbon::instance(ExcelDate::excelToDateTimeObject((float) $raw))->startOfDay();
+            } catch (Throwable) {
+                // Era un número pero no una fecha de Excel válida — cae a los formatos de texto.
+            }
+        }
+
+        foreach (['d/m/Y', 'd-m-Y', 'Y-m-d'] as $format) {
+            $date = Carbon::createFromFormat('!'.$format, $raw);
+
+            if ($date !== false) {
+                return $date->startOfDay();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Normaliza el género a los valores internos (`Employee::getGenderOptions()`).
+     */
+    private function resolveGender(mixed $raw): ?string
+    {
+        $raw = mb_strtolower(trim((string) $raw));
+
+        return match ($raw) {
+            'masculino', 'm', 'male' => 'masculino',
+            'femenino', 'f', 'female' => 'femenino',
+            default => null,
+        };
+    }
+}

--- a/app/Imports/EmployeesImport.php
+++ b/app/Imports/EmployeesImport.php
@@ -128,8 +128,15 @@ class EmployeesImport implements ToCollection, WithStartRow
                 continue;
             }
 
-            if (filled($sanitized['email']) && Employee::where('email', $sanitized['email'])->exists()) {
-                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Ya existe un empleado con el email {$sanitized['email']}"];
+            // sanitizeFormData() normaliza el email a string (nunca a null) aunque
+            // venga vacío — a diferencia de 'phone', que sí lo hace. Sin este
+            // ajuste, dos filas sin email insertarían '' en ambas, lo que en
+            // MySQL real (a diferencia de SQLite) viola el unique constraint de
+            // la columna (empresa con varios empleados sin email cargado).
+            $email = filled($sanitized['email']) ? $sanitized['email'] : null;
+
+            if ($email && Employee::where('email', $email)->exists()) {
+                $this->failures[] = ['row' => $rowNum, 'name' => $name, 'reason' => "Ya existe un empleado con el email {$email}"];
 
                 continue;
             }
@@ -144,7 +151,7 @@ class EmployeesImport implements ToCollection, WithStartRow
                 'gender' => $gender,
                 'branch_id' => $branch->id,
                 'phone' => $sanitized['phone'],
-                'email' => $sanitized['email'],
+                'email' => $email,
                 'nationality' => $nationality !== '' ? $nationality : 'Paraguaya',
                 'status' => 'active',
                 'face_descriptor' => null,
@@ -181,10 +188,13 @@ class EmployeesImport implements ToCollection, WithStartRow
         }
 
         foreach (['d/m/Y', 'd-m-Y', 'Y-m-d'] as $format) {
-            $date = Carbon::createFromFormat('!'.$format, $raw);
-
-            if ($date !== false) {
-                return $date->startOfDay();
+            try {
+                // En modo estricto (Carbon 3) createFromFormat() lanza
+                // InvalidFormatException en vez de retornar false cuando el
+                // string no matchea — a diferencia de Carbon 2.
+                return Carbon::createFromFormat('!'.$format, $raw)->startOfDay();
+            } catch (Throwable) {
+                continue;
             }
         }
 

--- a/tests/Feature/EmployeeFormDefaultsTest.php
+++ b/tests/Feature/EmployeeFormDefaultsTest.php
@@ -59,8 +59,9 @@ it('no preselecciona sucursal cuando la empresa tiene más de una', function () 
 it('avisa en vivo si la CI ya está en uso por otro empleado', function () {
     $this->actingAs(User::factory()->create());
 
-    $branch = Branch::factory()->create();
-    Employee::factory()->create(['ci' => '5551234', 'branch_id' => $branch->id]);
+    $company = Company::create(['name' => 'Empresa Hint', 'ruc' => '9-9', 'employer_number' => 9]);
+    $branch = Branch::create(['name' => 'Sucursal Hint', 'company_id' => $company->id]);
+    Employee::create(['first_name' => 'Existente', 'last_name' => 'X', 'ci' => '5551234', 'branch_id' => $branch->id, 'status' => 'active']);
 
     $field = Livewire::test(CreateEmployee::class)
         ->set('data.ci', '5551234')

--- a/tests/Feature/EmployeeFormDefaultsTest.php
+++ b/tests/Feature/EmployeeFormDefaultsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Filament\Resources\EmployeeResource\Pages\CreateEmployee;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión/mejora: con una sola empresa/sucursal activa, el alta de
+ * empleado preselecciona ambas — evita el clic inútil de elegir la única
+ * opción disponible en cada alta (mismo patrón ya usado para ocultar
+ * columnas cuando Company::active()->count() <= 1).
+ */
+it('preselecciona empresa y sucursal cuando solo hay una activa', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create(['name' => 'Única S.A.', 'ruc' => '1-1', 'employer_number' => 1, 'is_active' => true]);
+    $branch = Branch::create(['name' => 'Casa Central', 'company_id' => $company->id]);
+
+    Livewire::test(CreateEmployee::class)
+        ->assertFormSet([
+            'company_id' => $company->id,
+            'branch_id' => $branch->id,
+        ]);
+});
+
+it('no preselecciona empresa cuando hay más de una activa', function () {
+    $this->actingAs(User::factory()->create());
+
+    Company::create(['name' => 'Una S.A.', 'ruc' => '1-1', 'employer_number' => 1, 'is_active' => true]);
+    Company::create(['name' => 'Otra S.A.', 'ruc' => '2-2', 'employer_number' => 2, 'is_active' => true]);
+
+    Livewire::test(CreateEmployee::class)
+        ->assertFormSet(['company_id' => null]);
+});
+
+it('no preselecciona sucursal cuando la empresa tiene más de una', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create(['name' => 'Única S.A.', 'ruc' => '1-1', 'employer_number' => 1, 'is_active' => true]);
+    Branch::create(['name' => 'Casa Central', 'company_id' => $company->id]);
+    Branch::create(['name' => 'Sucursal 2', 'company_id' => $company->id]);
+
+    Livewire::test(CreateEmployee::class)
+        ->assertFormSet(['branch_id' => null]);
+});
+
+/**
+ * Regresión/mejora: el aviso de CI duplicado aparece en vivo (al perder
+ * foco el campo), no recién al hacer submit de todo el formulario.
+ */
+it('avisa en vivo si la CI ya está en uso por otro empleado', function () {
+    $this->actingAs(User::factory()->create());
+
+    $branch = Branch::factory()->create();
+    Employee::factory()->create(['ci' => '5551234', 'branch_id' => $branch->id]);
+
+    $field = Livewire::test(CreateEmployee::class)
+        ->set('data.ci', '5551234')
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['ci'];
+
+    expect($field->getHint())->toBe('Ya existe un empleado con esta CI');
+});
+
+it('no avisa si la CI no está en uso', function () {
+    $this->actingAs(User::factory()->create());
+
+    $field = Livewire::test(CreateEmployee::class)
+        ->set('data.ci', '9999999')
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['ci'];
+
+    expect($field->getHint())->toBeNull();
+});
+
+/**
+ * Regresión: el departamento/cargo del "Contrato Inicial" mostraba TODOS
+ * los departamentos de TODAS las empresas, a diferencia de
+ * ContractsRelationManager (edición) que sí filtra por la empresa del
+ * empleado — en un cliente multiempresa se podía elegir el departamento
+ * equivocado al crear.
+ */
+it('el departamento del contrato inicial se filtra por la empresa de la sucursal elegida', function () {
+    $this->actingAs(User::factory()->create());
+
+    $companyA = Company::create(['name' => 'Empresa A', 'ruc' => '1-1', 'employer_number' => 1]);
+    $companyB = Company::create(['name' => 'Empresa B', 'ruc' => '2-2', 'employer_number' => 2]);
+    $branchA = Branch::create(['name' => 'Sucursal A', 'company_id' => $companyA->id]);
+    Branch::create(['name' => 'Sucursal B', 'company_id' => $companyB->id]);
+
+    $deptA = Department::create(['name' => 'Depto A', 'company_id' => $companyA->id]);
+    $deptB = Department::create(['name' => 'Depto B', 'company_id' => $companyB->id]);
+
+    $field = Livewire::test(CreateEmployee::class)
+        ->set('data.branch_id', $branchA->id)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['ic_department_id'];
+
+    expect($field->getOptions())->toHaveKey($deptA->id)
+        ->not->toHaveKey($deptB->id);
+});
+
+it('el cargo del contrato inicial se filtra por la empresa aunque no haya departamento elegido', function () {
+    $this->actingAs(User::factory()->create());
+
+    $companyA = Company::create(['name' => 'Empresa A', 'ruc' => '1-1', 'employer_number' => 1]);
+    $companyB = Company::create(['name' => 'Empresa B', 'ruc' => '2-2', 'employer_number' => 2]);
+    $branchA = Branch::create(['name' => 'Sucursal A', 'company_id' => $companyA->id]);
+
+    $deptA = Department::create(['name' => 'Depto A', 'company_id' => $companyA->id]);
+    $deptB = Department::create(['name' => 'Depto B', 'company_id' => $companyB->id]);
+    $positionA = Position::create(['name' => 'Cargo A', 'department_id' => $deptA->id]);
+    $positionB = Position::create(['name' => 'Cargo B', 'department_id' => $deptB->id]);
+
+    $field = Livewire::test(CreateEmployee::class)
+        ->set('data.branch_id', $branchA->id)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['ic_position_id'];
+
+    expect($field->getOptions())->toHaveKey($positionA->id)
+        ->not->toHaveKey($positionB->id);
+});

--- a/tests/Feature/EmployeesImportTest.php
+++ b/tests/Feature/EmployeesImportTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use App\Imports\EmployeesImport;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeImportBranch(string $name = 'Casa Central'): Branch
+{
+    static $n = 8800000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa Import {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+
+    return Branch::create(['name' => $name, 'company_id' => $company->id]);
+}
+
+/** @param array<int, array<int, mixed>> $rows */
+function runEmployeesImport(array $rows): EmployeesImport
+{
+    $import = new EmployeesImport;
+    $import->collection(new Collection(array_map(fn ($row) => new Collection($row), $rows)));
+
+    return $import;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('crea un empleado válido con status activo', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'ana', 'gomez', '15/03/1990', 'Femenino', $branch->name, '0981123456', 'ana@test.com', 'Paraguaya'],
+    ]);
+
+    expect($import->created)->toBe(1)
+        ->and($import->failures)->toBeEmpty();
+
+    $employee = Employee::where('ci', '1111111')->first();
+    expect($employee)->not->toBeNull()
+        ->and($employee->first_name)->toBe('ANA')
+        ->and($employee->status)->toBe('active')
+        ->and($employee->gender)->toBe('femenino')
+        ->and($employee->branch_id)->toBe($branch->id);
+});
+
+it('salta en silencio una fila completamente vacía', function () {
+    $import = runEmployeesImport([
+        ['', '', '', '', '', '', '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures)->toBeEmpty();
+});
+
+it('reporta CI vacío como fallo', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['', 'Ana', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures)->toHaveCount(1)
+        ->and($import->failures[0]['reason'])->toBe('CI vacío');
+});
+
+it('reporta nombre o apellido faltante como fallo', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', '', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toBe('Nombre y apellido son obligatorios');
+});
+
+it('rechaza una CI ya usada por otro empleado', function () {
+    $branch = makeImportBranch();
+    Employee::create(['first_name' => 'Existente', 'last_name' => 'X', 'ci' => '1111111', 'branch_id' => $branch->id, 'status' => 'active']);
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toContain('Ya existe un empleado con CI');
+});
+
+it('rechaza CIs duplicadas dentro del mismo archivo (la segunda ocurrencia)', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+        ['1111111', 'Ana', 'Otra', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(1)
+        ->and($import->failures)->toHaveCount(1)
+        ->and($import->failures[0]['reason'])->toContain('Ya existe un empleado con CI');
+});
+
+it('rechaza una fecha de nacimiento con formato inválido', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', 'no-es-una-fecha', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toContain('Fecha de nacimiento inválida');
+});
+
+it('rechaza a un empleado menor de 18 años', function () {
+    $branch = makeImportBranch();
+    $recentDate = now()->subYears(10)->format('d/m/Y');
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', $recentDate, 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toBe('El empleado debe ser mayor de 18 años');
+});
+
+it('acepta variantes de género (M, F, Masculino, Femenino) sin distinguir mayúsculas', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'Uno', 'A', '15/03/1990', 'm', $branch->name, '', '', ''],
+        ['2222222', 'Dos', 'B', '15/03/1990', 'F', $branch->name, '', '', ''],
+        ['3333333', 'Tres', 'C', '15/03/1990', 'MASCULINO', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(3)
+        ->and($import->failures)->toBeEmpty();
+
+    expect(Employee::where('ci', '1111111')->value('gender'))->toBe('masculino')
+        ->and(Employee::where('ci', '2222222')->value('gender'))->toBe('femenino')
+        ->and(Employee::where('ci', '3333333')->value('gender'))->toBe('masculino');
+});
+
+it('rechaza un género que no es reconocible', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Otro', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toContain("Género inválido: 'Otro'");
+});
+
+it('rechaza una sucursal que no existe, sin distinguir mayúsculas', function () {
+    $branch = makeImportBranch('Casa Central');
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', 'Sucursal Inexistente', '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toBe("Sucursal no encontrada: 'Sucursal Inexistente'");
+});
+
+it('encuentra la sucursal sin distinguir mayúsculas ni espacios extra', function () {
+    $branch = makeImportBranch('Casa Central');
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', '  casa central  ', '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(1)
+        ->and(Employee::where('ci', '1111111')->value('branch_id'))->toBe($branch->id);
+});
+
+it('rechaza un email ya usado por otro empleado', function () {
+    $branch = makeImportBranch();
+    Employee::create(['first_name' => 'Existente', 'last_name' => 'X', 'ci' => '9999999', 'email' => 'ana@test.com', 'branch_id' => $branch->id, 'status' => 'active']);
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', 'ana@test.com', ''],
+    ]);
+
+    expect($import->created)->toBe(0)
+        ->and($import->failures[0]['reason'])->toContain('Ya existe un empleado con el email');
+});
+
+it('usa Paraguaya como nacionalidad por defecto si se deja vacía', function () {
+    $branch = makeImportBranch();
+
+    runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', '15/03/1990', 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect(Employee::where('ci', '1111111')->value('nationality'))->toBe('Paraguaya');
+});
+
+it('acepta una fecha de nacimiento como instancia DateTime (celda Excel formateada como fecha)', function () {
+    $branch = makeImportBranch();
+
+    $import = runEmployeesImport([
+        ['1111111', 'Ana', 'Gomez', new DateTime('1985-06-20'), 'Femenino', $branch->name, '', '', ''],
+    ]);
+
+    expect($import->created)->toBe(1);
+    expect(Employee::where('ci', '1111111')->first()->birth_date->format('Y-m-d'))->toBe('1985-06-20');
+});


### PR DESCRIPTION
## Resumen

Cluster "Alta de empleados" del backlog priorizado tras la prueba en producción, en dos partes:

### 1. UX del form de creación individual

- **CI duplicado en vivo**: la validación `unique()` de CI ya existía, pero solo se disparaba al hacer submit de todo el form (5 secciones). Ahora avisa apenas se completa el campo (`->live(onBlur: true)` + `->hint()`).
- **Empresa/sucursal preseleccionadas si solo hay una activa** — mismo criterio que ya usa el proyecto para ocultar columnas/filtros cuando `Company::active()->count() <= 1`.
- **Fix real encontrado de paso**: el departamento/cargo de "Contrato Inicial" mostraba TODOS los departamentos de TODAS las empresas, a diferencia de `ContractsRelationManager` (edición), que sí filtra por la empresa del empleado. En un cliente multiempresa se podía elegir el departamento equivocado al crear.

### 2. Creación masiva de empleados desde Excel

v1 acordada: solo datos básicos (CI, nombre, apellido, fecha de nacimiento, género, sucursal, teléfono, email, nacionalidad) — sin contrato ni enrolamiento facial en el mismo paso, igual que un alta individual sin completar la sección opcional "Contrato Inicial".

Mismo patrón ya establecido en el proyecto (`AdvancesImport`/`AdvancesTemplateExport`): `ToCollection` + `WithStartRow`, validación fila por fila con reporte de fallos, sin abortar el archivo completo por una fila mala. La plantilla se genera **sin fila de ejemplo** (a diferencia de `AdvancesTemplateExport`, que pre-puebla con empleados reales existentes) — acá no hay datos previos que pre-cargar, y una fila de ejemplo en la posición donde arranca la lectura real se importaría como empleado de verdad si el admin se olvida de borrarla.

Entry point: nuevo grupo "Creación masiva" en el header de `ListEmployees` (Descargar Plantilla / Importar Empleados), calcado del mismo grupo ya existente en `ListAdvances`.

## Test plan

- [x] Verificación de la lógica de negocio contra BD SQLite de scratch.
- [x] **Round-trip con un archivo Excel real** (no solo arrays en memoria): plantilla generada en blanco, fecha de nacimiento como texto DD/MM/AAAA y como celda de fecha real de Excel, CI/email duplicado, sucursal inexistente, género inválido, menor de edad, fila vacía saltada en silencio — 2 creados, 4 fallos, todo correcto.
- [x] Tests Pest nuevos: `tests/Feature/EmployeeFormDefaultsTest.php` (7 casos, `Livewire::test()`) y `tests/Feature/EmployeesImportTest.php` (15 casos).
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin errores.
- [ ] No se pudo correr `php artisan test` en este sandbox (sin MySQL) — correrá en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH
