### PR TITLE
Arreglar QR invisible en Terminal + flujo guiado de provisión

### DIFF
--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Grid as InfoGrid;
+use Filament\Infolists\Components\ImageEntry;
 use Filament\Infolists\Components\Section as InfoSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
@@ -181,13 +182,23 @@ class TerminalResource extends Resource
                                 ->state(fn (Terminal $record) => $record->url),
                         ]),
 
-                        TextEntry::make('qr_code')
+                        ImageEntry::make('qr_code')
                             ->label('QR de acceso')
-                            ->html()
-                            ->state(fn (Terminal $record) => '<div style="display:inline-block;background:#fff;padding:12px;border-radius:8px;border:1px solid #e5e7eb">'
-                                .QrCode::size(180)->generate($record->url)
-                                .'</div>'
-                            ),
+                            // No usar TextEntry->html() acá: el sanitizador HTML de Filament
+                            // (Symfony HtmlSanitizer, vía Str::sanitizeHtml()) elimina el <svg>
+                            // completo porque SVG no está en su lista de elementos "seguros" —
+                            // el QR quedaba invisible (solo el <div> contenedor vacío). Un data
+                            // URI en ImageEntry evita el sanitizador por completo: Filament lo
+                            // detecta (str($state)->startsWith('data:')) y lo usa tal cual como
+                            // src de <img>, sin pasar por el pipeline de HTML.
+                            ->state(fn (Terminal $record) => 'data:image/svg+xml;base64,'
+                                .base64_encode((string) QrCode::size(180)->generate($record->url))
+                            )
+                            ->height(180)
+                            ->extraImgAttributes([
+                                'style' => 'background:#fff;padding:12px;border-radius:8px;border:1px solid #e5e7eb',
+                                'alt' => 'Código QR de acceso al terminal',
+                            ]),
                     ]),
 
                 InfoSection::make('Dispositivo')
@@ -492,14 +503,16 @@ class TerminalResource extends Resource
 
     /**
      * Genera un nuevo token de configuración de un solo uso para el terminal y
-     * renderiza el modal con su URL/QR. Efecto colateral intencional dentro de
-     * un closure de contenido: si Livewire re-evalúa el modal más de una vez
-     * mientras está abierto, cada llamada genera Y muestra el token vigente
-     * en ese momento de forma consistente (nunca queda desincronizado con lo
-     * que se ve en pantalla) — a costa de invalidar tokens de configuración
+     * renderiza el modal con su URL/QR. Público porque lo usan tanto la acción
+     * de tabla (`ListTerminals`) como el header action equivalente en
+     * `ViewTerminal`. Efecto colateral intencional dentro de un closure de
+     * contenido: si Livewire re-evalúa el modal más de una vez mientras está
+     * abierto, cada llamada genera Y muestra el token vigente en ese momento
+     * de forma consistente (nunca queda desincronizado con lo que se ve en
+     * pantalla) — a costa de invalidar tokens de configuración
      * previos no usados, lo cual es aceptable para un enlace de un solo uso.
      */
-    protected static function renderSetupLinkModal(Terminal $record): View
+    public static function renderSetupLinkModal(Terminal $record): View
     {
         $expiresInMinutes = 30;
         $setupToken = $record->generateSetupToken($expiresInMinutes);

--- a/app/Filament/Resources/TerminalResource/Pages/CreateTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/CreateTerminal.php
@@ -13,14 +13,23 @@ class CreateTerminal extends CreateRecord
 
     /**
      * Notificación de éxito al crear la terminal.
-     *
-     * @return Notification|null
      */
     protected function getCreatedNotification(): ?Notification
     {
         return Notification::make()
             ->success()
             ->title('Terminal creada')
-            ->body("La terminal \"{$this->record->name}\" fue creada. Configurá el dispositivo con la URL generada.");
+            ->body("La terminal \"{$this->record->name}\" fue creada. Generá el enlace de configuración para provisionar el dispositivo.");
+    }
+
+    /**
+     * Redirige al detalle del terminal recién creado con `?provision=1` —
+     * ViewTerminal::mount() lo detecta y abre de una el modal "Generar enlace
+     * de configuración", para que el admin no tenga que volver a la lista a
+     * buscar el QR justo después de crear el terminal.
+     */
+    protected function getRedirectUrl(): string
+    {
+        return static::getResource()::getUrl('view', ['record' => $this->getRecord()]).'?provision=1';
     }
 }

--- a/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
@@ -16,6 +16,27 @@ class ViewTerminal extends ViewRecord
     protected static string $resource = TerminalResource::class;
 
     /**
+     * Al llegar desde la creación con `?provision=1` (ver
+     * CreateTerminal::getRedirectUrl()), abre automáticamente el modal de
+     * "Generar enlace de configuración" — evita que el admin tenga que volver
+     * a la lista para conseguir el QR justo después de crear el terminal.
+     *
+     * No puede hacerse en mount(): `mountAction()` resuelve la acción contra
+     * `cachedActions`, que recién se puebla en el hook de Livewire
+     * `bootedInteractsWithHeaderActions()` — que corre después de mount().
+     * Llamarlo ahí antes de tiempo hace que `getMountedAction()` no encuentre
+     * la acción y la desmonte de inmediato, sin abrir el modal.
+     */
+    public function bootedInteractsWithHeaderActions(): void
+    {
+        parent::bootedInteractsWithHeaderActions();
+
+        if (request()->boolean('provision')) {
+            $this->mountAction('generate_setup_link');
+        }
+    }
+
+    /**
      * Acciones del encabezado de la página de detalle.
      */
     protected function getHeaderActions(): array
@@ -70,6 +91,35 @@ class ViewTerminal extends ViewRecord
                         ->send();
 
                     $this->refreshFormData(['code']);
+                }),
+
+            Action::make('generate_setup_link')
+                ->label('Generar enlace de configuración')
+                ->tooltip('Enlace/QR de un solo uso para vincular el dispositivo a la sincronización offline')
+                ->icon('heroicon-o-qr-code')
+                ->color('gray')
+                ->modalHeading('Enlace de configuración del terminal')
+                ->modalContent(fn () => TerminalResource::renderSetupLinkModal($this->record))
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Cerrar'),
+
+            Action::make('revoke_token')
+                ->label('Revocar token')
+                ->tooltip('Invalida el acceso del terminal a la sincronización offline — requerirá re-provisión')
+                ->icon('heroicon-o-shield-exclamation')
+                ->color('danger')
+                ->visible(fn () => $this->record->tokens()->exists())
+                ->requiresConfirmation()
+                ->modalHeading('Revocar token de sincronización')
+                ->modalDescription('El terminal perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar.')
+                ->modalSubmitActionLabel('Sí, revocar')
+                ->action(function () {
+                    $this->record->revokeSyncTokens();
+                    Notification::make()
+                        ->success()
+                        ->title('Token revocado')
+                        ->body('El terminal deberá re-provisionarse para volver a sincronizar.')
+                        ->send();
                 }),
 
             EditAction::make()->label('Editar')->icon('heroicon-o-pencil-square')->color('primary'),

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Filament\Resources\TerminalResource\Pages\CreateTerminal;
+use App\Filament\Resources\TerminalResource\Pages\ViewTerminal;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Terminal;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeProvisioningTerminal(): Terminal
+{
+    static $n = 7500000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa Prov {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Prov {$n}", 'company_id' => $company->id]);
+
+    return Terminal::create(['name' => 'Kiosko Prov', 'branch_id' => $branch->id]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+/**
+ * Regresión: el QR se generaba como SVG y se inyectaba con
+ * TextEntry->html(), lo que activa el sanitizador HTML de Filament (Symfony
+ * HtmlSanitizer) — que elimina el <svg> completo porque no está en su lista
+ * de elementos "seguros", dejando el QR invisible. Un data URI en
+ * ImageEntry evita el sanitizador por completo.
+ */
+it('el QR de acceso es un data URI SVG válido, no HTML crudo', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $component = collect(
+        Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()])
+            ->instance()
+            ->getInfolist('infolist')
+            ->getFlatComponents()
+    )->first(fn ($c) => $c->getName() === 'qr_code');
+
+    expect($component)->not->toBeNull();
+
+    $state = $component->getState();
+    expect($state)->toStartWith('data:image/svg+xml;base64,');
+
+    $decoded = base64_decode(substr($state, strpos($state, ',') + 1));
+    expect($decoded)->toContain('<svg');
+});
+
+it('sin ?provision=1 no abre el modal de generar enlace automáticamente', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $test = Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()]);
+
+    expect($test->get('mountedActions'))->toBe([]);
+});
+
+/**
+ * Regresión de implementación: mountAction() no puede llamarse dentro de
+ * mount() porque cachedActions recién se puebla en el hook de Livewire
+ * bootedInteractsWithHeaderActions(), que corre después — hacerlo antes
+ * desmonta la acción de inmediato sin abrir el modal.
+ */
+it('con ?provision=1 abre el modal de generar enlace automáticamente tras crear', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $test = Livewire::withQueryParams(['provision' => '1'])
+        ->test(ViewTerminal::class, ['record' => $terminal->getKey()]);
+
+    expect($test->get('mountedActions'))->toBe(['generate_setup_link']);
+});
+
+it('el redirect tras crear un terminal apunta a su vista con ?provision=1', function () {
+    $terminal = makeProvisioningTerminal();
+
+    $page = new CreateTerminal;
+    $page->record = $terminal;
+
+    $reflection = new ReflectionMethod(CreateTerminal::class, 'getRedirectUrl');
+    $reflection->setAccessible(true);
+    $redirectUrl = $reflection->invoke($page);
+
+    expect($redirectUrl)->toContain("/terminales/{$terminal->id}")
+        ->and($redirectUrl)->toEndWith('?provision=1');
+});
+
+it('la acción "Revocar token" solo es visible en el detalle si el terminal tiene un token activo', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $withoutToken = Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()]);
+    $action = collect($withoutToken->instance()->getCachedHeaderActions())
+        ->first(fn ($a) => $a->getName() === 'revoke_token');
+
+    expect($action->isVisible())->toBeFalse();
+
+    $terminal->claimSanctumToken();
+
+    $withToken = Livewire::test(ViewTerminal::class, ['record' => $terminal->fresh()->getKey()]);
+    $action = collect($withToken->instance()->getCachedHeaderActions())
+        ->first(fn ($a) => $a->getName() === 'revoke_token');
+
+    expect($action->isVisible())->toBeTrue();
+});
+
+it('el detalle del terminal expone la acción "Generar enlace de configuración"', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $test = Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()]);
+    $action = collect($test->instance()->getCachedHeaderActions())
+        ->first(fn ($a) => $a->getName() === 'generate_setup_link');
+
+    expect($action)->not->toBeNull();
+});

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -42,7 +42,7 @@ it('el QR de acceso es un data URI SVG válido, no HTML crudo', function () {
             ->instance()
             ->getInfolist('infolist')
             ->getFlatComponents()
-    )->first(fn ($c) => $c->getName() === 'qr_code');
+    )->first(fn ($c) => method_exists($c, 'getName') && $c->getName() === 'qr_code');
 
     expect($component)->not->toBeNull();
 


### PR DESCRIPTION
## Summary

Cierra el bug reportado en la sesión 01 del testing manual ("el qr de acceso no muestra, mejorar la vista view del recurso") y la fricción de UX en el alta/provisión de terminales.

### Causa raíz del QR invisible
En `TerminalResource::infolist()`, el QR se generaba como SVG (formato por defecto de `simplesoftwareio/simple-qrcode`) y se inyectaba con `TextEntry->html()`. Ese `->html()` activa el sanitizador HTML de Filament (Symfony HtmlSanitizer, `Str::sanitizeHtml()`), que **elimina el `<svg>` completo** porque SVG no está en su lista de elementos "seguros" (`allowSafeElements()`/`W3CReference`) — quedaba solo el `<div>` contenedor vacío. Confirmado ejecutando el código real: el string sanitizado pasaba de 2388 a 71 caracteres, sin rastro del SVG.

El QR del modal "Generar Enlace" (acción de tabla) nunca tuvo este problema porque es Blade plano (`{!! !!}`), no pasa por ese pipeline.

**Fix:** `ImageEntry` con un data URI (`data:image/svg+xml;base64,...`) en vez de `TextEntry->html()`. Filament detecta el prefijo `data:` y lo usa directo como `src` de `<img>`, sin pasar por el sanitizador — mismo formato SVG, sin agregar dependencia de Imagick.

### Fricción de UX en la provisión (agregado tras acordar el alcance con el usuario)
- "Generar Enlace de Configuración" y "Revocar Token" solo existían como acciones de fila en la tabla (`ListTerminals`) — un admin en el detalle de un terminal (`ViewTerminal`), por ejemplo buscando justo el QR que no veía, no tenía forma de generarlo/revocarlo desde ahí. Ahora también están en los header actions de `ViewTerminal`.
- Al crear un terminal, ahora redirige directo a su detalle con el modal "Generar Enlace" ya abierto (`?provision=1`), en vez de volver a la lista y buscar la fila manualmente.

## Test plan

- [x] `php -l` en todos los archivos modificados, sin errores.
- [x] `vendor/bin/pint --dirty` sin hallazgos pendientes.
- [x] `npm run build` sin errores.
- [x] Verificación real vía `php artisan tinker` (Livewire::test + BD SQLite de scratch): el entry `qr_code` del infolist devuelve un data URI que decodifica a un `<svg>` válido; sin `?provision=1` el modal no se monta; con `?provision=1` (vía `Livewire::withQueryParams()`, que sí simula el query string real de una carga de página) el modal se monta automáticamente; `revoke_token` oculto/visible según exista un token; `generate_setup_link` disponible en el detalle; el redirect de `CreateTerminal` apunta a la vista con `?provision=1`. 10/10 aserciones OK.
- [x] Encontrado y corregido durante la verificación: `mountAction()` no puede llamarse dentro de `mount()` en `ViewTerminal` — el caché de acciones (`cachedActions`) recién se puebla en el hook de Livewire `bootedInteractsWithHeaderActions()`, que corre después. Se movió la lógica a ese hook.
- [x] Nuevos tests Pest en `tests/Feature/TerminalProvisioningUiTest.php` (6 casos) — mismos escenarios que la verificación manual. No se pudieron correr contra `php artisan test` en este sandbox (sin MySQL disponible); correrán en CI.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_