### PR TITLE
Notificar re-vinculación de dispositivo también por email

### DIFF
--- a/app/Notifications/MobileDeviceRelinkedNotification.php
+++ b/app/Notifications/MobileDeviceRelinkedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Filament\Resources\EmployeeResource;
 use App\Models\Employee;
 use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 /**
@@ -32,7 +33,27 @@ class MobileDeviceRelinkedNotification extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database'];
+        return ['database', 'mail'];
+    }
+
+    /**
+     * Envía por email a los admins además de la campanita — una
+     * re-vinculación puede indicar un intento de acoso/DoS dirigido (ver
+     * docblock de la clase) y no debería depender de que alguien revise
+     * Filament a tiempo.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject('Dispositivo re-vinculado — '.$this->employee->full_name)
+            ->line("El dispositivo vinculado de {$this->employee->full_name} (CI: {$this->employee->ci}) fue reemplazado por uno nuevo.")
+            ->line('Si el empleado no reconoce este cambio, revocá el acceso desde su ficha.');
+
+        if (filled($this->userAgent)) {
+            $mail->line("Dispositivo nuevo: {$this->userAgent}");
+        }
+
+        return $mail->action('Ver empleado', EmployeeResource::getUrl('view', ['record' => $this->employee]));
     }
 
     /**

--- a/app/Notifications/TerminalProvisionedNotification.php
+++ b/app/Notifications/TerminalProvisionedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Filament\Resources\TerminalResource;
 use App\Models\Terminal;
 use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 /**
@@ -26,7 +27,20 @@ class TerminalProvisionedNotification extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['database'];
+        return ['database', 'mail'];
+    }
+
+    /**
+     * Envía por email a los admins además de la campanita — confirma la
+     * instalación física del kiosko (o su reprovisión) sin depender de que
+     * alguien revise Filament a tiempo.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Terminal provisionado — '.$this->terminal->name)
+            ->line("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.")
+            ->action('Ver terminal', TerminalResource::getUrl('view', ['record' => $this->terminal]));
     }
 
     /**

--- a/tests/Feature/AdminNotificationsTest.php
+++ b/tests/Feature/AdminNotificationsTest.php
@@ -78,6 +78,20 @@ it('la url de la notificación de terminal apunta al detalle real del recurso', 
     expect($data['actions'][0]['url'])->toBe(TerminalResource::getUrl('view', ['record' => $terminal]));
 });
 
+it('la notificación de terminal provisionado también se envía por email', function () {
+    $employee = makeNotifiableEmployee();
+    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+
+    $notification = new TerminalProvisionedNotification($terminal);
+
+    expect($notification->via(new User))->toBe(['database', 'mail']);
+
+    $mail = $notification->toMail(new User);
+
+    expect($mail->subject)->toBe('Terminal provisionado — Kiosko Test')
+        ->and($mail->actionUrl)->toBe(TerminalResource::getUrl('view', ['record' => $terminal]));
+});
+
 // ─── Autoenrolamiento pendiente de aprobación ──────────────────────────────
 
 it('notifica a los admins cuando un empleado completa el autoenrolamiento facial', function () {
@@ -171,4 +185,20 @@ it('las notificaciones de dispositivo apuntan a la ficha real del empleado', fun
 
     expect($linked->toDatabase(new User)['actions'][0]['url'])->toBe($expectedUrl)
         ->and($relinked->toDatabase(new User)['actions'][0]['url'])->toBe($expectedUrl);
+});
+
+it('la notificación de re-vinculación también se envía por email, la de primera vinculación no', function () {
+    $employee = makeNotifiableEmployee();
+
+    $linked = new MobileDeviceLinkedNotification($employee);
+    $relinked = new MobileDeviceRelinkedNotification($employee, 'Mozilla/5.0 Test');
+
+    expect($linked->via(new User))->toBe(['database'])
+        ->and($relinked->via(new User))->toBe(['database', 'mail']);
+
+    $mail = $relinked->toMail(new User);
+
+    expect($mail->subject)->toBe("Dispositivo re-vinculado — {$employee->full_name}")
+        ->and($mail->actionUrl)->toBe(EmployeeResource::getUrl('view', ['record' => $employee]))
+        ->and(collect($mail->introLines)->implode(' '))->toContain('Dispositivo nuevo: Mozilla/5.0 Test');
 });


### PR DESCRIPTION
## Resumen

- `MobileDeviceRelinkedNotification` (celular personal re-vinculado) y `TerminalProvisionedNotification` (kiosko provisionado/reprovisionado) ahora agregan el canal `mail` además de la campanita in-app (`database`).
- `MobileDeviceLinkedNotification` (primera vinculación, sin riesgo de acoso/DoS) queda sin cambios — solo `database`.
- Destinatarios: los mismos admins que ya reciben la notificación in-app (`User::all()`), sin cambios en el punto de disparo (`Employee::claimMobileToken()` / `Terminal::claimSanctumToken()`).

**Por qué:** una re-vinculación de celular puede indicar que alguien con el CI + fecha de nacimiento de un empleado (credencial de baja entropía) revocó su dispositivo legítimo — la visibilidad no debería depender de que un admin entre a revisar Filament a tiempo.

**Nota operativa:** esta es la primera notificación por email de todo el proyecto — confirmar que el servidor de producción tiene `MAIL_MAILER` con un driver real (no `log`, el default de `.env.example`) antes de asumir que estos emails van a salir.

## Test plan

- [x] Verificado con un harness sobre SQLite de scratch (vía tinker, reproduciendo `via()`/`toMail()` de ambas notificaciones): canales correctos (`database`+`mail` en las dos nuevas, solo `database` en la de primera vinculación), `subject`/`actionUrl` correctos, y la línea de user-agent aparece en `introLines` (se reordenó el `->action()` al final para que la línea condicional no caiga en `outroLines`).
- [x] Tests Pest nuevos en `tests/Feature/AdminNotificationsTest.php` — mismo patrón que los tests existentes de esta suite.
- [x] `php -l` sobre los archivos tocados — sin errores de sintaxis.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_