### PR TITLE
Fix: fecha corrida al editar la hora de una marcación en Filament

### DIFF
--- a/app/Filament/Resources/AttendanceDayResource/RelationManagers/EventsRelationManager.php
+++ b/app/Filament/Resources/AttendanceDayResource/RelationManagers/EventsRelationManager.php
@@ -197,7 +197,10 @@ class EventsRelationManager extends RelationManager
                             ->required(),
                     ])
                     ->mutateRecordDataUsing(function (array $data) {
-                        $dt = Carbon::parse($data['recorded_at']);
+                        // $record->attributesToArray() serializa recorded_at en UTC
+                        // (Carbon::toJSON()), no en la timezone de la app — sin la
+                        // conversión acá, la fecha (y hora) mostradas quedan corridas.
+                        $dt = Carbon::parse($data['recorded_at'])->timezone(config('app.timezone'));
 
                         return array_merge($data, [
                             'time' => $dt->format('H:i'),

--- a/app/Filament/Resources/AttendanceEventResource.php
+++ b/app/Filament/Resources/AttendanceEventResource.php
@@ -279,8 +279,11 @@ class AttendanceEventResource extends Resource
                                 ->required(),
                         ])
                         ->mutateRecordDataUsing(fn (array $data) => array_merge($data, [
-                            'time' => Carbon::parse($data['recorded_at'])->format('H:i'),
-                            '_date' => Carbon::parse($data['recorded_at'])->format('Y-m-d'),
+                            // $record->attributesToArray() serializa recorded_at en UTC
+                            // (Carbon::toJSON()), no en la timezone de la app — sin la
+                            // conversión acá, la fecha (y hora) mostradas quedan corridas.
+                            'time' => Carbon::parse($data['recorded_at'])->timezone(config('app.timezone'))->format('H:i'),
+                            '_date' => Carbon::parse($data['recorded_at'])->timezone(config('app.timezone'))->format('Y-m-d'),
                         ]))
                         ->mutateFormDataUsing(fn (array $data) => [
                             'event_type' => $data['event_type'],

--- a/tests/Feature/AttendanceEventResourceEditTest.php
+++ b/tests/Feature/AttendanceEventResourceEditTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Filament\Resources\AttendanceDayResource\Pages\ViewAttendanceDay;
+use App\Filament\Resources\AttendanceDayResource\RelationManagers\EventsRelationManager;
+use App\Filament\Resources\AttendanceEventResource\Pages\ManageAttendanceEvents;
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeEditableAttendanceEvent(string $recordedAt): AttendanceEvent
+{
+    static $ci = 8700000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Edit {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Edit {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Edit {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Edit {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Edit', 'last_name' => 'Test', 'ci' => (string) $n,
+        'birth_date' => '1990-01-01', 'branch_id' => $branch->id, 'status' => 'active',
+    ]);
+    Contract::create([
+        'employee_id' => $employee->id, 'type' => 'indefinido', 'start_date' => now()->subYear(),
+        'salary_type' => 'mensual', 'salary' => 2_550_000, 'position_id' => $position->id,
+        'department_id' => $department->id, 'status' => 'active',
+    ]);
+
+    $day = AttendanceDay::create(['employee_id' => $employee->id, 'date' => date('Y-m-d', strtotime($recordedAt)), 'status' => 'present']);
+
+    return AttendanceEvent::create([
+        'attendance_day_id' => $day->id,
+        'event_type' => 'break_start',
+        'recorded_at' => $recordedAt,
+        'source' => 'mobile',
+    ]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+/**
+ * Regresión: $record->attributesToArray() (usado internamente por
+ * EditAction::fillForm()) serializa `recorded_at` en UTC (Carbon::toJSON()),
+ * no en la timezone de la app. Sin convertir antes de extraer fecha/hora, un
+ * evento marcado a las 21:32 en Paraguay (UTC-3) prellenaba el modal con la
+ * fecha del día SIGUIENTE (00:32 UTC cruza la medianoche).
+ */
+it('el modal de editar marcación prellena la fecha y hora correctas en la timezone de la app', function () {
+    $this->actingAs(User::factory()->create());
+    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+
+    $test = Livewire::test(ManageAttendanceEvents::class)
+        ->mountTableAction('edit', $event);
+
+    $data = $test->instance()->mountedTableActionsData[array_key_last($test->instance()->mountedTableActionsData)];
+
+    // '_date' es un campo Hidden plano, no pasa por la re-hidratación de
+    // TimePicker, así que refleja exactamente lo calculado en
+    // mutateRecordDataUsing(). 'time' sí la sufre (TimePicker le adjunta la
+    // fecha de "hoy" a su estado interno, descartada al guardar — ver el
+    // siguiente test para la verificación funcional real), por eso se
+    // valida por contenido en vez de por igualdad exacta.
+    expect($data['_date'])->toBe('2026-08-23')
+        ->and($data['time'])->toContain('21:32');
+});
+
+it('guardar el modal de editar marcación sin cambios no corre la fecha ni la hora', function () {
+    $this->actingAs(User::factory()->create());
+    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+
+    Livewire::test(ManageAttendanceEvents::class)
+        ->mountTableAction('edit', $event)
+        ->callMountedTableAction();
+
+    expect($event->fresh()->recorded_at->format('Y-m-d H:i'))->toBe('2026-08-23 21:32');
+});
+
+/**
+ * Mismo bug, mismo patrón, en la relation manager de AttendanceDayResource.
+ */
+it('el modal de editar marcación en AttendanceDayResource prellena la fecha correcta', function () {
+    $this->actingAs(User::factory()->create());
+    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+
+    $test = Livewire::test(
+        EventsRelationManager::class,
+        ['ownerRecord' => $event->day, 'pageClass' => ViewAttendanceDay::class]
+    )
+        ->mountTableAction('edit', $event);
+
+    $data = $test->instance()->mountedTableActionsData[array_key_last($test->instance()->mountedTableActionsData)];
+
+    expect($data['_date'])->toBe('2026-08-23')
+        ->and($data['time'])->toContain('21:32');
+});

--- a/tests/Feature/AttendanceEventResourceEditTest.php
+++ b/tests/Feature/AttendanceEventResourceEditTest.php
@@ -13,13 +13,23 @@ use App\Models\Employee;
 use App\Models\Position;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function makeEditableAttendanceEvent(string $recordedAt): AttendanceEvent
+/**
+ * Crea un AttendanceEvent marcado "hoy" a las 21:32:39 — hora elegida a
+ * propósito porque +3h de offset (America/Asuncion → UTC) cruza la
+ * medianoche, ejerciendo el escenario exacto de la regresión. Se usa la
+ * fecha real de "hoy" (no un valor fijo) porque ManageAttendanceEvents
+ * arranca con el tab "Hoy" activo (whereDate('recorded_at', now())) — un
+ * evento con fecha fija quedaría filtrado fuera de la tabla en CI y
+ * mountTableAction() no lo encontraría.
+ */
+function makeEditableAttendanceEvent(): AttendanceEvent
 {
     static $ci = 8700000;
     $n = $ci++;
@@ -39,7 +49,8 @@ function makeEditableAttendanceEvent(string $recordedAt): AttendanceEvent
         'department_id' => $department->id, 'status' => 'active',
     ]);
 
-    $day = AttendanceDay::create(['employee_id' => $employee->id, 'date' => date('Y-m-d', strtotime($recordedAt)), 'status' => 'present']);
+    $recordedAt = Carbon::today()->setTime(21, 32, 39);
+    $day = AttendanceDay::create(['employee_id' => $employee->id, 'date' => $recordedAt->toDateString(), 'status' => 'present']);
 
     return AttendanceEvent::create([
         'attendance_day_id' => $day->id,
@@ -60,7 +71,8 @@ function makeEditableAttendanceEvent(string $recordedAt): AttendanceEvent
  */
 it('el modal de editar marcación prellena la fecha y hora correctas en la timezone de la app', function () {
     $this->actingAs(User::factory()->create());
-    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+    $event = makeEditableAttendanceEvent();
+    $expectedDate = $event->recorded_at->toDateString();
 
     $test = Livewire::test(ManageAttendanceEvents::class)
         ->mountTableAction('edit', $event);
@@ -73,19 +85,20 @@ it('el modal de editar marcación prellena la fecha y hora correctas en la timez
     // fecha de "hoy" a su estado interno, descartada al guardar — ver el
     // siguiente test para la verificación funcional real), por eso se
     // valida por contenido en vez de por igualdad exacta.
-    expect($data['_date'])->toBe('2026-08-23')
+    expect($data['_date'])->toBe($expectedDate)
         ->and($data['time'])->toContain('21:32');
 });
 
 it('guardar el modal de editar marcación sin cambios no corre la fecha ni la hora', function () {
     $this->actingAs(User::factory()->create());
-    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+    $event = makeEditableAttendanceEvent();
+    $expected = $event->recorded_at->format('Y-m-d H:i');
 
     Livewire::test(ManageAttendanceEvents::class)
         ->mountTableAction('edit', $event)
         ->callMountedTableAction();
 
-    expect($event->fresh()->recorded_at->format('Y-m-d H:i'))->toBe('2026-08-23 21:32');
+    expect($event->fresh()->recorded_at->format('Y-m-d H:i'))->toBe($expected);
 });
 
 /**
@@ -93,7 +106,8 @@ it('guardar el modal de editar marcación sin cambios no corre la fecha ni la ho
  */
 it('el modal de editar marcación en AttendanceDayResource prellena la fecha correcta', function () {
     $this->actingAs(User::factory()->create());
-    $event = makeEditableAttendanceEvent('2026-08-23 21:32:39');
+    $event = makeEditableAttendanceEvent();
+    $expectedDate = $event->recorded_at->toDateString();
 
     $test = Livewire::test(
         EventsRelationManager::class,
@@ -103,6 +117,6 @@ it('el modal de editar marcación en AttendanceDayResource prellena la fecha cor
 
     $data = $test->instance()->mountedTableActionsData[array_key_last($test->instance()->mountedTableActionsData)];
 
-    expect($data['_date'])->toBe('2026-08-23')
+    expect($data['_date'])->toBe($expectedDate)
         ->and($data['time'])->toContain('21:32');
 });


### PR DESCRIPTION
## Resumen

Bug encontrado en QA manual real: en el recurso **Marcaciones**, al editar el horario de una marcación, el modal (que solo permite editar la hora, mostrando la fecha como solo lectura) asignaba la fecha del **día siguiente**.

**Causa:** `$record->attributesToArray()` — usado internamente por Filament's `EditAction::fillForm()` para prellenar el formulario — serializa atributos `datetime` en **UTC** (`Carbon::toJSON()`), no en la timezone de la app. El patrón de "editar solo la hora" (documentado en `CLAUDE.md`, replicado en `AttendanceEventResource` y `AttendanceDayResource/EventsRelationManager`) calculaba `_date`/`time` con `Carbon::parse()` directo sobre ese valor UTC, sin convertir a `config('app.timezone')`. Una marcación a las 21:32 en Paraguay (UTC-3) cruza la medianoche en UTC (00:32 del día siguiente), así que el modal prellenaba con la fecha equivocada.

Mismo patrón de bug que ya corregimos en el PR #95 (sync offline), esta vez del lado del modal de edición del admin.

**Fix:** convertir a `config('app.timezone')` antes de extraer fecha y hora, en ambos lugares donde se replica el patrón.

## Test plan

- [x] Verificado con datos reales del servidor (vía tinker, replicando exactamente `$record->attributesToArray()`): antes del fix, una marcación de las 21:32:39 prellenaba el modal con fecha del día siguiente; después del fix, la fecha y hora quedan correctas.
- [x] `tests/Feature/AttendanceEventResourceEditTest.php` (nuevo): el modal de `AttendanceEventResource` prellena `_date`/`time` correctos; guardar sin cambios no corre la fecha ni la hora; mismo test para `AttendanceDayResource/EventsRelationManager`.
- [x] Verificado el round-trip completo (prellenado → guardado sin cambios) contra una BD SQLite de scratch vía `Livewire::test()` — el valor final coincide exactamente con el original.
- [x] `php -l` sobre los archivos tocados — sin errores de sintaxis.
- [x] `vendor/bin/pint --dirty` — aplicó fixers menores (orden de imports).
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL; el test de `ManageAttendanceEvents` además usa una consulta con `CURDATE()`, MySQL-only, para los contadores de tabs), se confirma en el pipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_