### PR TITLE
Avisar cuando el dispositivo ya está vinculado antes de re-vincular

### DIFF
--- a/resources/js/attendances/device-link.js
+++ b/resources/js/attendances/device-link.js
@@ -1,0 +1,52 @@
+/**
+ * =============================================================================
+ * VINCULACIÓN DE DISPOSITIVO — AVISO DE RE-VINCULACIÓN
+ * =============================================================================
+ *
+ * @fileoverview device-link.blade.php es HTML+JS plano sin build step, salvo
+ *               por este módulo: chequea si el propio navegador ya tiene un
+ *               dispositivo vinculado (IndexedDB) antes de dejar completar el
+ *               formulario de nuevo. Sin esto, volver a esta URL desde un
+ *               dispositivo ya vinculado y reenviar el mismo CI+fecha genera
+ *               una re-vinculación real (revoca el token actual, dispara
+ *               MobileDeviceRelinkedNotification a los admins por campanita +
+ *               email) sin que el empleado se entere de que está pasando —
+ *               indistinguible para RRHH de un intento real de secuestro del
+ *               dispositivo.
+ */
+
+import { getMeta, getOwnEmployee, migrateTokenFromLocalStorage } from './mobile-offline/db.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    // Por si quedó un token sin migrar de una vinculación interrumpida (ej. el
+    // empleado cerró la pestaña antes de que /marcar corriera la migración).
+    await migrateTokenFromLocalStorage();
+
+    const token = await getMeta('api_token');
+    if (!token) return; // caso normal: primera vinculación, nada que avisar
+
+    const warning = document.getElementById('alreadyLinkedWarning');
+    const form = document.getElementById('linkForm');
+    const nameEl = document.getElementById('alreadyLinkedName');
+    const btnContinue = document.getElementById('btnContinueAnyway');
+    const btnCancel = document.getElementById('btnCancelRelink');
+    if (!warning || !form) return;
+
+    if (nameEl) {
+        const employee = await getOwnEmployee();
+        const fullName = [employee?.first_name, employee?.last_name].filter(Boolean).join(' ');
+        nameEl.textContent = fullName || 'este empleado';
+    }
+
+    form.classList.add('hidden');
+    warning.classList.remove('hidden');
+
+    btnContinue?.addEventListener('click', () => {
+        warning.classList.add('hidden');
+        form.classList.remove('hidden');
+    });
+
+    btnCancel?.addEventListener('click', () => {
+        window.location.href = '/marcar';
+    });
+});

--- a/resources/views/attendances/device-link.blade.php
+++ b/resources/views/attendances/device-link.blade.php
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Vincular dispositivo — Marcación de asistencia</title>
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    @vite('resources/js/attendances/device-link.js')
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
@@ -62,6 +63,32 @@
         .status--error { color: #f87171; }
         .status--success { color: #4ade80; }
         .hint { font-size: 0.8rem; color: #64748b; margin-top: 1.5rem; line-height: 1.5; }
+        .hidden { display: none !important; }
+
+        /* Aviso: este navegador ya tiene un dispositivo vinculado */
+        .already-linked-warning {
+            text-align: left;
+            background: #422006;
+            border: 1px solid #f59e0b;
+            border-radius: 0.75rem;
+            padding: 1.1rem 1.25rem;
+            margin-bottom: 1.5rem;
+        }
+        .already-linked-warning p { color: #fcd34d; font-size: 0.9rem; margin-bottom: 1rem; }
+        .already-linked-warning p:last-of-type { margin-bottom: 1.25rem; }
+        .already-linked-actions { display: flex; flex-direction: column; gap: 0.6rem; }
+        .btn-continue-anyway {
+            width: 100%; font: inherit; font-weight: 600; font-size: 0.9rem;
+            padding: 0.7rem 1.5rem; border-radius: 0.6rem; border: 1px solid #f59e0b;
+            background: transparent; color: #fcd34d; cursor: pointer;
+        }
+        .btn-continue-anyway:hover { background: rgba(245, 158, 11, 0.12); }
+        .btn-cancel-relink {
+            width: 100%; font: inherit; font-weight: 600; font-size: 0.9rem;
+            padding: 0.7rem 1.5rem; border-radius: 0.6rem; border: none;
+            background: #38bdf8; color: #0f172a; cursor: pointer;
+        }
+        .btn-cancel-relink:hover { background: #7dd3fc; }
     </style>
 </head>
 
@@ -74,6 +101,18 @@
         </div>
         <h1>Vincular este dispositivo</h1>
         <p>Ingresá tu CI y fecha de nacimiento para vincular este dispositivo. Vas a poder marcar tu asistencia aunque no tengas conexión a internet.</p>
+
+        {{-- Solo se muestra si device-link.js detecta un token ya vinculado en este
+        navegador (IndexedDB) — evita re-vinculaciones accidentales que disparan una
+        alerta de seguridad real (MobileDeviceRelinkedNotification) a los admins. --}}
+        <div id="alreadyLinkedWarning" class="already-linked-warning hidden">
+            <p><strong>Este dispositivo ya está vinculado</strong> a <span id="alreadyLinkedName"></span>.</p>
+            <p>Si continuás y vinculás uno nuevo, el dispositivo actual va a dejar de funcionar y se le va a avisar a RRHH.</p>
+            <div class="already-linked-actions">
+                <button type="button" id="btnCancelRelink" class="btn-cancel-relink">Ya tengo un dispositivo — volver a marcar</button>
+                <button type="button" id="btnContinueAnyway" class="btn-continue-anyway">Continuar y vincular este de todos modos</button>
+            </div>
+        </div>
 
         <form id="linkForm">
             <label for="ci">CI</label>

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
                 'resources/css/app.css',
                 'resources/js/app.js',
                 'resources/js/attendances/mark.js',
+                'resources/js/attendances/device-link.js',
                 'resources/css/attendances/styles.css',
                 'resources/js/attendances/terminal.js',
                 'resources/css/attendances/terminal.css',


### PR DESCRIPTION
## Resumen

`/vincular-dispositivo` no chequeaba si el propio navegador ya tenía un dispositivo vinculado. Volver a esa URL desde un celular ya vinculado y reenviar el mismo CI+fecha funcionaba (revocaba el token actual y emitía uno nuevo — el dispositivo queda igual de operativo), pero al tratarse de una **re-vinculación** disparaba `MobileDeviceRelinkedNotification` a todos los admins (campanita + email desde el PR #99) — indistinguible de un intento real de secuestro del dispositivo. Un simple reingreso accidental a la página generaba una alarma de seguridad falsa.

**Fix:** nuevo módulo `device-link.js` (primer build step de esta página — antes era HTML+JS plano sin Vite) chequea IndexedDB al cargar. Si ya hay un `api_token` guardado:
- Oculta el formulario.
- Muestra un aviso con el nombre del empleado vinculado.
- Dos acciones explícitas: **"Ya tengo un dispositivo"** (vuelve a `/marcar`) o **"Continuar y vincular este de todos modos"** (revela el formulario).

La re-vinculación legítima (celular perdido, se borró el storage del navegador) sigue funcionando exactamente igual — ahora es una decisión deliberada en vez de un reenvío accidental del formulario.

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real (flujo completo: vincular por primera vez → volver a `/vincular-dispositivo` → aviso visible con nombre real → "Ya tengo un dispositivo" redirige a `/marcar` → volver y "Continuar de todos modos" revela el formulario): 8/8 aserciones.
- [x] `npm run build` — sin errores, nuevo chunk `device-link-*.js` (0.8kB) + chunk compartido `db-*.js` (extraído automáticamente por Vite, ya usado también por `mark.js`).
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- Sin cambios PHP en este PR — no aplica Pest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_