### PR TITLE
Fix: throttle compartido entre terminal.setup y registro-facial

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -53,7 +53,11 @@ Route::get('/terminal/{code}', [AttendanceFaceMarkController::class, 'terminalBy
 
 // Provisión del terminal como PWA offline — enlace de un solo uso generado desde TerminalResource,
 // emite el token Sanctum que el kiosko usará contra la API de sincronización (routes/api.php).
-Route::prefix('terminal/{code}/setup/{setupToken}')->name('terminal.setup.')->middleware('throttle:10,1')->group(function () {
+// Prefijo explícito en el throttle: sin él, comparte bucket de rate limit (por
+// IP, sin distinguir ruta — ver ThrottleRequests::resolveRequestSignature())
+// con cualquier otra ruta pública que use 'throttle:X,Y' sin prefijo, como
+// 'registro-facial' más abajo.
+Route::prefix('terminal/{code}/setup/{setupToken}')->name('terminal.setup.')->middleware('throttle:10,1,terminal-setup')->group(function () {
     Route::get('/', [TerminalSetupController::class, 'show'])->name('show');
     Route::post('/claim', [TerminalSetupController::class, 'claim'])->name('claim');
 });
@@ -87,7 +91,8 @@ Route::prefix('vincular-dispositivo')->name('device-link.')->group(function () {
 |
 */
 
-Route::prefix('registro-facial')->name('face-enrollment.')->middleware('throttle:10,1')->group(function () {
+// Prefijo explícito por el mismo motivo que 'terminal.setup' arriba.
+Route::prefix('registro-facial')->name('face-enrollment.')->middleware('throttle:10,1,face-enrollment')->group(function () {
     Route::get('/{token}', [FaceEnrollmentController::class, 'show'])->name('show');
     Route::post('/{token}', [FaceEnrollmentController::class, 'store'])->name('store');
 });

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -375,6 +375,26 @@ it('el 429 de otras rutas throttled no se ve afectado por el mensaje de vincular
 });
 
 /**
+ * Regresión: 'terminal.setup' y 'face-enrollment' usaban ambos 'throttle:10,1'
+ * sin prefijo — ThrottleRequests::resolveRequestSignature() genera la clave
+ * del rate limit solo con dominio+IP (sin distinguir ruta), así que ambos
+ * grupos compartían el mismo bucket por IP. Agotar el límite de una ruta
+ * bloqueaba también a la otra, aunque cada una tenga su propio límite
+ * nominal de 10/min. Ahora cada grupo tiene su propio prefijo
+ * ('terminal-setup' / 'face-enrollment').
+ */
+it('el throttle de terminal.setup y el de face-enrollment ya no comparten bucket', function () {
+    for ($i = 0; $i < 10; $i++) {
+        $this->getJson('/terminal/BOGUS/setup/faketoken');
+    }
+    $this->getJson('/terminal/BOGUS/setup/faketoken')->assertStatus(429);
+
+    // Antes del fix, esta request ya venía bloqueada por el bucket compartido
+    // aunque 'registro-facial' nunca haya sido golpeada.
+    $this->getJson('/registro-facial/faketoken')->assertStatus(404);
+});
+
+/**
  * MobileLinkController::throttledResponse() es la lógica que arma el mensaje
  * y decide si notificar a los admins — se prueba directamente (sin esperar
  * 15 requests reales limitadas a 5/minuto) construyendo la excepción con los


### PR DESCRIPTION
## Resumen

Mismo bug ya corregido para `/vincular-dispositivo` en un PR anterior, esta vez en las dos rutas públicas restantes que quedaban con `throttle:10,1` sin prefijo: `terminal/{code}/setup/{setupToken}` y `registro-facial/{token}`.

**Causa:** `ThrottleRequests::resolveRequestSignature()` genera la clave del rate limit solo con `dominio+IP` — no incluye la ruta, ni `maxAttempts`, ni `decayMinutes`. Sin un prefijo explícito en el middleware, **cualquier** `throttle:X,Y` golpeado por la misma IP comparte el mismo contador, sin importar la ruta. Como ambos grupos usaban `throttle:10,1` sin prefijo, compartían bucket entre sí — agotar el límite de uno bloqueaba también al otro.

**Fix:** prefijo explícito por grupo (`terminal-setup` / `face-enrollment`), mismo patrón ya usado en `/vincular-dispositivo`. Se mantienen los límites nominales (10/min cada uno) — no se tocó la relación GET/POST dentro de cada grupo porque ambos tokens (setup del terminal, registro facial) son aleatorios de alta entropía, sin el mismo riesgo de fuerza bruta que CI+fecha de nacimiento.

## Test plan

- [x] Verificado end-to-end contra un servidor real (`php artisan serve` + curl, SQLite de scratch): antes del fix, agotar el bucket de `terminal.setup` (10 requests) hacía que la 11ª request a `registro-facial` también devolviera 429 sin haberla tocado antes. Después del fix, cada ruta tiene su propio balde de 10/min independiente (confirmado también que `registro-facial` agota su propio límite en su propia 11ª request).
- [x] Test Pest nuevo en `tests/Feature/MobileAttendanceLinkTest.php`.
- [x] `php -l` sobre los archivos tocados — sin errores de sintaxis.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_