### PR TITLE
Mostrar foto real del empleado al marcar desde el celular

### DIFF
--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -51,6 +51,7 @@ class MobileHeartbeatController extends Controller
                 'last_name' => $employee->last_name,
                 'ci' => $employee->ci,
                 'face_descriptor' => $employee->face_descriptor,
+                'photo_thumbnail' => $employee->photo_thumbnail,
             ],
         ]);
     }

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1466,6 +1466,7 @@ const statusBar           = document.getElementById("statusBar");
                 first_name: matched.first_name,
                 last_name: matched.last_name,
                 ci: matched.ci,
+                photo_url: matched.photo_thumbnail || null,
             };
 
             // Estado del día: intenta consulta en línea (y la cachea); si no hay red, cae a lo

--- a/resources/js/attendances/mobile-offline/matcher.js
+++ b/resources/js/attendances/mobile-offline/matcher.js
@@ -35,7 +35,7 @@ export function euclideanDistance(a, b) {
  * aplicando el mismo criterio de umbral + gap de confianza que el backend.
  *
  * @param {number[]} liveDescriptor - Descriptor capturado en el momento.
- * @param {Array<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}>} candidates - Normalmente un solo empleado (el propio dueño del dispositivo).
+ * @param {Array<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[], photo_thumbnail?: string|null}>} candidates - Normalmente un solo empleado (el propio dueño del dispositivo).
  * @param {number} threshold - Distancia máxima para aceptar un match (face_threshold).
  * @param {number} minGap - Diferencia mínima requerida con el segundo candidato (face_min_confidence_gap).
  * @returns {{employee: object|null, distance: number, reason: 'no_match'|'ambiguous'|'no_candidates'|null}}

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -150,6 +150,16 @@ it('el heartbeat devuelve la config vigente y el descriptor facial del empleado'
         ->and($response->json('config.face_threshold'))->not->toBeNull();
 });
 
+it('el heartbeat también devuelve photo_thumbnail para que el celular muestre la foto real', function () {
+    $employee = makeLinkableEmployee(['photo_thumbnail' => 'data:image/jpeg;base64,FAKE_THUMBNAIL']);
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.photo_thumbnail'))->toBe('data:image/jpeg;base64,FAKE_THUMBNAIL');
+});
+
 it('el heartbeat revoca el token y responde 403 si el empleado ya no está activo', function () {
     $employee = makeLinkableEmployee();
     Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);


### PR DESCRIPTION
## Resumen

El kiosko muestra la foto real del empleado desde el PR #83, pero `/marcar` (celular) siempre caía al fallback de iniciales — el frontend (`mark.js`) ya tenía el código listo para mostrarla (`employee.photo_url`, con fallback automático a iniciales), pero el backend nunca la enviaba.

**Causa:** el kiosko sincroniza `photo_thumbnail` vía un endpoint de "sync de empleados" dedicado (`EmployeeDescriptorSyncService`). El celular no tiene ese endpoint — todo llega por el heartbeat (`MobileHeartbeatController`), que no incluía `photo_thumbnail` en su respuesta.

**Fix:**
- `MobileHeartbeatController` agrega `photo_thumbnail` al payload del `employee` (mismo campo, mismo formato data-URI que ya usa el kiosko).
- `mark.js` mapea `matched.photo_thumbnail` → `photo_url` al construir el empleado identificado tras el matching local — es el mismo campo que `transitionToStep2()` ya consumía, sin cambios de UI.

## Test plan

- [x] Verificado end-to-end contra un servidor real (`php artisan serve` + curl con token Sanctum real, SQLite de scratch): el heartbeat devuelve `photo_thumbnail` correctamente.
- [x] Verificado el mapeo `matched.photo_thumbnail` → `photo_url` en Node directo contra `identifyEmployee()` real (con y sin foto — el caso sin foto cae a `null`, que `transitionToStep2()` ya traduce a iniciales).
- [x] Test Pest nuevo en `tests/Feature/MobileAttendanceLinkTest.php`.
- [x] `npm run build` — sin errores, sin cambios de tamaño relevantes.
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_