### PR TITLE
Auto-desvinculación de celular + contexto al revocar desde Filament

### DIFF
--- a/app/Filament/Resources/EmployeeResource.php
+++ b/app/Filament/Resources/EmployeeResource.php
@@ -1067,7 +1067,14 @@ class EmployeeResource extends Resource
                         ->visible(fn (Employee $record): bool => $record->hasMobileLinked())
                         ->requiresConfirmation()
                         ->modalHeading('Revocar sesión móvil')
-                        ->modalDescription(fn (Employee $record) => "El celular vinculado de {$record->first_name} {$record->last_name} perderá acceso a la marcación offline de inmediato. Deberá vincularse de nuevo con CI + fecha de nacimiento.")
+                        ->modalDescription(function (Employee $record): string {
+                            $base = "El celular vinculado de {$record->first_name} {$record->last_name} perderá acceso a la marcación offline de inmediato. Deberá vincularse de nuevo con CI + fecha de nacimiento.";
+
+                            $linkedAt = $record->mobile_linked_at?->format('d/m/Y H:i');
+                            $lastSync = $record->mobile_last_heartbeat_at?->diffForHumans() ?? 'nunca sincronizó';
+
+                            return "{$base} Vinculado el {$linkedAt}. Último sync: {$lastSync}.";
+                        })
                         ->modalSubmitActionLabel('Sí, revocar')
                         ->action(function (Employee $record) {
                             $record->revokeMobileToken();

--- a/app/Http/Controllers/Api/MobileUnlinkController.php
+++ b/app/Http/Controllers/Api/MobileUnlinkController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Employee;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Auto-desvinculación del celular personal — a diferencia de "Revocar sesión
+ * móvil" en EmployeeResource (accionada por un admin desde Filament), acá es
+ * el propio empleado quien decide desvincular su dispositivo (ej. antes de
+ * venderlo o prestarlo) desde /marcar. Autenticado vía Sanctum (ability
+ * `mobile:sync`) — el token usado para autenticar esta misma petición queda
+ * revocado al responder.
+ */
+class MobileUnlinkController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        /** @var Employee $employee */
+        $employee = $request->user();
+
+        $employee->revokeMobileToken();
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -208,6 +208,16 @@ body.modal-open { overflow: hidden; }
 }
 .sync-status-btn:hover:not(:disabled) { background: var(--c-surface); color: var(--c-text); }
 .sync-status-btn:disabled { opacity: .5; cursor: not-allowed; }
+/* Desvincular celular: acción rara y destructiva — discreta hasta el hover, no compite visualmente con "Sincronizar". */
+.sync-status-btn--unlink {
+    border-color: transparent;
+    margin-left: auto;
+}
+.sync-status-btn--unlink:hover:not(:disabled) {
+    background: var(--c-danger-bg);
+    color: var(--c-danger);
+    border-color: var(--c-danger-bg);
+}
 .app-mode-badge {
     background: var(--c-primary-bg);
     color: var(--c-primary);

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1,8 +1,8 @@
 import L from 'leaflet';
 import { captureFaceSamples } from '../shared/face-capture-core.js';
-import { migrateTokenFromLocalStorage, getMeta, getOwnEmployee } from './mobile-offline/db.js';
+import { migrateTokenFromLocalStorage, getMeta, getOwnEmployee, resetDb } from './mobile-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './mobile-offline/matcher.js';
-import { heartbeat, getFaceConfig, MobileAuthError } from './mobile-offline/sync.js';
+import { heartbeat, getFaceConfig, unlinkDevice, MobileAuthError } from './mobile-offline/sync.js';
 import {
     getOwnStatus,
     enqueueMark,
@@ -106,6 +106,7 @@ const statusBar           = document.getElementById("statusBar");
     const markHint            = document.getElementById("markHint");
     const syncStatusText      = document.getElementById("syncStatusText");
     const btnSyncNow          = document.getElementById("btnSyncNow");
+    const btnUnlinkDevice     = document.getElementById("btnUnlinkDevice");
     const conflictBanner      = document.getElementById("conflictBanner");
     const btnDismissConflict  = document.getElementById("btnDismissConflict");
 
@@ -460,6 +461,51 @@ const statusBar           = document.getElementById("statusBar");
                 await refreshSyncStatus();
             } finally {
                 btnSyncNow.disabled = false;
+            }
+        });
+    }
+
+    // Botón "Desvincular celular" — auto-servicio del empleado (ej. antes de
+    // vender o prestar el dispositivo), a diferencia de "Revocar sesión móvil"
+    // en EmployeeResource (accionada por un admin). Intenta sincronizar lo
+    // pendiente primero para no perder marcaciones sin necesidad; si igual
+    // queda algo sin confirmar, avisa antes de continuar (informa, no bloquea
+    // — el empleado decide).
+    if (btnUnlinkDevice) {
+        btnUnlinkDevice.addEventListener("click", async () => {
+            btnUnlinkDevice.disabled = true;
+            try {
+                if (navigator.onLine) {
+                    try {
+                        await flushQueue();
+                    } catch (error) {
+                        logWarn("No se pudo sincronizar antes de desvincular:", error.message);
+                    }
+                }
+
+                const pending = await countPendingEvents();
+                const warning = pending > 0
+                    ? `Tenés ${pending} marcación(es) sin sincronizar — se van a perder. `
+                    : "";
+                const confirmed = window.confirm(
+                    `${warning}¿Seguro que querés desvincular este celular? Vas a necesitar tu CI y fecha de nacimiento para volver a vincularlo.`
+                );
+                if (!confirmed) return;
+
+                await unlinkDevice();
+                await resetDb();
+                window.location.href = "/vincular-celular";
+            } catch (error) {
+                if (error instanceof MobileAuthError) {
+                    // El token ya no era válido — el dispositivo ya está desvinculado
+                    // del lado del servidor, solo falta limpiar la copia local.
+                    await resetDb();
+                    window.location.href = "/vincular-celular";
+                    return;
+                }
+                window.alert(error.message || "No se pudo desvincular el dispositivo. Intentá de nuevo.");
+            } finally {
+                btnUnlinkDevice.disabled = false;
             }
         });
     }

--- a/resources/js/attendances/mobile-offline/db.js
+++ b/resources/js/attendances/mobile-offline/db.js
@@ -121,6 +121,22 @@ export async function logSync(type, ok, detail = null) {
 }
 
 /**
+ * Vacía por completo la caché local del celular — llamado tras una
+ * auto-desvinculación exitosa (ver `unlinkDevice()` en `sync.js`). El
+ * dispositivo queda como recién instalado: sin token, sin empleado
+ * cacheado, sin cola de eventos ni estado. Cualquier marcación pendiente de
+ * sincronizar en `outbound_events` se pierde — el caller es responsable de
+ * intentar `flushQueue()` y advertir al usuario antes de llamar a esto.
+ * @returns {Promise<void>}
+ */
+export async function resetDb() {
+    const db = await getDb();
+    await Promise.all(
+        ['mobile_meta', 'outbound_events', 'employee_status_cache', 'sync_log'].map((store) => db.clear(store))
+    );
+}
+
+/**
  * Empleado dueño del dispositivo, con su descriptor facial cacheado — el
  * único "candidato" contra el que el matcher local compara.
  * @returns {Promise<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}|undefined>}

--- a/resources/js/attendances/mobile-offline/sync.js
+++ b/resources/js/attendances/mobile-offline/sync.js
@@ -97,6 +97,19 @@ export async function fetchStatus() {
 }
 
 /**
+ * Auto-desvinculación: el propio empleado decide desvincular este celular
+ * (ej. antes de venderlo o prestarlo) desde /marcar — a diferencia de
+ * "Revocar sesión móvil" en EmployeeResource (accionada por un admin). El
+ * caller es responsable de vaciar la caché local (ver `resetDb()` en
+ * `db.js`) tras una respuesta exitosa.
+ * @returns {Promise<void>}
+ */
+export async function unlinkDevice() {
+    const data = await apiFetch('/unlink', { method: 'POST' });
+    if (!data.ok) throw new Error(data.message || 'No se pudo desvincular el dispositivo.');
+}
+
+/**
  * Envía un lote de eventos de marcación — uno solo si se llama justo tras
  * capturar la marcación con red disponible, o varios si se está vaciando la
  * cola offline acumulada (ver mobile-offline/queue.js). A diferencia del

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -96,6 +96,9 @@
         <button type="button" id="btnSyncNow" class="sync-status-btn" aria-label="Sincronizar marcaciones pendientes">
             Sincronizar
         </button>
+        <button type="button" id="btnUnlinkDevice" class="sync-status-btn sync-status-btn--unlink" aria-label="Desvincular este celular">
+            Desvincular celular
+        </button>
     </div>
 
     <main id="main-content" class="page-wrapper">

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\MobileEventSyncController;
 use App\Http\Controllers\Api\MobileHeartbeatController;
 use App\Http\Controllers\Api\MobileStatusController;
+use App\Http\Controllers\Api\MobileUnlinkController;
 use App\Http\Controllers\Api\TerminalEmployeeSyncController;
 use App\Http\Controllers\Api\TerminalEventSyncController;
 use App\Http\Controllers\Api\TerminalHeartbeatController;
@@ -59,4 +60,8 @@ Route::prefix('v1/mobile')->name('api.mobile.')->middleware(['auth:sanctum'])->g
     Route::post('/events/sync', [MobileEventSyncController::class, 'store'])
         ->middleware('ability:mobile:sync')
         ->name('events.sync');
+
+    Route::post('/unlink', [MobileUnlinkController::class, 'store'])
+        ->middleware('ability:mobile:sync')
+        ->name('unlink');
 });

--- a/tests/Feature/EmployeeMobileRevocationTest.php
+++ b/tests/Feature/EmployeeMobileRevocationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Filament\Resources\EmployeeResource\Pages\ListEmployees;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeMobileLinkedEmployee(): Employee
+{
+    static $n = 8600000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa Revoc {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Revoc {$n}", 'company_id' => $company->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Revoc',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-05-15',
+        'email' => "revoc{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+        'mobile_linked_at' => now()->subDays(3),
+        'mobile_last_heartbeat_at' => now()->subHours(2),
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+/**
+ * El modal de "Revocar sesión móvil" debe mostrar cuándo se vinculó el
+ * celular y cuándo sincronizó por última vez, para que el admin no revoque
+ * a ciegas — antes solo describía el efecto de la acción, sin contexto del
+ * dispositivo en sí.
+ */
+it('el modal de revocar sesión móvil muestra la fecha de vinculación y el último sync', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeMobileLinkedEmployee();
+
+    $test = Livewire::test(ListEmployees::class)
+        ->mountTableAction('revoke_mobile_session', $employee);
+
+    $description = $test->instance()->getMountedTableAction()->getModalDescription();
+
+    expect($description)
+        ->toContain($employee->mobile_linked_at->format('d/m/Y H:i'))
+        ->toContain('Último sync');
+});
+
+it('el modal de revocar sesión móvil indica "nunca sincronizó" si no hubo heartbeat', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeMobileLinkedEmployee();
+    $employee->update(['mobile_last_heartbeat_at' => null]);
+
+    $test = Livewire::test(ListEmployees::class)
+        ->mountTableAction('revoke_mobile_session', $employee);
+
+    $description = $test->instance()->getMountedTableAction()->getModalDescription();
+
+    expect($description)->toContain('nunca sincronizó');
+});
+
+it('revocar la sesión móvil desde el modal limpia mobile_linked_at y borra el token', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeMobileLinkedEmployee();
+    $employee->createToken('mobile:'.$employee->id, [Employee::MOBILE_SYNC_ABILITY]);
+
+    Livewire::test(ListEmployees::class)
+        ->mountTableAction('revoke_mobile_session', $employee)
+        ->callMountedTableAction();
+
+    $fresh = $employee->fresh();
+    expect($fresh->mobile_linked_at)->toBeNull()
+        ->and($fresh->tokens()->count())->toBe(0);
+});

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -223,6 +223,42 @@ it('un token de terminal no puede usar las rutas móviles (ability distinta)', f
     $this->postJson('/api/v1/mobile/heartbeat')->assertStatus(403);
 });
 
+// ─── Auto-desvinculación (/api/v1/mobile/unlink) ───────────────────────────
+
+it('unlink revoca el token propio del empleado — auto-servicio, sin admin', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/unlink');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    expect($employee->fresh()->hasMobileLinked())->toBeFalse()
+        ->and($employee->tokens()->count())->toBe(0);
+});
+
+it('unlink deja al empleado listo para vincular un celular nuevo', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $this->postJson('/api/v1/mobile/unlink')->assertOk();
+
+    $response = $this->postJson('/vincular-celular', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+});
+
+it('un token de terminal no puede usar el endpoint de unlink móvil (ability distinta)', function () {
+    $employee = makeLinkableEmployee();
+    $terminal = Terminal::create([
+        'name' => 'Kiosko Test', 'branch_id' => $employee->branch_id,
+    ]);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $this->postJson('/api/v1/mobile/unlink')->assertStatus(403);
+});
+
 // ─── Hardening (Fase 4) ─────────────────────────────────────────────────────
 
 it('notifica a los admins (sin advertencia) en la primera vinculación', function () {


### PR DESCRIPTION
## Resumen

Cierra el último cluster del backlog de QA de marcación offline: **"Revocación de celular"**.

- **Auto-servicio del empleado**: nuevo botón "Desvincular celular" en `/marcar` (fila de estado de sincronización, junto a "Sincronizar"). Antes solo era posible desvincularse implícitamente al vincular otro dispositivo, o mediante revocación manual de un admin desde Filament.
  - Nuevo endpoint `POST /api/v1/mobile/unlink` (Sanctum, ability `mobile:sync`) — `MobileUnlinkController` revoca el token propio del empleado autenticado.
  - Antes de desvincular, intenta sincronizar la cola pendiente (`flushQueue()`); si igual quedan marcaciones sin confirmar, avisa la cantidad antes de que el empleado confirme (informa, no bloquea).
  - Tras confirmar, limpia por completo la caché local (`resetDb()` en `mobile-offline/db.js`) y redirige a `/vincular-celular`.
  - Si el token ya era inválido (`MobileAuthError`), igual limpia la caché local y redirige — el dispositivo ya estaba desvinculado del lado del servidor.
- **Contexto en el modal de admin**: "Revocar sesión móvil" (`EmployeeResource`) ahora muestra en la descripción del modal cuándo se vinculó el celular y cuándo sincronizó por última vez (o "nunca sincronizó"), para que el admin no revoque a ciegas.

## Test plan

- [x] `tests/Feature/MobileAttendanceLinkTest.php` — nuevos tests: `unlink` revoca el token propio; tras `unlink` el empleado puede vincular un celular nuevo; un token de terminal no puede usar `/unlink` (ability distinta).
- [x] `tests/Feature/EmployeeMobileRevocationTest.php` (nuevo) — el modal de "Revocar sesión móvil" incluye fecha de vinculación y último sync (o "nunca sincronizó"); revocar desde el modal limpia `mobile_linked_at` y borra el token.
- [x] Verificación end-to-end por HTTP real (`php artisan serve` + curl, BD SQLite de scratch): token válido antes de `unlink`, `unlink` responde `{"ok":true}`, el mismo token queda inválido (401) después.
- [x] Verificación del modal de Filament vía `Livewire::test()` en tinker (mismo patrón que fases anteriores): confirma el texto exacto de la descripción, incluyendo el caso sin heartbeat previo y el locale español (`hace 2 horas`).
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [x] `npm run build` — sin errores.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` en este sandbox (sin MySQL; las migraciones del proyecto usan `INFORMATION_SCHEMA`, MySQL-only), se confirma en el pipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_