### PR TITLE
Paridad de sync offline en celular + throttling claro en vincular-celular

### DIFF
--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Models\Employee;
+use App\Models\User;
+use App\Notifications\MobileLinkThrottledNotification;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 
@@ -82,5 +86,62 @@ class MobileLinkController extends Controller
                 'face_descriptor' => $employee->face_descriptor,
             ],
         ]);
+    }
+
+    /**
+     * Traduce el 429 genérico de Laravel ("Too Many Attempts.") a un mensaje
+     * en español con el tiempo de espera real, para la ruta de vinculación
+     * de celular (`throttle:5,1,mobile-link-minute` +
+     * `throttle:15,1440,mobile-link-day` en routes/web.php). Registrado
+     * desde `bootstrap/app.php`, scopeado a esta única ruta — el resto de
+     * los enlaces públicos del proyecto (registro-facial, terminal/setup)
+     * quedan con el comportamiento por defecto, fuera de alcance acá.
+     *
+     * El header `X-RateLimit-Limit` distingue qué throttle disparó la
+     * excepción sin necesitar adivinar la clave interna del rate limiter:
+     * 5 = límite por minuto (probablemente un usuario tipeando mal),
+     * 15 = límite diario (señal más fuerte de empleado trabado o fuerza
+     * bruta — amerita avisar a los admins).
+     */
+    public static function throttledResponse(ThrottleRequestsException $exception, Request $request): JsonResponse
+    {
+        $headers = $exception->getHeaders();
+        $retryAfterSeconds = (int) ($headers['Retry-After'] ?? 60);
+        $limit = (int) ($headers['X-RateLimit-Limit'] ?? 0);
+
+        if ($limit === 15) {
+            static::notifyAdminsOfDailyLimitOnce($request->ip(), $request->input('ci'));
+
+            return response()->json([
+                'ok' => false,
+                'message' => 'Alcanzó el límite de intentos por hoy. Contacte a RRHH para vincular su dispositivo.',
+            ], 429, $headers);
+        }
+
+        $minutes = max(1, (int) ceil($retryAfterSeconds / 60));
+
+        return response()->json([
+            'ok' => false,
+            'message' => "Demasiados intentos. Espere {$minutes} minuto".($minutes === 1 ? '' : 's').' e intente de nuevo.',
+        ], 429, $headers);
+    }
+
+    /**
+     * Notifica a los admins como máximo una vez por IP por día calendario
+     * cuando se agota el límite diario — sin este flag, la notificación se
+     * dispararía en cada uno de los intentos bloqueados posteriores (el
+     * contador del rate limiter queda fijo en el máximo el resto del día).
+     */
+    private static function notifyAdminsOfDailyLimitOnce(string $ip, ?string $lastCiAttempted): void
+    {
+        $notifiedKey = 'mobile-link-day-notified:'.$ip.':'.now()->format('Y-m-d');
+
+        if (Cache::has($notifiedKey)) {
+            return;
+        }
+
+        Cache::put($notifiedKey, true, now()->endOfDay());
+
+        User::all()->each(fn (User $user) => $user->notify(new MobileLinkThrottledNotification($ip, $lastCiAttempted)));
     }
 }

--- a/app/Notifications/MobileLinkThrottledNotification.php
+++ b/app/Notifications/MobileLinkThrottledNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notificación a los admins cuando una IP agota el límite diario de intentos
+ * de vinculación de celular (`/vincular-celular`, 15/día). Puede ser un
+ * empleado real trabado (CI o fecha de nacimiento mal recordada) o un
+ * intento de fuerza bruta contra una credencial de baja entropía — en
+ * cualquiera de los dos casos, antes nadie se enteraba hasta que el
+ * empleado reclamaba directamente. Se dispara como máximo una vez por
+ * IP por día (ver `MobileLinkController::notifyAdminsOfDailyLimitOnce()`).
+ */
+class MobileLinkThrottledNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $ip,
+        public readonly ?string $lastCiAttempted,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        $ciLabel = filled($this->lastCiAttempted) ? " (último CI intentado: {$this->lastCiAttempted})" : '';
+
+        return [
+            'title' => 'Límite diario de vinculación de celular agotado',
+            'body' => "La IP {$this->ip} alcanzó el límite de 15 intentos de vinculación hoy{$ciLabel}. Puede ser un empleado con datos incorrectos o un intento de acceso indebido — revisar los logs si es necesario.",
+            'icon' => 'heroicon-o-shield-exclamation',
+            'color' => 'warning',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Http\Controllers\MobileLinkController;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
 use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 
@@ -22,5 +25,15 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // Mensaje en español + tiempo de espera para el throttling de vinculación
+        // de celular — ver MobileLinkController::throttledResponse(). Sin esto, el
+        // empleado ve el 429 genérico de Laravel ("Too Many Attempts.", en inglés,
+        // sin contexto de cuánto esperar ni a quién contactar).
+        $exceptions->render(function (ThrottleRequestsException $e, Request $request) {
+            if (! $request->routeIs('mobile-link.claim')) {
+                return null;
+            }
+
+            return MobileLinkController::throttledResponse($e, $request);
+        });
     })->create();

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -141,6 +141,73 @@ body.modal-open { overflow: hidden; }
 }
 .offline-banner svg { width: 15px; height: 15px; flex-shrink: 0; }
 .offline-banner.is-visible { max-height: 48px; opacity: 1; padding: var(--sp-2) var(--sp-4); }
+
+/* ============================================================
+   BANNER DE CONFLICTO DE SINCRONIZACIÓN
+   ============================================================ */
+.conflict-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--sp-2) var(--sp-3);
+    padding: var(--sp-2) var(--sp-4);
+    background: var(--c-danger-bg);
+    border-bottom: 1px solid var(--c-danger-ring);
+    color: var(--c-danger);
+    font-size: .8125rem;
+    font-weight: 600;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 400ms ease, opacity 400ms ease, padding 400ms ease;
+}
+.conflict-banner svg { width: 15px; height: 15px; flex-shrink: 0; }
+.conflict-banner.is-visible { max-height: 64px; opacity: 1; padding: var(--sp-2) var(--sp-4); }
+.conflict-dismiss-btn {
+    background: transparent;
+    border: 1px solid var(--c-danger);
+    color: var(--c-danger);
+    font: inherit;
+    font-size: .75rem;
+    font-weight: 700;
+    padding: 2px var(--sp-3);
+    border-radius: var(--r);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background var(--tr-f), color var(--tr-f);
+}
+.conflict-dismiss-btn:hover { background: var(--c-danger); color: #fff; }
+
+/* ============================================================
+   ESTADO DE SINCRONIZACIÓN OFFLINE (celular)
+   ============================================================ */
+.sync-status-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sp-3);
+    padding: var(--sp-1) var(--sp-4);
+    background: var(--c-bg);
+    border-bottom: 1px solid var(--c-border);
+    font-size: .75rem;
+}
+.sync-status-text { color: var(--c-muted); min-width: 0; }
+.sync-status-btn {
+    background: transparent;
+    border: 1px solid var(--c-border-s);
+    color: var(--c-muted);
+    font: inherit;
+    font-size: .75rem;
+    font-weight: 600;
+    padding: 2px var(--sp-3);
+    border-radius: var(--r);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background var(--tr-f), color var(--tr-f);
+}
+.sync-status-btn:hover:not(:disabled) { background: var(--c-surface); color: var(--c-text); }
+.sync-status-btn:disabled { opacity: .5; cursor: not-allowed; }
 .app-mode-badge {
     background: var(--c-primary-bg);
     color: var(--c-primary);

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -3,7 +3,14 @@ import { captureFaceSamples } from '../shared/face-capture-core.js';
 import { migrateTokenFromLocalStorage, getMeta, getOwnEmployee } from './mobile-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './mobile-offline/matcher.js';
 import { heartbeat, getFaceConfig, MobileAuthError } from './mobile-offline/sync.js';
-import { getOwnStatus, enqueueMark, flushQueue } from './mobile-offline/queue.js';
+import {
+    getOwnStatus,
+    enqueueMark,
+    flushQueue,
+    countPendingEvents,
+    countConflictEvents,
+    dismissConflictEvents,
+} from './mobile-offline/queue.js';
 
 /**
  * =============================================================================
@@ -97,6 +104,10 @@ const statusBar           = document.getElementById("statusBar");
     const gpsBannerText       = document.getElementById("gpsBannerText");
     const gpsBannerRetry      = document.getElementById("gpsBannerRetry");
     const markHint            = document.getElementById("markHint");
+    const syncStatusText      = document.getElementById("syncStatusText");
+    const btnSyncNow          = document.getElementById("btnSyncNow");
+    const conflictBanner      = document.getElementById("conflictBanner");
+    const btnDismissConflict  = document.getElementById("btnDismissConflict");
 
     // ==========================================================================
     // CONFIGURACIÓN Y CONSTANTES
@@ -381,6 +392,76 @@ const statusBar           = document.getElementById("statusBar");
         banner.setAttribute("aria-hidden", String(!isOffline));
         // Re-evaluar botón de marcación al cambiar estado de conexión
         checkEnableMark();
+    }
+
+    // --------------------------------------------------------------------------
+    // ESTADO DE SINCRONIZACIÓN OFFLINE — paridad con refreshIdleSyncStatus()
+    // de terminal.js (kiosko): mismo texto/prioridad (conflictos > pendientes >
+    // sincronizado), pero acá además hay un aviso separado (conflictBanner)
+    // porque un conflicto en el celular es del propio empleado, no de un
+    // tercero — amerita más que una línea de texto discreta.
+    // --------------------------------------------------------------------------
+    function updateSyncStatus(text) {
+        if (syncStatusText) syncStatusText.textContent = text;
+    }
+
+    /**
+     * Refleja en la fila de estado la cola de eventos offline real (no solo
+     * el último resultado puntual) — se llama después de cada intento de
+     * sincronización (marcación, sync de fondo, botón manual, carga inicial).
+     */
+    async function refreshSyncStatus() {
+        const [pending, conflicts] = await Promise.all([countPendingEvents(), countConflictEvents()]);
+
+        if (conflicts > 0) {
+            updateSyncStatus(`${conflicts} marcación(es) requieren revisión`);
+        } else if (pending > 0) {
+            updateSyncStatus(`${pending} marcación(es) pendiente(s) de sincronizar`);
+        } else {
+            updateSyncStatus(navigator.onLine ? "Sincronizado" : "Sin conexión — usando datos locales");
+        }
+
+        if (conflictBanner) {
+            conflictBanner.classList.toggle("is-visible", conflicts > 0);
+            conflictBanner.setAttribute("aria-hidden", String(conflicts === 0));
+        }
+    }
+
+    // Botón "Entendido" del aviso de conflicto — el empleado no puede resolverlo
+    // (ya lo revisa RRHH en Filament), solo confirma que lo vio. Limpia la copia
+    // local para que el aviso no quede pegado para siempre.
+    if (btnDismissConflict) {
+        btnDismissConflict.addEventListener("click", async () => {
+            btnDismissConflict.disabled = true;
+            try {
+                await dismissConflictEvents();
+                await refreshSyncStatus();
+            } finally {
+                btnDismissConflict.disabled = false;
+            }
+        });
+    }
+
+    // Botón "Sincronizar" manual — mismo patrón que btnForceSync en terminal.js.
+    if (btnSyncNow) {
+        btnSyncNow.addEventListener("click", async () => {
+            btnSyncNow.disabled = true;
+            updateSyncStatus("Sincronizando...");
+            try {
+                await heartbeat();
+                await flushQueue();
+                await refreshSyncStatus();
+            } catch (error) {
+                if (error instanceof MobileAuthError) {
+                    window.location.href = "/vincular-celular";
+                    return;
+                }
+                logWarn("Sincronización manual falló:", error.message);
+                await refreshSyncStatus();
+            } finally {
+                btnSyncNow.disabled = false;
+            }
+        });
     }
 
     // --------------------------------------------------------------------------
@@ -821,8 +902,10 @@ const statusBar           = document.getElementById("statusBar");
      * fallará con un mensaje claro hasta que haya conexión al menos una vez).
      */
     async function initializeOfflineSync() {
+        updateSyncStatus("Sincronizando...");
         try {
             await heartbeat();
+            await flushQueue();
         } catch (error) {
             if (error instanceof MobileAuthError) {
                 window.location.href = "/vincular-celular";
@@ -830,6 +913,7 @@ const statusBar           = document.getElementById("statusBar");
             }
             logWarn("No se pudo sincronizar con el servidor (heartbeat):", error.message);
         }
+        await refreshSyncStatus();
     }
 
     /**
@@ -844,7 +928,9 @@ const statusBar           = document.getElementById("statusBar");
         };
         const runQueueFlush = () => {
             if (!navigator.onLine) return;
-            flushQueue().catch((error) => logWarn("Sincronización de cola en segundo plano falló:", error.message));
+            flushQueue()
+                .then(() => refreshSyncStatus())
+                .catch((error) => logWarn("Sincronización de cola en segundo plano falló:", error.message));
         };
 
         setInterval(runHeartbeat, 90 * 1000);
@@ -2091,6 +2177,7 @@ const statusBar           = document.getElementById("statusBar");
                 btnMark.classList.remove("btn-loading");
                 btnMark.textContent = "Confirmar marcación";
                 btnMark.disabled = false;
+                refreshSyncStatus();
             }
         });
     }

--- a/resources/js/attendances/mobile-offline/db.js
+++ b/resources/js/attendances/mobile-offline/db.js
@@ -209,6 +209,23 @@ export async function countConflictEvents() {
     return all.filter((event) => event.status === 'conflict').length;
 }
 
+/**
+ * Elimina del store local los eventos en conflicto — el registro real de lo
+ * ocurrido ya vive en el servidor (`AttendanceMarkFailure`, revisado por un
+ * admin en Filament); la copia local solo sirve para avisarle una vez al
+ * empleado. Sin esto, el aviso de conflicto en /marcar quedaría pegado para
+ * siempre (nada más limpia `outbound_events` del lado del cliente).
+ */
+export async function dismissConflictEvents() {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    const tx = db.transaction('outbound_events', 'readwrite');
+    for (const event of all) {
+        if (event.status === 'conflict') await tx.store.delete(event.client_event_id);
+    }
+    await tx.done;
+}
+
 // =========================================================================
 // CACHÉ DE ESTADO (employee_status_cache)
 // =========================================================================

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -22,6 +22,7 @@ import {
     incrementQueuedEventAttempts,
     countPendingEvents,
     countConflictEvents,
+    dismissConflictEvents,
     getEmployeeStatusCache,
     setEmployeeStatusCache,
 } from './db.js';
@@ -231,4 +232,4 @@ export async function flushQueue() {
     }
 }
 
-export { countPendingEvents, countConflictEvents };
+export { countPendingEvents, countConflictEvents, dismissConflictEvents };

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -76,6 +76,28 @@
         <span>Sin conexión — la marcación se guarda en el dispositivo y se sincroniza al reconectar</span>
     </div>
 
+    {{-- Conflicto de sincronización: una marcación encolada offline fue rechazada por el
+    servidor al reconectar (ej. secuencia inválida) — no es accionable por el empleado, solo
+    informativo (RRHH la revisa en AttendanceMarkFailureResource); se puede cerrar el aviso. --}}
+    <div id="conflictBanner" class="conflict-banner" role="alert" aria-live="polite" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="12" y1="8" x2="12" y2="12"/>
+            <line x1="12" y1="16" x2="12.01" y2="16"/>
+        </svg>
+        <span>Una marcación reciente no pudo confirmarse — RRHH la va a revisar.</span>
+        <button type="button" id="btnDismissConflict" class="conflict-dismiss-btn">Entendido</button>
+    </div>
+
+    {{-- Estado de sincronización offline + sync manual — paridad con el botón "Sincronizar"
+    del kiosko (terminal-idle.blade.php). --}}
+    <div class="sync-status-row" id="syncStatusRow">
+        <span class="sync-status-text" id="syncStatusText" aria-live="polite"></span>
+        <button type="button" id="btnSyncNow" class="sync-status-btn" aria-label="Sincronizar marcaciones pendientes">
+            Sincronizar
+        </button>
+    </div>
+
     <main id="main-content" class="page-wrapper">
         <div class="main-grid">
             <x-attendance.video-section />

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -358,9 +358,11 @@ it('el límite diario notifica a los admins con la IP y el CI intentado, una sol
     ]);
 
     $response = MobileLinkController::throttledResponse($exception, $request);
+    $data = $response->getData(true);
 
-    $response->assertStatus(429)->assertJson(['ok' => false]);
-    expect($response->json('message'))->toContain('RRHH');
+    expect($response->getStatusCode())->toBe(429)
+        ->and($data['ok'])->toBeFalse()
+        ->and($data['message'])->toContain('RRHH');
 
     Notification::assertSentTimes(MobileLinkThrottledNotification::class, 1);
     Notification::assertSentTo(User::first(), MobileLinkThrottledNotification::class, function ($notification) {

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\MobileLinkController;
 use App\Models\AttendanceEvent;
 use App\Models\Branch;
 use App\Models\Company;
@@ -11,7 +12,10 @@ use App\Models\Terminal;
 use App\Models\User;
 use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
+use App\Notifications\MobileLinkThrottledNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
@@ -296,4 +300,92 @@ it('el POST de vincular-celular tiene throttling más estricto que el GET', func
     // El 6º intento en la misma ventana debe ser rechazado por el rate limiter.
     $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '2000-01-01'])
         ->assertStatus(429);
+});
+
+/**
+ * Regresión: el 429 del throttling por minuto mostraba el mensaje genérico
+ * de Laravel ("Too Many Attempts.", en inglés, sin indicar cuánto esperar).
+ */
+it('el 429 por límite de minuto tiene un mensaje en español con el tiempo de espera', function () {
+    $employee = makeLinkableEmployee();
+
+    for ($i = 0; $i < 5; $i++) {
+        $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '2000-01-01'])->assertStatus(422);
+    }
+
+    $response = $this->postJson('/vincular-celular', ['ci' => $employee->ci, 'birth_date' => '2000-01-01']);
+
+    $response->assertStatus(429)->assertJson(['ok' => false]);
+    expect($response->json('message'))->toContain('Demasiados intentos')
+        ->and($response->json('message'))->toContain('minuto');
+});
+
+/**
+ * Regresión: otras rutas públicas con throttling (terminal/setup,
+ * registro-facial) no deben verse afectadas por el render() scopeado a
+ * mobile-link.claim en bootstrap/app.php — deben mantener el 429 default.
+ */
+it('el 429 de otras rutas throttled no se ve afectado por el mensaje de vincular-celular', function () {
+    // terminal/{code}/setup/{setupToken} usa throttle:10,1 (sin scopear en bootstrap/app.php).
+    for ($i = 0; $i < 10; $i++) {
+        $this->getJson('/terminal/BOGUS/setup/faketoken');
+    }
+
+    $response = $this->getJson('/terminal/BOGUS/setup/faketoken');
+
+    $response->assertStatus(429);
+    // No debe tener la forma de MobileLinkController::throttledResponse() ('ok' + 'message' en español).
+    expect($response->json('ok'))->toBeNull();
+});
+
+/**
+ * MobileLinkController::throttledResponse() es la lógica que arma el mensaje
+ * y decide si notificar a los admins — se prueba directamente (sin esperar
+ * 15 requests reales limitadas a 5/minuto) construyendo la excepción con los
+ * headers exactos que produce ThrottleRequests::buildException().
+ */
+it('el límite diario notifica a los admins con la IP y el CI intentado, una sola vez por día', function () {
+    Notification::fake();
+    User::factory()->create();
+
+    $request = Request::create('/vincular-celular', 'POST', ['ci' => '4445556']);
+    $request->server->set('REMOTE_ADDR', '203.0.113.20');
+
+    $exception = new ThrottleRequestsException('Too Many Attempts.', null, [
+        'Retry-After' => 43200,
+        'X-RateLimit-Limit' => 15,
+        'X-RateLimit-Remaining' => 0,
+    ]);
+
+    $response = MobileLinkController::throttledResponse($exception, $request);
+
+    $response->assertStatus(429)->assertJson(['ok' => false]);
+    expect($response->json('message'))->toContain('RRHH');
+
+    Notification::assertSentTimes(MobileLinkThrottledNotification::class, 1);
+    Notification::assertSentTo(User::first(), MobileLinkThrottledNotification::class, function ($notification) {
+        return $notification->ip === '203.0.113.20' && $notification->lastCiAttempted === '4445556';
+    });
+
+    // Un segundo 429 diario de la MISMA IP el mismo día no debe volver a notificar.
+    MobileLinkController::throttledResponse($exception, $request);
+    Notification::assertSentTimes(MobileLinkThrottledNotification::class, 1);
+});
+
+it('el límite por minuto (distinto de 15) no notifica a los admins', function () {
+    Notification::fake();
+    User::factory()->create();
+
+    $request = Request::create('/vincular-celular', 'POST', ['ci' => '1112223']);
+    $request->server->set('REMOTE_ADDR', '203.0.113.10');
+
+    $exception = new ThrottleRequestsException('Too Many Attempts.', null, [
+        'Retry-After' => 45,
+        'X-RateLimit-Limit' => 5,
+        'X-RateLimit-Remaining' => 0,
+    ]);
+
+    MobileLinkController::throttledResponse($exception, $request);
+
+    Notification::assertNothingSent();
 });


### PR DESCRIPTION
## Summary

Cierra 2 de los gaps detectados en el cluster "Marcación día a día" (sesiones 08 y 11 del testing manual en producción):

### 1. Paridad de sincronización offline en `/marcar` (celular)
El kiosko (`terminal.js`) ya tenía, desde Parte B, un indicador de estado de sync ("N pendientes" / "N en conflicto") + botón manual "Sincronizar" en su pantalla idle. `/marcar` (celular personal) no tenía nada equivalente — las funciones `countPendingEvents()`/`countConflictEvents()` ya existían en `mobile-offline/db.js` pero no se usaban.

- Nueva fila de estado en `mark.blade.php` (`syncStatusText` + botón `btnSyncNow`), misma lógica que `refreshIdleSyncStatus()` del kiosko.
- Nuevo aviso `conflictBanner`: si una marcación encolada offline fue rechazada por el servidor al sincronizar (ej. secuencia inválida), se le informa al empleado — no es accionable por su parte (RRHH la revisa en `AttendanceMarkFailureResource`, ya notificado desde PR #89), así que trae un botón "Entendido" que limpia la copia local (`dismissConflictEvents()`, nuevo en `db.js`/`queue.js`) para que el aviso no quede pegado para siempre.
- `initializeOfflineSync()` ahora también vacía la cola al arrancar (antes solo lo hacía el timer de fondo o al marcar).

### 2. Mensaje claro + aviso al admin en el throttling de `/vincular-celular`
El 429 devolvía el genérico de Laravel ("Too Many Attempts.", en inglés, sin contexto de cuánto esperar). Ahora:

- `MobileLinkController::throttledResponse()` (invocado desde un `render()` en `bootstrap/app.php`, scopeado únicamente a `mobile-link.claim` — el resto de rutas throttled del proyecto no se tocan) devuelve un JSON en español con el tiempo de espera real, usando el header `X-RateLimit-Limit` para distinguir el límite por minuto (5) del límite diario (15).
- Al agotar el límite diario, notifica a los admins (`MobileLinkThrottledNotification`, canal `database`) con la IP y el último CI intentado — como máximo una vez por IP por día calendario, para no spamear en cada intento bloqueado posterior.

## Test plan

- [x] `php -l` en todos los archivos PHP modificados/nuevos, sin errores.
- [x] `vendor/bin/pint --dirty` sin hallazgos pendientes.
- [x] `npm run build` sin errores.
- [x] Verificación end-to-end del throttling contra un servidor real (`php artisan serve` + curl, BD SQLite de scratch, `CACHE_STORE=file`): el 5º intento por minuto pasa, el 6º devuelve el mensaje en español; otras rutas throttled (`terminal/setup`) no se ven afectadas por el scoping.
- [x] Verificación de `MobileLinkController::throttledResponse()` vía tinker (10/10 aserciones): mensaje correcto por tier, notificación al admin solo en el límite diario, deduplicada por IP+día, y una IP distinta sí genera notificación nueva.
- [x] Verificación de `dismissConflictEvents()` vía Playwright + Vite dev server + IndexedDB real (9/9 aserciones): elimina solo los eventos en conflicto, deja los pendientes intactos, idempotente.
- [x] Nuevos tests Pest en `tests/Feature/MobileAttendanceLinkTest.php` — mensaje en español del throttle por minuto, scoping (otras rutas throttled no afectadas), notificación al admin en el límite diario (una sola vez, con IP+CI correctos), sin notificación en el límite por minuto. No se pudieron correr contra `php artisan test` en este sandbox (sin MySQL disponible); correrán en CI.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_