### PR TITLE
Agregar botón de WhatsApp a "Ver Enlace" y "Regenerar Enlace" en FaceEnrollmentResource

### DIFF
--- a/app/Filament/Resources/FaceEnrollmentResource.php
+++ b/app/Filament/Resources/FaceEnrollmentResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\FaceEnrollmentResource\Pages;
+use App\Models\Employee;
 use App\Models\FaceEnrollment;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -258,7 +259,11 @@ class FaceEnrollmentResource extends Resource
                             ]),
                     ])
                     ->modalSubmitAction(false)
-                    ->modalCancelActionLabel('Cerrar'),
+                    ->modalCancelActionLabel('Cerrar')
+                    ->extraModalFooterActions(fn (FaceEnrollment $record): array => static::whatsappShareAction(
+                        $record->employee,
+                        route('face-enrollment.show', $record->token)
+                    )),
 
                 Action::make('regenerate_link')
                     ->label('Regenerar Enlace')
@@ -304,6 +309,7 @@ class FaceEnrollmentResource extends Resource
                                     ->label('Abrir enlace')
                                     ->url($url)
                                     ->openUrlInNewTab(),
+                                ...static::whatsappNotificationAction($enrollment->employee, $url),
                             ])
                             ->send();
                     }),
@@ -401,6 +407,68 @@ class FaceEnrollmentResource extends Resource
             ->emptyStateIcon('heroicon-o-finger-print')
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(10);
+    }
+
+    /**
+     * Construye la URL de WhatsApp para compartir el enlace de captura facial
+     * con el empleado, o null si no tiene teléfono cargado.
+     */
+    private static function buildWhatsappUrl(?Employee $employee, string $url): ?string
+    {
+        if (! $employee || blank($employee->phone)) {
+            return null;
+        }
+
+        $message = "Hola {$employee->first_name}, usa este enlace para registrar tu rostro: {$url}";
+
+        return 'https://api.whatsapp.com/send?phone=595'.ltrim($employee->phone, '0').'&text='.urlencode($message);
+    }
+
+    /**
+     * Botón "Enviar por WhatsApp" para el pie de un modal (ej. "Ver Enlace").
+     *
+     * @return array<int, Action>
+     */
+    private static function whatsappShareAction(?Employee $employee, string $url): array
+    {
+        $whatsappUrl = static::buildWhatsappUrl($employee, $url);
+
+        if (! $whatsappUrl) {
+            return [];
+        }
+
+        return [
+            Action::make('send_whatsapp')
+                ->label('Enviar por WhatsApp')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('success')
+                ->url($whatsappUrl)
+                ->openUrlInNewTab(),
+        ];
+    }
+
+    /**
+     * Acción "Enviar por WhatsApp" para el arreglo de acciones de una
+     * `Filament\Notifications\Notification` (ej. tras regenerar el enlace).
+     *
+     * @return array<int, \Filament\Notifications\Actions\Action>
+     */
+    private static function whatsappNotificationAction(?Employee $employee, string $url): array
+    {
+        $whatsappUrl = static::buildWhatsappUrl($employee, $url);
+
+        if (! $whatsappUrl) {
+            return [];
+        }
+
+        return [
+            \Filament\Notifications\Actions\Action::make('send_whatsapp')
+                ->label('Enviar por WhatsApp')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('success')
+                ->url($whatsappUrl)
+                ->openUrlInNewTab(),
+        ];
     }
 
     /**

--- a/tests/Feature/FaceEnrollmentWhatsappShareTest.php
+++ b/tests/Feature/FaceEnrollmentWhatsappShareTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Filament\Resources\FaceEnrollmentResource;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: "Enviar por WhatsApp" existía al generar el enlace de
+ * enrolamiento facial desde EmployeeResource, pero faltaba en las dos
+ * acciones de FaceEnrollmentResource donde un admin recupera/reenvía el
+ * enlace más tarde ("Ver Enlace" y "Regenerar Enlace").
+ */
+function callFaceEnrollmentWhatsappHelper(string $method, ?Employee $employee, string $url): array
+{
+    $reflection = new ReflectionMethod(FaceEnrollmentResource::class, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke(null, $employee, $url);
+}
+
+it('genera la acción de WhatsApp para el modal "Ver Enlace" cuando el empleado tiene teléfono', function () {
+    $company = Company::create(['name' => 'Empresa WA', 'ruc' => '1-1', 'employer_number' => 1]);
+    $branch = Branch::create(['name' => 'Sucursal WA', 'company_id' => $company->id]);
+    $employee = Employee::create([
+        'first_name' => 'Ana', 'last_name' => 'Gomez', 'ci' => '1234567',
+        'branch_id' => $branch->id, 'status' => 'active', 'phone' => '0981123456',
+    ]);
+
+    $actions = callFaceEnrollmentWhatsappHelper('whatsappShareAction', $employee, 'https://nominapp.test/registro-facial/abc');
+
+    expect($actions)->toHaveCount(1);
+    expect($actions[0])->toBeInstanceOf(\Filament\Tables\Actions\Action::class);
+    expect($actions[0]->getUrl())->toContain('https://api.whatsapp.com/send?phone=595981123456')
+        ->and($actions[0]->getUrl())->toContain(urlencode('https://nominapp.test/registro-facial/abc'));
+});
+
+it('no genera la acción de WhatsApp para "Ver Enlace" si el empleado no tiene teléfono', function () {
+    $company = Company::create(['name' => 'Empresa WA2', 'ruc' => '2-2', 'employer_number' => 2]);
+    $branch = Branch::create(['name' => 'Sucursal WA2', 'company_id' => $company->id]);
+    $employee = Employee::create([
+        'first_name' => 'Bruno', 'last_name' => 'Lopez', 'ci' => '7654321',
+        'branch_id' => $branch->id, 'status' => 'active', 'phone' => null,
+    ]);
+
+    $actions = callFaceEnrollmentWhatsappHelper('whatsappShareAction', $employee, 'https://nominapp.test/registro-facial/def');
+
+    expect($actions)->toBeEmpty();
+});
+
+it('no genera la acción de WhatsApp para "Ver Enlace" si el empleado fue eliminado', function () {
+    $actions = callFaceEnrollmentWhatsappHelper('whatsappShareAction', null, 'https://nominapp.test/registro-facial/ghi');
+
+    expect($actions)->toBeEmpty();
+});
+
+it('genera la acción de WhatsApp para la notificación de "Regenerar Enlace" cuando el empleado tiene teléfono', function () {
+    $company = Company::create(['name' => 'Empresa WA3', 'ruc' => '3-3', 'employer_number' => 3]);
+    $branch = Branch::create(['name' => 'Sucursal WA3', 'company_id' => $company->id]);
+    $employee = Employee::create([
+        'first_name' => 'Carla', 'last_name' => 'Diaz', 'ci' => '1112223',
+        'branch_id' => $branch->id, 'status' => 'active', 'phone' => '0971987654',
+    ]);
+
+    $actions = callFaceEnrollmentWhatsappHelper('whatsappNotificationAction', $employee, 'https://nominapp.test/registro-facial/jkl');
+
+    expect($actions)->toHaveCount(1);
+    expect($actions[0])->toBeInstanceOf(\Filament\Notifications\Actions\Action::class);
+    expect($actions[0]->getUrl())->toContain('https://api.whatsapp.com/send?phone=595971987654');
+});


### PR DESCRIPTION
## Summary

- Cierra la última inconsistencia detectada en el cluster "Alta de empleados" (enrolamiento/autoenrolamiento): el botón "Enviar por WhatsApp" existía al generar el enlace de captura facial desde `EmployeeResource` (`generate_enrollment`), pero faltaba en las dos acciones de `FaceEnrollmentResource` donde un admin recupera o reenvía el enlace más tarde — "Ver Enlace" (`copy_link`) y "Regenerar Enlace" (`regenerate_link`).
- Nuevos helpers privados `whatsappShareAction()` (para el pie de un modal, vía `extraModalFooterActions()`) y `whatsappNotificationAction()` (para las acciones de una `Filament\Notifications\Notification`), ambos compartiendo la construcción de la URL en `buildWhatsappUrl()`. Se ocultan (array vacío) cuando el empleado no tiene teléfono cargado o fue eliminado — mismo criterio que ya usaba la acción original.

## Test plan

- [x] `php -l` sin errores de sintaxis.
- [x] `vendor/bin/pint --dirty` sin hallazgos.
- [x] Verificado que `Filament\Tables\Actions\Action` (ya usado en este archivo) es una instancia válida de `Filament\Actions\StaticAction`, el tipo que exige `extraModalFooterActions()`.
- [x] Nuevo test `tests/Feature/FaceEnrollmentWhatsappShareTest.php` (Pest) — cubre ambos helpers con empleado con teléfono, sin teléfono, y `null` (empleado eliminado). No se pudo correr contra `php artisan test` en este sandbox (sin MySQL disponible); la misma lógica se verificó equivalentemente contra una BD SQLite de scratch vía `tinker` (10/10 aserciones OK) — correrá en CI (MySQL real) al abrir este PR.
- [x] `npm run build` sin errores (sin cambios de JS en este PR).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_