### PR TITLE
Fix: hora desfasada y opciones de marcación atascadas en sync offline (celular + kiosko)

### DIFF
--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -95,7 +95,12 @@ class AttendanceEventSyncService
         }
 
         try {
-            $recordedAt = Carbon::parse($eventData['recorded_at']);
+            // El kiosko manda recorded_at en UTC (Date.toISOString()) — convertir a la
+            // timezone de la app ANTES de persistir, no solo para calcular $date. Sin esto
+            // el evento queda guardado con la hora UTC "cruda" (ej. 3 horas adelantado en
+            // America/Asuncion), porque el resto de la app asume que recorded_at ya está en
+            // hora local.
+            $recordedAt = Carbon::parse($eventData['recorded_at'])->timezone(config('app.timezone'));
         } catch (Throwable) {
             return [
                 'client_event_id' => $clientEventId,
@@ -105,7 +110,7 @@ class AttendanceEventSyncService
             ];
         }
 
-        $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
+        $date = $recordedAt->toDateString();
 
         try {
             return DB::transaction(fn () => $this->insertEvent($terminal, $employee, $eventData, $clientEventId, $recordedAt, $date));

--- a/app/Services/MobileEventSyncService.php
+++ b/app/Services/MobileEventSyncService.php
@@ -56,7 +56,12 @@ class MobileEventSyncService
         }
 
         try {
-            $recordedAt = Carbon::parse($eventData['recorded_at']);
+            // El celular manda recorded_at en UTC (Date.toISOString()) — convertir a la
+            // timezone de la app ANTES de persistir, no solo para calcular $date. Sin esto
+            // el evento queda guardado con la hora UTC "cruda" (ej. 3 horas adelantado en
+            // America/Asuncion), porque el resto de la app asume que recorded_at ya está en
+            // hora local.
+            $recordedAt = Carbon::parse($eventData['recorded_at'])->timezone(config('app.timezone'));
         } catch (Throwable) {
             return [
                 'client_event_id' => $clientEventId,
@@ -66,7 +71,7 @@ class MobileEventSyncService
             ];
         }
 
-        $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
+        $date = $recordedAt->toDateString();
 
         try {
             return DB::transaction(fn () => $this->insertEvent($employee, $eventData, $clientEventId, $recordedAt, $date));

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -153,6 +153,19 @@ export async function enqueueMark(eventType, location = null) {
         location,
     });
 
+    // Refresca el caché de estado de inmediato — sin esto, una vez que este
+    // evento se sincroniza y se borra de outbound_events, resolveOwnStatus()
+    // no tiene forma de saber que ya se registró (el caché queda con el
+    // último estado confirmado ANTES de esta marcación) y vuelve a ofrecer
+    // los mismos eventos permitidos que antes de marcar.
+    if (employeeId) {
+        await setEmployeeStatusCache(employeeId, {
+            last_event: eventType,
+            last_event_time: recordedAt.toTimeString().slice(0, 5),
+            allowed_events: allowedNextEventTypes(eventType),
+        });
+    }
+
     return { client_event_id: clientEventId, recorded_at: recordedAt.toISOString() };
 }
 

--- a/resources/js/attendances/terminal-offline/queue.js
+++ b/resources/js/attendances/terminal-offline/queue.js
@@ -148,6 +148,17 @@ export async function enqueueMark(employeeId, eventType) {
         date: localDateString(recordedAt),
     });
 
+    // Refresca el caché de estado de inmediato — sin esto, una vez que este
+    // evento se sincroniza y se borra de outbound_events, resolveEmployeeStatus()
+    // no tiene forma de saber que ya se registró (el caché queda con el
+    // último estado confirmado ANTES de esta marcación) y vuelve a ofrecer
+    // los mismos eventos permitidos que antes de marcar.
+    await setEmployeeStatusCache(employeeId, {
+        last_event: eventType,
+        last_event_time: recordedAt.toTimeString().slice(0, 5),
+        allowed_events: allowedNextEventTypes(eventType),
+    });
+
     return { client_event_id: clientEventId, recorded_at: recordedAt.toISOString() };
 }
 

--- a/tests/Feature/AttendanceEventSyncServiceTest.php
+++ b/tests/Feature/AttendanceEventSyncServiceTest.php
@@ -89,6 +89,11 @@ it('sincroniza un evento nuevo y lo marca con origen terminal', function () {
  * 22:30, 3 horas adelantado.
  */
 it('convierte recorded_at de UTC a la timezone de la app antes de persistir', function () {
+    // Se fija explícitamente (en vez de asumir el app.timezone ambiente, que en
+    // CI es UTC) para que el test ejercite realmente la conversión y no solo
+    // coincida "por casualidad" cuando origen y destino son el mismo UTC.
+    config(['app.timezone' => 'America/Asuncion']);
+
     $employee = makeSyncEmployee();
     $terminal = makeSyncTerminal($employee);
     $clientEventId = (string) Str::uuid();
@@ -102,7 +107,7 @@ it('convierte recorded_at de UTC a la timezone de la app antes de persistir', fu
 
     $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
     expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
-        ->and($event->recorded_at->timezone->getName())->toBe(config('app.timezone'));
+        ->and($event->recorded_at->timezone->getName())->toBe('America/Asuncion');
 });
 
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {

--- a/tests/Feature/AttendanceEventSyncServiceTest.php
+++ b/tests/Feature/AttendanceEventSyncServiceTest.php
@@ -105,9 +105,12 @@ it('convierte recorded_at de UTC a la timezone de la app antes de persistir', fu
         'recorded_at' => '2026-08-23T22:30:00.000Z',
     ]]);
 
+    // El valor leído de vuelta se re-hidrata con el timezone default de PHP a
+    // nivel de proceso (fijado una sola vez al boot vía date_default_timezone_set()),
+    // no con el config() recién sobreescrito — por eso solo se verifica el
+    // valor de reloj persistido, no el nombre de la timezone del objeto leído.
     $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
-    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
-        ->and($event->recorded_at->timezone->getName())->toBe('America/Asuncion');
+    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00');
 });
 
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {

--- a/tests/Feature/AttendanceEventSyncServiceTest.php
+++ b/tests/Feature/AttendanceEventSyncServiceTest.php
@@ -81,6 +81,30 @@ it('sincroniza un evento nuevo y lo marca con origen terminal', function () {
         ->and($event->terminal_id)->toBe($terminal->id);
 });
 
+/**
+ * Regresión: el kiosko manda recorded_at en UTC (Date.toISOString(), ej.
+ * "...T22:30:00.000Z"). Antes del fix, ese valor se persistía tal cual (sin
+ * convertir a la timezone de la app), guardando la hora UTC "cruda" — un
+ * evento marcado a las 19:30 en Paraguay (UTC-3) quedaba con recorded_at en
+ * 22:30, 3 horas adelantado.
+ */
+it('convierte recorded_at de UTC a la timezone de la app antes de persistir', function () {
+    $employee = makeSyncEmployee();
+    $terminal = makeSyncTerminal($employee);
+    $clientEventId = (string) Str::uuid();
+
+    app(AttendanceEventSyncService::class)->syncBatch($terminal, [[
+        'client_event_id' => $clientEventId,
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-23T22:30:00.000Z',
+    ]]);
+
+    $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
+        ->and($event->recorded_at->timezone->getName())->toBe(config('app.timezone'));
+});
+
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {
     $employee = makeSyncEmployee();
     $terminal = makeSyncTerminal($employee);

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -74,6 +74,28 @@ it('sincroniza un evento nuevo y lo marca con origen mobile', function () {
         ->and($event->terminal_id)->toBeNull();
 });
 
+/**
+ * Regresión: el celular manda recorded_at en UTC (Date.toISOString(), ej.
+ * "...T22:30:00.000Z"). Antes del fix, ese valor se persistía tal cual (sin
+ * convertir a la timezone de la app), guardando la hora UTC "cruda" — un
+ * empleado que marcó a las 19:30 en Paraguay (UTC-3) quedaba con recorded_at
+ * en 22:30, 3 horas adelantado.
+ */
+it('convierte recorded_at de UTC a la timezone de la app antes de persistir', function () {
+    $employee = makeMobileSyncEmployee();
+    $clientEventId = (string) Str::uuid();
+
+    app(MobileEventSyncService::class)->syncBatch($employee, [[
+        'client_event_id' => $clientEventId,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-23T22:30:00.000Z',
+    ]]);
+
+    $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
+        ->and($event->recorded_at->timezone->getName())->toBe(config('app.timezone'));
+});
+
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {
     $employee = makeMobileSyncEmployee();
     $clientEventId = (string) Str::uuid();

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -96,9 +96,12 @@ it('convierte recorded_at de UTC a la timezone de la app antes de persistir', fu
         'recorded_at' => '2026-08-23T22:30:00.000Z',
     ]]);
 
+    // El valor leído de vuelta se re-hidrata con el timezone default de PHP a
+    // nivel de proceso (fijado una sola vez al boot vía date_default_timezone_set()),
+    // no con el config() recién sobreescrito — por eso solo se verifica el
+    // valor de reloj persistido, no el nombre de la timezone del objeto leído.
     $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
-    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
-        ->and($event->recorded_at->timezone->getName())->toBe('America/Asuncion');
+    expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00');
 });
 
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -82,6 +82,11 @@ it('sincroniza un evento nuevo y lo marca con origen mobile', function () {
  * en 22:30, 3 horas adelantado.
  */
 it('convierte recorded_at de UTC a la timezone de la app antes de persistir', function () {
+    // Se fija explícitamente (en vez de asumir el app.timezone ambiente, que en
+    // CI es UTC) para que el test ejercite realmente la conversión y no solo
+    // coincida "por casualidad" cuando origen y destino son el mismo UTC.
+    config(['app.timezone' => 'America/Asuncion']);
+
     $employee = makeMobileSyncEmployee();
     $clientEventId = (string) Str::uuid();
 
@@ -93,7 +98,7 @@ it('convierte recorded_at de UTC a la timezone de la app antes de persistir', fu
 
     $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
     expect($event->recorded_at->format('Y-m-d H:i:s'))->toBe('2026-08-23 19:30:00')
-        ->and($event->recorded_at->timezone->getName())->toBe(config('app.timezone'));
+        ->and($event->recorded_at->timezone->getName())->toBe('America/Asuncion');
 });
 
 it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {


### PR DESCRIPTION
## Resumen

Dos bugs encontrados en QA manual real sobre el flujo de marcación offline por celular (probando el PR #94), ambos presentes también en el kiosko de sucursal por compartir el mismo diseño.

### Bug 1 — hora registrada 3 horas adelantada

El cliente (celular y kiosko) manda `recorded_at` en UTC (`Date.toISOString()`). En `MobileEventSyncService::syncOne()` y `AttendanceEventSyncService::syncOne()`, ese valor se parseaba con `Carbon::parse()` pero **nunca se convertía a la timezone de la app antes de persistirse** — solo `$date` (usado para agrupar el día) se convertía. El resultado: una marcación hecha a las 19:30 en Paraguay quedaba guardada en la base como 22:30.

Fix: convertir `$recordedAt` a `config('app.timezone')` inmediatamente después de parsearlo, en ambos servicios (antes de que `$date` se derive de él).

### Bug 2 — el selector de eventos solo ofrecía "Entrada"

Al identificarse offline después de haber marcado con conexión, el selector de tipo de evento solo mostraba "Entrada" en vez de "Inicio de descanso"/"Salida". Causa: `employee_status_cache` (el "último estado conocido") solo se refrescaba cuando la identificación consultaba al servidor con éxito (`fetchStatus()`/`fetchEmployeeStatus()`) — nunca después de una marcación exitosa. Una vez que el evento se sincronizaba y se borraba de la cola local (`outbound_events`), `resolveOwnStatus()`/`resolveEmployeeStatus()` no tenía cómo saber que ya se había registrado, y volvía a ofrecer solo `check_in`.

Fix: `enqueueMark()` ahora actualiza `employee_status_cache` de inmediato al encolar cada marcación (en `mobile-offline/queue.js` y `terminal-offline/queue.js`), sin depender de una consulta al servidor.

## Test plan

- [x] `tests/Feature/MobileEventSyncServiceTest.php` — nuevo test: `recorded_at` con sufijo UTC `Z` se persiste convertido a `America/Asuncion` (19:30 en vez de 22:30).
- [x] `tests/Feature/AttendanceEventSyncServiceTest.php` — mismo test para el flujo de kiosko.
- [x] Verificado con Carbon real en tinker que strings UTC (`...Z`) se corrigen y strings "naive" (sin timezone, como usan los tests existentes) no cambian de comportamiento — sin regresión.
- [x] Verificado end-to-end contra una BD SQLite de scratch (`php artisan tinker`) para ambos servicios: 22:30 UTC → 19:30 local, confirmado en ambos.
- [x] Verificado el fix del bug 2 con Playwright + Vite dev server + IndexedDB real, reproduciendo el escenario exacto del QA: marcar `check_in` → simular sync exitoso (evento borrado de la cola) → identificarse de nuevo → `allowed_events` incluye `break_start`/`check_out` en vez de solo `check_in`. Verificado para `mobile-offline/queue.js` y `terminal-offline/queue.js`.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [x] `npm run build` — sin errores.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` en este sandbox (sin MySQL; las migraciones del proyecto usan `INFORMATION_SCHEMA`, MySQL-only), se confirma en el pipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_