### PR TITLE
Personalizar splash de /marcar y aprovechar el espacio vacío

### DIFF
--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -933,6 +933,16 @@ select#eventType { display: none; }
     letter-spacing: .03em;
 }
 
+/* Última marcación de hoy — aprovecha el espacio entre el reloj y el ícono central */
+.splash-status {
+    font-size: .8125rem; font-weight: 500;
+    color: var(--c-muted);
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-2) var(--sp-4);
+}
+
 /* — Bloque central: ícono + título + hint — */
 .splash-center {
     display: flex; flex-direction: column;

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -203,6 +203,14 @@ const statusBar           = document.getElementById("statusBar");
      */
     let lastDetectionTime = 0;
 
+    /**
+     * Reasignada en el bloque del splash con la función real — permite que
+     * initializeOfflineSync() la vuelva a disparar tras el heartbeat inicial sin
+     * acoplar ambos bloques directamente. No-op si la página no tiene splash.
+     * @type {() => void}
+     */
+    let refreshSplashPersonalization = () => {};
+
     /** Instancia del mapa Leaflet del mini-mapa de ubicación */
     let locationMap    = null;
     /** Marcador del mini-mapa */
@@ -1021,6 +1029,10 @@ const statusBar           = document.getElementById("statusBar");
             logWarn("No se pudo sincronizar con el servidor (heartbeat):", error.message);
         }
         await refreshSyncStatus();
+        // Un dispositivo recién vinculado todavía no tenía own_employee cacheado la
+        // primera vez que se llamó (ver bloque del splash) — ahora que el heartbeat
+        // ya lo escribió en IndexedDB, reintentar para completar el saludo.
+        refreshSplashPersonalization();
     }
 
     /**
@@ -2187,13 +2199,21 @@ const statusBar           = document.getElementById("statusBar");
         const splashGreetingEl = document.getElementById("splashGreeting");
         const splashTimeEl     = document.getElementById("splashTime");
         const splashDateEl     = document.getElementById("splashDate");
+        const splashStatusEl   = document.getElementById("splashStatus");
+
+        // Nombre propio cacheado (mismo dato que ya usa Mis marcaciones) — normalmente
+        // ya está en IndexedDB de una sesión anterior, así que suele completarse antes
+        // de que el empleado termine de leer la pantalla. Se recalcula el saludo con
+        // él ya incorporado en cuanto resuelve, sin bloquear el reloj mientras tanto.
+        let ownFirstName = null;
 
         const updateSplashClock = () => {
             const now  = new Date();
             const hour = now.getHours();
 
             if (splashGreetingEl) {
-                splashGreetingEl.textContent = hour < 12 ? "Buenos días" : hour < 19 ? "Buenas tardes" : "Buenas noches";
+                const greeting = hour < 12 ? "Buenos días" : hour < 19 ? "Buenas tardes" : "Buenas noches";
+                splashGreetingEl.textContent = ownFirstName ? `${greeting}, ${ownFirstName}` : greeting;
             }
             if (splashTimeEl) {
                 splashTimeEl.textContent = now.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false });
@@ -2208,6 +2228,32 @@ const statusBar           = document.getElementById("statusBar");
 
         updateSplashClock();
         const splashClockInterval = setInterval(updateSplashClock, 10000);
+
+        // Se llama dos veces: acá mismo (caché de una sesión anterior, si existe) y de
+        // nuevo desde initializeOfflineSync() tras el heartbeat inicial — un dispositivo
+        // recién vinculado todavía no tiene own_employee cacheado en este primer intento,
+        // solo lo consigue una vez que ese heartbeat termina de escribirlo.
+        refreshSplashPersonalization = () => {
+            getOwnEmployee()
+                .then((employee) => {
+                    if (employee?.first_name) {
+                        ownFirstName = employee.first_name;
+                        updateSplashClock();
+                    }
+                })
+                .catch(() => {}); // sin caché todavía — se queda con el saludo genérico
+
+            getOwnStatus()
+                .then((status) => {
+                    if (!splashStatusEl) return;
+                    splashStatusEl.textContent = status.last_event
+                        ? `Hoy: ${translateEventType(status.last_event)}${status.last_event_time ? ` · ${status.last_event_time}` : ""}`
+                        : "Todavía no marcaste hoy";
+                    splashStatusEl.classList.remove("hidden");
+                })
+                .catch(() => {}); // sin red y sin nada cacheado todavía — se deja oculto, no vale la pena mostrar un error acá
+        };
+        refreshSplashPersonalization();
 
         const handleSplashTap = () => {
             if (splashHandled) return;

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -30,6 +30,11 @@
                 <p class="splash-date"     id="splashDate"></p>
             </div>
 
+            {{-- Última marcación de hoy — datos ya cacheados en el dispositivo (mismo
+            camino que "Mis marcaciones"), se completa apenas resuelve sin bloquear
+            la pantalla. Oculto hasta tener una respuesta para no mostrar "cargando". --}}
+            <p id="splashStatus" class="splash-status hidden" aria-live="polite"></p>
+
             <div class="splash-center">
                 <div class="splash-icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Resumen

Mejora de UX pedida sobre la pantalla de bienvenida (`/marcar`, antes de tocar "Identificarme") — tenía mucho espacio vacío entre el reloj y el ícono central, y un saludo genérico pudiendo ser personalizado.

- **Saludo con nombre**: "Buenas tardes, Edgar" en vez de "Buenas tardes" — el dispositivo ya sabe de quién es (vinculación 1:1). Se resuelve dos veces: al cargar (caché de una sesión anterior, casi instantáneo) y de nuevo tras el heartbeat inicial (`initializeOfflineSync()`) — un dispositivo recién vinculado todavía no tiene `own_employee` cacheado en el primer intento.
- **Card de estado del día**: "Hoy: Entrada · 08:03" (o "Todavía no marcaste hoy" si no hay marcaciones), entre el reloj y el ícono central. Mismo dato que ya expone `MobileStatusController` para "Mis marcaciones" (PR #102) — `getOwnStatus()`, con la misma resiliencia offline. No agrega ningún paso al flujo, la info aparece sola.

Revisé también el resto del flujo (Paso 1 cámara, Paso 2 confirmar marcación) buscando oportunidades similares — ya están bastante densos/funcionales (video ocupando el espacio principal en Paso 1, barra de empleado + grid de eventos + mini-mapa en Paso 2), no encontré un espacio vacío comparable que amerite cambios ahí.

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real (cámara falsa, viewport 412×915 similar a un celular real): saludo con nombre + card de estado correctos en 2 escenarios (con marcaciones de hoy / sin marcaciones), y confirmado visualmente en modo claro y oscuro con capturas de pantalla reales.
- [x] `npm run build` — sin errores.
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- Sin cambios PHP en este PR — no aplica Pest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_