### PR TITLE
Mostrar sucursal y empresa en el header de ambos modos de marcación

### DIFF
--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -52,6 +52,8 @@ class MobileHeartbeatController extends Controller
                 'ci' => $employee->ci,
                 'face_descriptor' => $employee->face_descriptor,
                 'photo_thumbnail' => $employee->photo_thumbnail,
+                'branch_name' => $employee->branch?->name,
+                'company_name' => $employee->branch?->company?->name,
             ],
         ]);
     }

--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -44,7 +44,7 @@ class AttendanceFaceMarkController extends Controller
      */
     public function terminalByCode(string $code): ViewContract
     {
-        $terminal = Terminal::with('branch')->where('code', $code)->first();
+        $terminal = Terminal::with('branch.company')->where('code', $code)->first();
 
         if (! $terminal) {
             abort(404);

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -118,7 +118,17 @@ body.modal-open { overflow: hidden; }
     justify-content: space-between;
     box-shadow: var(--sh-sm);
 }
-.app-header-brand { display: flex; align-items: center; gap: var(--sp-3); }
+.app-header-brand { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
+/* Sucursal — empresa del empleado, visible en todas las pantallas (splash, Paso 1, Paso 2) */
+.app-location-badge {
+    font-size: .8125rem;
+    font-weight: 500;
+    color: var(--c-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
 
 /* ============================================================
    BANNER OFFLINE

--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -179,12 +179,13 @@ body {
     box-shadow: none;
 }
 .terminal-header--idle .terminal-mode-badge,
+.terminal-header--idle .terminal-location-badge,
 .terminal-header--idle .terminal-clock {
     opacity: 0;
     visibility: hidden;
     transition: opacity 400ms ease, visibility 400ms ease;
 }
-.terminal-header-brand { display: flex; align-items: center; gap: var(--sp-3); }
+.terminal-header-brand { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
 .terminal-mode-badge {
     background: var(--c-primary-bg);
     color: var(--c-primary);
@@ -195,6 +196,18 @@ body {
     padding: 3px var(--sp-2);
     border-radius: var(--r);
     border: 1px solid rgba(13,148,136,.25);
+    flex-shrink: 0;
+}
+/* Sucursal — empresa del terminal, visible también durante la identificación
+   activa (a diferencia del bloque idle-only en la pantalla de reposo). */
+.terminal-location-badge {
+    font-size: .8125rem;
+    font-weight: 500;
+    color: var(--c-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
 }
 .theme-toggle {
     display: flex; align-items: center; justify-content: center;

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -204,12 +204,14 @@ const statusBar           = document.getElementById("statusBar");
     let lastDetectionTime = 0;
 
     /**
-     * Reasignada en el bloque del splash con la función real — permite que
-     * initializeOfflineSync() la vuelva a disparar tras el heartbeat inicial sin
-     * acoplar ambos bloques directamente. No-op si la página no tiene splash.
+     * Refresca el saludo/estado del splash y la sucursal — empresa del header
+     * persistente con el propio empleado cacheado. Reasignada en el bloque del
+     * splash con la función real — permite que initializeOfflineSync() la vuelva
+     * a disparar tras el heartbeat inicial sin acoplar ambos bloques
+     * directamente. No-op si la página no tiene splash.
      * @type {() => void}
      */
-    let refreshSplashPersonalization = () => {};
+    let refreshOwnEmployeeUi = () => {};
 
     /** Instancia del mapa Leaflet del mini-mapa de ubicación */
     let locationMap    = null;
@@ -1032,7 +1034,7 @@ const statusBar           = document.getElementById("statusBar");
         // Un dispositivo recién vinculado todavía no tenía own_employee cacheado la
         // primera vez que se llamó (ver bloque del splash) — ahora que el heartbeat
         // ya lo escribió en IndexedDB, reintentar para completar el saludo.
-        refreshSplashPersonalization();
+        refreshOwnEmployeeUi();
     }
 
     /**
@@ -2200,6 +2202,7 @@ const statusBar           = document.getElementById("statusBar");
         const splashTimeEl     = document.getElementById("splashTime");
         const splashDateEl     = document.getElementById("splashDate");
         const splashStatusEl   = document.getElementById("splashStatus");
+        const headerLocationEl = document.getElementById("headerLocation");
 
         // Nombre propio cacheado (mismo dato que ya usa Mis marcaciones) — normalmente
         // ya está en IndexedDB de una sesión anterior, así que suele completarse antes
@@ -2233,12 +2236,17 @@ const statusBar           = document.getElementById("statusBar");
         // nuevo desde initializeOfflineSync() tras el heartbeat inicial — un dispositivo
         // recién vinculado todavía no tiene own_employee cacheado en este primer intento,
         // solo lo consigue una vez que ese heartbeat termina de escribirlo.
-        refreshSplashPersonalization = () => {
+        refreshOwnEmployeeUi = () => {
             getOwnEmployee()
                 .then((employee) => {
                     if (employee?.first_name) {
                         ownFirstName = employee.first_name;
                         updateSplashClock();
+                    }
+                    if (headerLocationEl && (employee?.branch_name || employee?.company_name)) {
+                        headerLocationEl.textContent = [employee.branch_name, employee.company_name]
+                            .filter(Boolean)
+                            .join(" — ");
                     }
                 })
                 .catch(() => {}); // sin caché todavía — se queda con el saludo genérico
@@ -2253,7 +2261,7 @@ const statusBar           = document.getElementById("statusBar");
                 })
                 .catch(() => {}); // sin red y sin nada cacheado todavía — se deja oculto, no vale la pena mostrar un error acá
         };
-        refreshSplashPersonalization();
+        refreshOwnEmployeeUi();
 
         const handleSplashTap = () => {
             if (splashHandled) return;

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -87,6 +87,15 @@ document.addEventListener("DOMContentLoaded", () => {
         idleTerminalInfo.style.display = "";
     }
 
+    // Empresa — sucursal en el header persistente (a diferencia del bloque idle de
+    // arriba, este queda visible también durante la identificación activa).
+    const headerLocation = document.getElementById("terminalHeaderLocation");
+    if (terminalData && headerLocation && (terminalData.branch_name || terminalData.company_name)) {
+        headerLocation.textContent = [terminalData.branch_name, terminalData.company_name]
+            .filter(Boolean)
+            .join(" — ");
+    }
+
     // ============================================================================
     // ESTADO GLOBAL
     // ============================================================================

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -64,6 +64,7 @@
     <header class="app-header">
         <div class="app-header-brand">
             <span class="app-mode-badge">Marcación Facial</span>
+            <span id="headerLocation" class="app-location-badge"></span>
         </div>
         <div class="app-clock" id="headerClock" aria-live="off" aria-label="Hora actual"></div>
     </header>

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -20,6 +20,7 @@
         <header class="terminal-header">
             <div class="terminal-header-brand">
                 <span class="terminal-mode-badge">Modo Terminal</span>
+                <span id="terminalHeaderLocation" class="terminal-location-badge"></span>
                 <button type="button" id="btnThemeToggle" class="theme-toggle" aria-label="Cambiar tema claro/oscuro">
                     <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
@@ -67,6 +68,7 @@
             name: @json($terminal->name),
             branch_id: {{ $terminal->branch_id ?? 'null' }},
             branch_name: @json($terminal->branch?->name),
+            company_name: @json($terminal->branch?->company?->name),
         };
     </script>
     @endisset

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -160,6 +160,17 @@ it('el heartbeat también devuelve photo_thumbnail para que el celular muestre l
     expect($response->json('employee.photo_thumbnail'))->toBe('data:image/jpeg;base64,FAKE_THUMBNAIL');
 });
 
+it('el heartbeat también devuelve sucursal y empresa para el header de /marcar', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.branch_name'))->toBe($employee->branch->name)
+        ->and($response->json('employee.company_name'))->toBe($employee->branch->company->name);
+});
+
 it('el heartbeat revoca el token y responde 403 si el empleado ya no está activo', function () {
     $employee = makeLinkableEmployee();
     Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);


### PR DESCRIPTION
## Resumen

Ni el celular (`/marcar`) ni el kiosko (`/terminal/{code}`) mostraban la empresa. El kiosko solo mostraba la sucursal en la pantalla de reposo (desaparecía durante la identificación activa, el header persistente solo tenía el badge "Modo Terminal" + reloj). El celular tenía una referencia rota a `employee.branch_name` que nunca se disparaba en la práctica (fallback detrás de `employee.ci`, que casi siempre existe) y ni siquiera venía poblada desde que se migró a matching local — en los hechos, hoy no muestra ni sucursal ni empresa en ningún lado.

**Fix:**
- `MobileHeartbeatController` agrega `branch_name`/`company_name` al payload del `employee`.
- `AttendanceFaceMarkController::terminalByCode()` cambia el eager-load de `branch` a `branch.company`; `terminal.blade.php` expone `company_name` en `window.terminalData`.
- Header persistente en ambos modos: `"Sucursal — Empresa"`, siempre visible (kiosko: también durante la identificación activa, no solo en reposo).
- **Se muestra siempre**, aunque haya una sola empresa/sucursal — a diferencia de la convención de ocultar columnas redundantes en reportes, acá cumple una función de confirmación ("estás marcando en el lugar correcto"), no de desduplicación de una lista.

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real (celular en 375px, kiosko en 800px): header sin overflow, texto correcto en ambos modos, y confirmado que la sucursal sigue visible en el kiosko durante la identificación activa (no solo en reposo) — con capturas de pantalla reales.
- [x] Test Pest nuevo en `tests/Feature/MobileAttendanceLinkTest.php`.
- [x] `npm run build` — sin errores.
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_