### PR TITLE
Título de página con empresa/sucursal + toggle de tema en el celular

### DIFF
--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -59,8 +59,15 @@ class AttendanceFaceMarkController extends Controller
 
         $terminal->update(['last_seen_at' => now()]);
 
+        // Sucursal — empresa en el título de pestaña: ayuda a diferenciar kioskos de
+        // distintas sucursales cuando un admin monitorea varios a la vez. Sin
+        // sucursal/empresa cargada (dato incompleto), cae al nombre del propio terminal.
+        $title = collect([$terminal->branch?->name, $terminal->branch?->company?->name])
+            ->filter()
+            ->implode(' — ');
+
         return view('attendances.terminal', [
-            'title' => "Terminal — {$terminal->name}",
+            'title' => $title !== '' ? $title : "Terminal — {$terminal->name}",
             'terminal' => $terminal,
         ]);
     }

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -61,8 +61,10 @@
     --tr-s: 300ms ease-in-out;
 }
 
+/* Tokens oscuros — activados por preferencia del sistema O por toggle manual
+   (#btnThemeToggle, mismo mecanismo que ya usa el kiosko en terminal.css). */
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
         --c-bg:          #0f172a;
         --c-surface:     #1e293b;
         --c-border:      #334155;
@@ -84,6 +86,28 @@
         --sh-md: 0 4px 6px -1px rgba(0,0,0,.5);
         --sh-lg: 0 10px 15px -3px rgba(0,0,0,.5);
     }
+}
+html[data-theme="dark"] {
+    --c-bg:          #0f172a;
+    --c-surface:     #1e293b;
+    --c-border:      #334155;
+    --c-border-s:    #475569;
+    --c-text:        #f1f5f9;
+    --c-muted:       #94a3b8;
+    --c-subtle:      #64748b;
+    --c-primary-bg:  rgba(20,184,166,.12);
+    --c-success-bg:  rgba(22,163,74,.15);
+    --c-success-ring:rgba(134,239,172,.3);
+    --c-danger-bg:   rgba(220,38,38,.15);
+    --c-danger-ring: rgba(252,165,165,.3);
+    --c-warning-bg:  rgba(217,119,6,.15);
+    --c-warning-ring:rgba(252,211,77,.3);
+    --c-info-bg:     rgba(37,99,235,.15);
+    --c-info-ring:   rgba(147,197,253,.3);
+    --sh-sm: 0 1px 2px rgba(0,0,0,.3);
+    --sh:    0 1px 3px rgba(0,0,0,.4);
+    --sh-md: 0 4px 6px -1px rgba(0,0,0,.5);
+    --sh-lg: 0 10px 15px -3px rgba(0,0,0,.5);
 }
 
 /* ============================================================
@@ -119,6 +143,27 @@ body.modal-open { overflow: hidden; }
     box-shadow: var(--sh-sm);
 }
 .app-header-brand { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
+.theme-toggle {
+    display: flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--c-border);
+    background: transparent;
+    color: var(--c-muted);
+    cursor: pointer;
+    transition: background var(--tr-f), color var(--tr-f), border-color var(--tr-f);
+    flex-shrink: 0;
+}
+.theme-toggle:hover { background: var(--c-primary-bg); color: var(--c-primary); border-color: var(--c-primary); }
+.theme-toggle svg { width: 16px; height: 16px; display: block; }
+.theme-toggle .icon-sun  { display: none; }
+.theme-toggle .icon-moon { display: block; }
+html[data-theme="dark"]  .theme-toggle .icon-sun  { display: block; }
+html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-toggle .icon-sun  { display: block; }
+    :root:not([data-theme="light"]) .theme-toggle .icon-moon { display: none; }
+}
 /* Sucursal — empresa del empleado, visible en todas las pantallas (splash, Paso 1, Paso 2) */
 .app-location-badge {
     font-size: .8125rem;

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -2248,6 +2248,12 @@ const statusBar           = document.getElementById("statusBar");
                             .filter(Boolean)
                             .join(" — ");
                     }
+                    // Título de pestaña — la empresa no se conoce server-side en esta
+                    // página (la identidad del empleado se resuelve recién acá, vía
+                    // IndexedDB/Sanctum), así que se corrige client-side apenas resuelve.
+                    if (employee?.company_name) {
+                        document.title = `${employee.company_name} — Marcación Facial`;
+                    }
                 })
                 .catch(() => {}); // sin caché todavía — se queda con el saludo genérico
 
@@ -2629,6 +2635,28 @@ const statusBar           = document.getElementById("statusBar");
             }
         });
         errorKeyListenerAdded = true;
+    }
+
+    // ==========================================================================
+    // TEMA CLARO / OSCURO
+    // ==========================================================================
+    // Mismo mecanismo que ya usa el kiosko (terminal.js) — localStorage con clave
+    // propia para no interferir si algún dispositivo llegara a usarse en los dos modos.
+    (function initTheme() {
+        const saved = localStorage.getItem("mark-theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const isDark = saved === "dark" || (!saved && prefersDark);
+        document.documentElement.setAttribute("data-theme", isDark ? "dark" : "light");
+    })();
+
+    const btnThemeToggle = document.getElementById("btnThemeToggle");
+    if (btnThemeToggle) {
+        btnThemeToggle.addEventListener("click", () => {
+            const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+            const next = isDark ? "light" : "dark";
+            document.documentElement.setAttribute("data-theme", next);
+            localStorage.setItem("mark-theme", next);
+        });
     }
 
     // ==========================================================================

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -65,6 +65,17 @@
         <div class="app-header-brand">
             <span class="app-mode-badge">Marcación Facial</span>
             <span id="headerLocation" class="app-location-badge"></span>
+            <button type="button" id="btnThemeToggle" class="theme-toggle" aria-label="Cambiar tema claro/oscuro">
+                <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+                </svg>
+                <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                    <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                </svg>
+            </button>
         </div>
         <div class="app-clock" id="headerClock" aria-live="off" aria-label="Hora actual"></div>
     </header>

--- a/tests/Feature/TerminalConnectivityTest.php
+++ b/tests/Feature/TerminalConnectivityTest.php
@@ -141,3 +141,18 @@ it('el heartbeat sin contadores no rompe y deja los contadores en null', functio
     expect($terminal->last_pending_events_count)->toBeNull()
         ->and($terminal->last_conflict_events_count)->toBeNull();
 });
+
+/**
+ * Regresión: el título de pestaña ayuda a diferenciar kioskos de distintas
+ * sucursales cuando un admin monitorea varios a la vez — antes solo mostraba
+ * el nombre del propio terminal, sin sucursal ni empresa.
+ */
+it('el título de la página del terminal muestra sucursal — empresa', function () {
+    $terminal = makeConnectivityTerminal();
+
+    $response = $this->get("/terminal/{$terminal->code}");
+
+    $response->assertOk();
+    $expectedTitle = "{$terminal->branch->name} — {$terminal->branch->company->name}";
+    expect($response->getContent())->toContain("<title>{$expectedTitle}</title>");
+});


### PR DESCRIPTION
## Resumen

Dos mejoras chicas de UX pedidas sobre `/marcar` y `/terminal/{code}`:

**Título de pestaña:**
- Terminal: `"Sucursal — Empresa"` en vez de `"Terminal — {nombre del kiosko}"` — ayuda a diferenciar pestañas cuando un admin monitorea varios kioskos de distintas sucursales a la vez. Se resuelve server-side, el terminal ya se conoce por el `{code}` de la ruta.
- Celular: `"Empresa — Marcación Facial"` en vez del genérico fijo — se corrige client-side tras el heartbeat inicial, porque la identidad del empleado (y la empresa) recién se conoce una vez que resuelve el token guardado en el dispositivo, no en el render inicial del servidor.

**Toggle de tema claro/oscuro en el celular** — el kiosko ya lo tenía (`data-theme` + localStorage), el celular no. Portado el mecanismo completo: `styles.css` solo tenía `@media (prefers-color-scheme: dark)` sin soporte para override manual, ahora replica la estructura de `terminal.css` (`:root:not([data-theme="light"])` + `html[data-theme="dark"]` explícito). Clave de localStorage propia (`mark-theme`, distinta de `terminal-theme`) para no interferir si algún dispositivo se usara en los dos modos.

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real: título del terminal correcto server-side; título del celular genérico al cargar y actualizado tras el heartbeat; toggle cambia `data-theme` + color de fondo real + persiste en localStorage + sobrevive un reload — 7/7 aserciones.
- [x] Test Pest nuevo en `tests/Feature/TerminalConnectivityTest.php` para el título del terminal.
- [x] `npm run build` — sin errores.
- [x] `php -l` / sintaxis JS — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_