### PR TITLE
Switch de pausa de cámara y "Mis marcaciones" en /marcar

### DIFF
--- a/app/Http/Controllers/Api/MobileStatusController.php
+++ b/app/Http/Controllers/Api/MobileStatusController.php
@@ -17,6 +17,10 @@ use Illuminate\Http\Request;
  * El dispositivo prefiere esta consulta en línea; si falla, cae a una
  * resolución local equivalente (ver mobile-offline/queue.js, igual que
  * hace el kiosko desde la Fase 4).
+ *
+ * `today_events` (lista completa del día, no solo el último) alimenta la
+ * pantalla "Mis marcaciones" en /marcar — a diferencia del resto de esta
+ * respuesta, no tiene resolución local offline equivalente.
  */
 class MobileStatusController extends Controller
 {
@@ -28,15 +32,21 @@ class MobileStatusController extends Controller
         $today = now(config('app.timezone'))->toDateString();
 
         $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today)->first();
-        $last = $day
-            ? AttendanceEvent::where('attendance_day_id', $day->id)->latest('recorded_at')->first()
-            : null;
+        $events = $day
+            ? AttendanceEvent::where('attendance_day_id', $day->id)->orderBy('recorded_at')->get(['event_type', 'recorded_at'])
+            : collect();
+        $last = $events->last();
 
         return response()->json([
             'ok' => true,
             'last_event' => $last?->event_type,
             'last_event_time' => $last?->recorded_at?->format('H:i'),
             'allowed_events' => AttendanceEvent::allowedNextEventTypes($last?->event_type),
+            'today_events' => $events->map(fn (AttendanceEvent $event): array => [
+                'event_type' => $event->event_type,
+                'event_type_label' => AttendanceEvent::getEventTypeLabel($event->event_type),
+                'time' => $event->recorded_at->format('H:i'),
+            ])->values(),
         ]);
     }
 }

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -188,9 +188,10 @@ body.modal-open { overflow: hidden; }
    ============================================================ */
 .sync-status-row {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
-    gap: var(--sp-3);
+    gap: var(--sp-2) var(--sp-3);
     padding: var(--sp-1) var(--sp-4);
     background: var(--c-bg);
     border-bottom: 1px solid var(--c-border);
@@ -221,6 +222,14 @@ body.modal-open { overflow: hidden; }
     background: var(--c-danger-bg);
     color: var(--c-danger);
     border-color: var(--c-danger-bg);
+}
+.sync-status-btn--camera-pause { display: inline-flex; align-items: center; gap: 4px; }
+.camera-pause-icon { width: 14px; height: 14px; flex-shrink: 0; }
+/* Estado activo (cámara pausada) — mismo tratamiento visual que otros avisos de atención */
+.sync-status-btn--camera-pause[aria-pressed="true"] {
+    background: var(--c-warning-bg);
+    color: var(--c-warning);
+    border-color: var(--c-warning-ring);
 }
 .app-mode-badge {
     background: var(--c-primary-bg);
@@ -344,6 +353,25 @@ video  { width: 100%; height: 100%; object-fit: cover; display: block; filter: b
 }
 .camera-fallback:hover { background: rgba(15, 23, 42, 0.7); }
 .camera-fallback svg { width: 48px; height: 48px; opacity: .9; }
+
+/* Pausa manual de cámara (btnCameraPause) — cubre el video mientras la detección está detenida */
+.camera-paused-overlay {
+    position: absolute; inset: 0; z-index: 11;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    gap: var(--sp-2);
+    background: rgba(15, 23, 42, 0.92);
+    border: none; cursor: pointer;
+    color: #fff;
+    text-align: center;
+    padding: var(--sp-4);
+    transition: background var(--tr);
+}
+.camera-paused-overlay:hover { background: rgba(15, 23, 42, 0.8); }
+.camera-paused-overlay svg { width: 40px; height: 40px; opacity: .85; }
+.camera-paused-title { font-size: 1rem; font-weight: 600; }
+.camera-paused-hint  { font-size: .8125rem; opacity: .8; }
+
 canvas {
     position: absolute; inset: 0;
     width: 100%; height: 100%;
@@ -1037,6 +1065,27 @@ select#eventType { display: none; }
     padding: var(--sp-2) var(--sp-3);
     margin-bottom: var(--sp-4);
 }
+
+/* Lista de "Mis marcaciones de hoy" */
+.my-events-list {
+    list-style: none;
+    margin: 0 0 var(--sp-5);
+    padding: 0;
+    text-align: left;
+    max-height: 260px;
+    overflow-y: auto;
+}
+.my-events-item {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: var(--sp-3);
+    padding: var(--sp-3) var(--sp-1);
+    border-bottom: 1px solid var(--c-border);
+    font-size: .9375rem;
+}
+.my-events-item:last-child { border-bottom: none; }
+.my-events-item-type { font-weight: 600; color: var(--c-text); }
+.my-events-item-time { color: var(--c-muted); font-variant-numeric: tabular-nums; }
+.my-events-status { font-size: .875rem; color: var(--c-muted); margin-bottom: var(--sp-6); }
 
 .modal-actions { display: flex; flex-direction: column; gap: var(--sp-2); }
 .btn-modal-retry   { background: var(--c-primary); color: #fff; }

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -109,6 +109,10 @@ const statusBar           = document.getElementById("statusBar");
     const btnUnlinkDevice     = document.getElementById("btnUnlinkDevice");
     const conflictBanner      = document.getElementById("conflictBanner");
     const btnDismissConflict  = document.getElementById("btnDismissConflict");
+    const btnMyEvents         = document.getElementById("btnMyEvents");
+    const btnCameraPause      = document.getElementById("btnCameraPause");
+    const btnCameraPauseLabel = document.getElementById("btnCameraPauseLabel");
+    const cameraPausedOverlay = document.getElementById("cameraPausedOverlay");
 
     // ==========================================================================
     // CONFIGURACIÓN Y CONSTANTES
@@ -155,6 +159,25 @@ const statusBar           = document.getElementById("statusBar");
      * @type {MediaStream|null}
      */
     let stream = null;
+
+    /**
+     * Pausa manual de cámara (btnCameraPause) — el empleado la activa para usar
+     * Sincronizar/Mis marcaciones/Desvincular sin riesgo de que el dwell lo
+     * identifique de encima. Independiente de `stream`: se consulta al volver
+     * a Paso 1 (transitionToStep1) para no reactivar la cámara sola.
+     * @type {boolean}
+     */
+    let cameraPaused = false;
+
+    /**
+     * Auto-reanudado de seguridad — evita que una pausa olvidada bloquee la
+     * marcación indefinidamente sin que el empleado lo note.
+     * @type {number|null}
+     */
+    let cameraPauseResumeTimer = null;
+
+    /** Milisegundos de pausa antes del auto-reanudado de seguridad */
+    const CAMERA_PAUSE_AUTO_RESUME_MS = 120_000;
 
     /**
      * Indica si los modelos de face-api.js están cargados
@@ -509,6 +532,44 @@ const statusBar           = document.getElementById("statusBar");
             }
         });
     }
+
+    // Switch "Pausar cámara" — apaga el stream para que el empleado pueda usar
+    // Sincronizar/Mis marcaciones/Desvincular sin riesgo de que el dwell lo
+    // identifique de encima (ver pauseCamera()/resumeCamera() más abajo).
+    if (btnCameraPause) {
+        btnCameraPause.addEventListener("click", () => {
+            if (cameraPaused) {
+                resumeCamera();
+            } else {
+                pauseCamera();
+            }
+        });
+    }
+    if (cameraPausedOverlay) {
+        cameraPausedOverlay.addEventListener("click", () => { resumeCamera(); });
+    }
+
+    // Botón "Mis marcaciones" — no requiere pasar por la cámara, el dispositivo
+    // ya sabe de quién es (vinculación 1:1). Reusa getOwnStatus() (mismo
+    // camino que la identificación) para no duplicar el manejo de auth/red.
+    if (btnMyEvents) {
+        btnMyEvents.addEventListener("click", () => { openMyEventsModal(); });
+    }
+    const closeMyEventsBtn = document.getElementById("closeMyEventsModal");
+    if (closeMyEventsBtn) {
+        closeMyEventsBtn.addEventListener("click", () => { closeMyEventsModal(); });
+    }
+    const myEventsModalEl = document.getElementById("myEventsModal");
+    if (myEventsModalEl) {
+        myEventsModalEl.addEventListener("click", (e) => {
+            if (e.target === myEventsModalEl) closeMyEventsModal();
+        });
+    }
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && myEventsModalEl && !myEventsModalEl.classList.contains("hidden")) {
+            closeMyEventsModal();
+        }
+    });
 
     // --------------------------------------------------------------------------
     // RELOJ EN TIEMPO REAL
@@ -1107,6 +1168,65 @@ const statusBar           = document.getElementById("statusBar");
                 setStatusBar("Iniciando cámara...", "detecting");
                 await startCamera();
             });
+        }
+    }
+
+    /** Refleja `cameraPaused` en el switch, el overlay del video y el status bar. */
+    function setCameraPausedUi(paused) {
+        if (btnCameraPause) {
+            btnCameraPause.setAttribute("aria-pressed", String(paused));
+        }
+        if (btnCameraPauseLabel) {
+            btnCameraPauseLabel.textContent = paused ? "Reanudar cámara" : "Pausar cámara";
+        }
+        if (cameraPausedOverlay) {
+            cameraPausedOverlay.classList.toggle("hidden", !paused);
+        }
+    }
+
+    /**
+     * Pausa manual de la cámara — apaga el stream por completo (no solo el
+     * dwell) para que el indicador de cámara del navegador se apague también.
+     * Rearma un auto-reanudado de seguridad para que una pausa olvidada no
+     * bloquee la marcación indefinidamente.
+     * @returns {void}
+     */
+    function pauseCamera() {
+        if (cameraPaused || !stream) return;
+
+        cancelAutoIdentifyDwell();
+        stream.getTracks().forEach((t) => t.stop());
+        stream = null;
+        drawLoopActive = false;
+        faceInFrameState = null;
+        if (video) video.srcObject = null;
+
+        cameraPaused = true;
+        setCameraPausedUi(true);
+        setStatusBar("Cámara en pausa", null);
+        logStatus("Cámara pausada manualmente");
+
+        clearTimeout(cameraPauseResumeTimer);
+        cameraPauseResumeTimer = setTimeout(() => { resumeCamera(); }, CAMERA_PAUSE_AUTO_RESUME_MS);
+    }
+
+    /**
+     * Reanuda la cámara tras una pausa manual. Si el empleado ya avanzó a
+     * Paso 2 mientras estaba pausada, solo limpia el estado — Paso 2 maneja
+     * su propio apagado/reinicio de cámara al volver a Paso 1.
+     * @returns {Promise<void>}
+     */
+    async function resumeCamera() {
+        if (!cameraPaused) return;
+
+        clearTimeout(cameraPauseResumeTimer);
+        cameraPauseResumeTimer = null;
+        cameraPaused = false;
+        setCameraPausedUi(false);
+
+        const onStep1 = step1Section && !step1Section.classList.contains("hidden");
+        if (onStep1) {
+            await startCamera();
         }
     }
 
@@ -1723,8 +1843,14 @@ const statusBar           = document.getElementById("statusBar");
             locationMarker = null;
         }
 
-        // Reiniciar cámara en paralelo con la animación
+        // Reiniciar cámara en paralelo con la animación — salvo que el empleado la
+        // haya pausado manualmente (btnCameraPause): en ese caso queda pausada y se
+        // vuelve a mostrar el overlay correspondiente en vez de reactivar el stream.
         faceInFrameState = null;
+        if (cameraPaused) {
+            setCameraPausedUi(true);
+            return;
+        }
         try {
             await startCamera();
         } catch (error) {
@@ -1886,6 +2012,90 @@ const statusBar           = document.getElementById("statusBar");
     function closeErrorModalHandler() {
         errorModalVisible = false;
         setTimeout(() => window.location.reload(), 250);
+    }
+
+    /**
+     * Abre el modal "Mis marcaciones de hoy" y consulta la lista completa de
+     * eventos del día vía getOwnStatus() (mismo camino que la identificación,
+     * con su misma resiliencia offline) — a diferencia del resto de esa
+     * respuesta, `today_events` no tiene resolución local equivalente: sin
+     * red, se avisa en vez de mostrar una lista parcial/desactualizada.
+     * @returns {Promise<void>}
+     */
+    async function openMyEventsModal() {
+        const modal      = document.getElementById("myEventsModal");
+        const listEl      = document.getElementById("myEventsList");
+        const emptyEl     = document.getElementById("myEventsEmpty");
+        const offlineEl   = document.getElementById("myEventsOffline");
+        const loadingEl   = document.getElementById("myEventsLoading");
+        const closeBtn    = document.getElementById("closeMyEventsModal");
+        if (!modal || !listEl) return;
+
+        listEl.innerHTML = "";
+        emptyEl?.classList.add("hidden");
+        offlineEl?.classList.add("hidden");
+        loadingEl?.classList.remove("hidden");
+
+        modal.setAttribute("aria-hidden", "false");
+        modal.classList.remove("hidden");
+        void modal.offsetWidth;
+        requestAnimationFrame(() => { modal.classList.add("show"); });
+        document.body.classList.add("modal-open");
+        setTimeout(() => { closeBtn?.focus(); }, 100);
+
+        try {
+            const status = await getOwnStatus();
+            loadingEl?.classList.add("hidden");
+
+            const events = status.today_events;
+            if (!Array.isArray(events)) {
+                // getOwnStatus() cayó al fallback offline — ese fallback no reconstruye
+                // la lista completa, solo el último evento (ver resolveOwnStatus()).
+                offlineEl?.classList.remove("hidden");
+                return;
+            }
+            if (events.length === 0) {
+                emptyEl?.classList.remove("hidden");
+                return;
+            }
+            for (const event of events) {
+                const li = document.createElement("li");
+                li.className = "my-events-item";
+
+                const typeSpan = document.createElement("span");
+                typeSpan.className = "my-events-item-type";
+                typeSpan.textContent = event.event_type_label || translateEventType(event.event_type);
+
+                const timeSpan = document.createElement("span");
+                timeSpan.className = "my-events-item-time";
+                timeSpan.textContent = event.time || "";
+
+                li.append(typeSpan, timeSpan);
+                listEl.appendChild(li);
+            }
+        } catch (error) {
+            loadingEl?.classList.add("hidden");
+            if (error instanceof MobileAuthError) {
+                closeMyEventsModal();
+                window.location.href = "/vincular-dispositivo";
+                return;
+            }
+            logWarn("No se pudo consultar mis marcaciones:", error.message);
+            offlineEl?.classList.remove("hidden");
+        }
+    }
+
+    /** Cierra el modal "Mis marcaciones de hoy" con animación. */
+    function closeMyEventsModal() {
+        const modal = document.getElementById("myEventsModal");
+        if (!modal) return;
+
+        modal.setAttribute("aria-hidden", "true");
+        modal.classList.remove("show");
+        setTimeout(() => {
+            modal.classList.add("hidden");
+            document.body.classList.remove("modal-open");
+        }, 250);
     }
 
     // ==========================================================================

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -96,6 +96,21 @@
         <button type="button" id="btnSyncNow" class="sync-status-btn" aria-label="Sincronizar marcaciones pendientes">
             Sincronizar
         </button>
+        <button type="button" id="btnMyEvents" class="sync-status-btn" aria-label="Ver mis marcaciones de hoy">
+            Mis marcaciones
+        </button>
+        {{-- Pausa manual de la cámara — apaga la detección facial para que el empleado pueda
+        usar Sincronizar/Mis marcaciones/Desvincular sin riesgo de que el dwell lo identifique
+        de encima mientras tanto. Ver cameraPausedOverlay en video-section.blade.php. --}}
+        <button type="button" id="btnCameraPause" class="sync-status-btn sync-status-btn--camera-pause"
+            aria-pressed="false" aria-label="Pausar identificación por cámara">
+            <svg class="camera-pause-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+                <circle cx="12" cy="13" r="4"/>
+            </svg>
+            <span id="btnCameraPauseLabel">Pausar cámara</span>
+        </button>
         <button type="button" id="btnUnlinkDevice" class="sync-status-btn sync-status-btn--unlink" aria-label="Desvincular este dispositivo">
             Desvincular dispositivo
         </button>
@@ -115,6 +130,30 @@
         description="Su marcación se ha registrado correctamente."
         buttonText="Listo"
     />
+
+    {{-- Mis marcaciones de hoy — no requiere pasar por la cámara: el dispositivo ya
+    sabe de quién es (vinculación 1:1), así que se consulta directo al abrir. --}}
+    <div id="myEventsModal" class="modal hidden" role="dialog" aria-modal="true"
+        aria-labelledby="myEventsModalTitle">
+        <div class="modal-content modal-info">
+            <div class="modal-icon modal-icon--info" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <polyline points="12 6 12 12 16 14"/>
+                </svg>
+            </div>
+            <h2 id="myEventsModalTitle">Mis marcaciones de hoy</h2>
+
+            <ul id="myEventsList" class="my-events-list" aria-live="polite"></ul>
+            <p id="myEventsEmpty" class="my-events-status hidden">Todavía no tenés marcaciones registradas hoy.</p>
+            <p id="myEventsOffline" class="my-events-status hidden">No se pudo consultar sin conexión — probá de nuevo cuando tengas internet.</p>
+            <p id="myEventsLoading" class="my-events-status hidden">Consultando...</p>
+
+            <div class="modal-actions">
+                <button id="closeMyEventsModal" type="button" class="btn-modal-dismiss">Cerrar</button>
+            </div>
+        </div>
+    </div>
 
     <div id="errorModal" class="modal hidden" role="dialog" aria-modal="true"
         aria-labelledby="errorModalTitle" aria-describedby="errorModalDesc">

--- a/resources/views/components/attendance/video-section.blade.php
+++ b/resources/views/components/attendance/video-section.blade.php
@@ -35,6 +35,22 @@
                 </svg>
                 <span>Toca para activar la cámara</span>
             </button>
+
+            {{-- Pausa manual de cámara (btnCameraPause en el header) — tocar el overlay
+            también reanuda, además del switch de arriba. --}}
+            <button id="cameraPausedOverlay" type="button" class="camera-paused-overlay hidden"
+                aria-label="Cámara en pausa — tocá para reanudar">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M1 1l22 22"/>
+                    <path d="M21 21H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l.65.98"/>
+                    <path d="M23 8v11a2 2 0 0 1-1.11 1.79"/>
+                    <path d="M14.12 9.88a4 4 0 0 1 1.87 3.62"/>
+                    <path d="M9.88 14.12A4 4 0 0 1 9 12"/>
+                </svg>
+                <span class="camera-paused-title">Cámara en pausa</span>
+                <span class="camera-paused-hint">Tocá para reanudar la identificación</span>
+            </button>
         </div>
 
         <div class="status-bar" id="statusBar" role="status" aria-live="polite">

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -182,7 +182,47 @@ it('status devuelve el último evento y los eventos permitidos para el propio em
             'ok' => true,
             'last_event' => null,
             'allowed_events' => ['check_in'],
+            'today_events' => [],
         ]);
+});
+
+/**
+ * Regresión: alimenta la pantalla "Mis marcaciones" en /marcar — a diferencia
+ * del resto de la respuesta, esta lista completa del día no tiene resolución
+ * offline local equivalente (ver resolveOwnStatus() en mobile-offline/queue.js).
+ */
+it('status devuelve la lista completa de eventos de hoy, no solo el último', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $this->postJson('/api/v1/mobile/events/sync', [
+        'events' => [
+            [
+                'client_event_id' => (string) Str::uuid(),
+                'event_type' => 'check_in',
+                'recorded_at' => now()->setTime(8, 3)->toDateTimeString(),
+                'location' => ['lat' => -25.28, 'lng' => -57.64],
+            ],
+            [
+                'client_event_id' => (string) Str::uuid(),
+                'event_type' => 'break_start',
+                'recorded_at' => now()->setTime(12, 1)->toDateTimeString(),
+                'location' => ['lat' => -25.28, 'lng' => -57.64],
+            ],
+        ],
+    ])->assertOk();
+
+    $response = $this->getJson('/api/v1/mobile/status');
+
+    $response->assertOk();
+    expect($response->json('today_events'))->toHaveCount(2)
+        ->and($response->json('today_events.0'))->toBe([
+            'event_type' => 'check_in',
+            'event_type_label' => 'Entrada jornada',
+            'time' => '08:03',
+        ])
+        ->and($response->json('today_events.1.event_type'))->toBe('break_start')
+        ->and($response->json('today_events.1.time'))->toBe('12:01');
 });
 
 it('events/sync crea el evento con origen mobile para el empleado autenticado', function () {


### PR DESCRIPTION
## Resumen

Pedido del empleado: poder tocar "Sincronizar"/"Desvincular dispositivo" (siempre visibles en la fila superior de `/marcar`) sin riesgo de que la detección automática en vivo (dwell) lo identifique de encima mientras tanto.

**Dos agregados, ambos en la misma fila (`sync-status-row`):**

1. **Switch "Pausar cámara"** — apaga el stream de cámara por completo (no solo el temporizador de dwell), muestra un overlay claro sobre el video ("Cámara en pausa — tocá para reanudar"). Reanuda al tocar el switch de nuevo o el propio overlay. Auto-reanudado de seguridad a los 2 minutos por si el empleado se olvida de reactivarla. `transitionToStep1()` (volver de Paso 2) respeta la pausa en vez de reactivar la cámara sola.

2. **Botón "Mis marcaciones"** — panel con la lista de eventos de hoy del propio empleado. No requiere pasar por la cámara (el dispositivo ya sabe de quién es, vinculación 1:1). `MobileStatusController` agrega `today_events` (lista completa, no solo el último evento) a la respuesta ya existente. Reusa `getOwnStatus()` (mismo camino que la identificación, misma resiliencia); si no hay red, avisa explícitamente en vez de mostrar una lista vieja o vacía engañosa — el fallback offline local no reconstruye la lista completa.

El kiosko queda sin cambios — es un dispositivo compartido pensado para funcionar sin que nadie lo toque, no aplica el mismo caso de uso.

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real (`php artisan serve`, cámara falsa vía flags de Chromium, SQLite de scratch con 2 eventos de hoy seedeados): 22/22 aserciones — layout de los 4 botones sin overflow en 375px, pausar/reanudar (aria-pressed, label, overlay, `video.srcObject`), modal "Mis marcaciones" con datos reales del servidor, cierre con Escape, y el caso sin conexión (aviso explícito, sin lista vieja/parcial).
- [x] Test Pest nuevo en `tests/Feature/MobileAttendanceLinkTest.php` para `today_events`.
- [x] `npm run build` — sin errores.
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_