### PR TITLE
Fix: botón "Entendido" recortado en el aviso de conflicto de /marcar

### DIFF
--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -163,7 +163,11 @@ body.modal-open { overflow: hidden; }
     transition: max-height 400ms ease, opacity 400ms ease, padding 400ms ease;
 }
 .conflict-banner svg { width: 15px; height: 15px; flex-shrink: 0; }
-.conflict-banner.is-visible { max-height: 64px; opacity: 1; padding: var(--sp-2) var(--sp-4); }
+/* 64px alcanza en una línea, pero el mensaje envuelve a 2 líneas en pantallas
+   angostas y el botón "Entendido" pasa a una tercera fila (flex-wrap) — sin
+   margen extra queda recortado por overflow:hidden, invisible pero presente
+   en el DOM. */
+.conflict-banner.is-visible { max-height: 140px; opacity: 1; padding: var(--sp-2) var(--sp-4); }
 .conflict-dismiss-btn {
     background: transparent;
     border: 1px solid var(--c-danger);


### PR DESCRIPTION
## Resumen

Bug encontrado en QA manual real (Chrome Android): el botón "Entendido" del aviso de conflicto de sincronización en `/marcar` no era visible en pantallas angostas, dejando al empleado sin forma de descartar el aviso una vez que RRHH ya resolvió el conflicto en Filament.

**Causa:** `.conflict-banner.is-visible` tenía `max-height: 64px` junto con `overflow: hidden`, dimensionado para una sola línea de contenido. En pantallas angostas el mensaje ("Una marcación reciente no pudo confirmarse — RRHH la va a revisar.") envuelve a 2 líneas, y el botón "Entendido" pasa a una tercera fila por `flex-wrap` — el contenido total supera los 64px y el botón queda recortado: sigue en el DOM (el listener funciona normal) pero invisible.

**Fix:** `max-height: 140px`, con margen suficiente para 3 líneas envueltas incluso con configuraciones de fuente más grandes (accesibilidad).

Confirmado con datos reales del servidor (vía tinker) que los 2 conflictos reportados por el usuario en esta sesión de QA son de un día anterior y ya están `resolution_status=approved` — el bug era puramente de visibilidad del botón, no de lógica de negocio.

## Test plan

- [x] Verificado visualmente con Playwright en un viewport de 360px (ancho típico de celular): antes del fix el botón "Entendido" queda fuera del área visible (recortado por `overflow: hidden`); después del fix se ve completo.
- [x] `vendor/bin/pint --dirty` — sin hallazgos (solo CSS, no aplica).
- [x] `npm run build` — sin errores.
- Sin cambios de lógica de negocio ni backend — no requiere tests Pest nuevos.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_