### PR TITLE
Recurso Filament de dispositivos del empleado + historial completo

### DIFF
--- a/app/Filament/Resources/EmployeeDeviceResource.php
+++ b/app/Filament/Resources/EmployeeDeviceResource.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\EmployeeDeviceResource\Pages;
+use App\Models\EmployeeDevice;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Infolists\Components\Grid as InfoGrid;
+use Filament\Infolists\Components\Section as InfoSection;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Historial de dispositivos personales vinculados por empleados para
+ * marcación offline vía PWA — contraparte de `TerminalResource` para
+ * dispositivos propios (no kioskos compartidos). Registros creados
+ * automáticamente por `Employee::claimMobileToken()`/`revokeMobileToken()`;
+ * este recurso solo permite anotar marca/modelo/serie/MAC/notas a mano,
+ * igual que ya se hace con los terminales.
+ */
+class EmployeeDeviceResource extends Resource
+{
+    protected static ?string $model = EmployeeDevice::class;
+
+    protected static ?string $navigationLabel = 'Dispositivos de Empleados';
+
+    protected static ?string $label = 'dispositivo';
+
+    protected static ?string $pluralLabel = 'dispositivos de empleados';
+
+    protected static ?string $slug = 'dispositivos-empleados';
+
+    protected static ?string $navigationIcon = 'heroicon-o-device-phone-mobile';
+
+    protected static ?string $navigationGroup = 'Asistencias';
+
+    protected static ?int $navigationSort = 7;
+
+    /**
+     * Formulario de edición — solo los campos anotables a mano. Vinculación,
+     * revocación, empleado y user agent son de solo lectura (gestionados por
+     * el ciclo de vida real de la vinculación, no editables desde acá).
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make('Dispositivo')
+                    ->icon('heroicon-o-device-phone-mobile')
+                    ->compact()
+                    ->schema([
+                        TextInput::make('device_brand')
+                            ->label('Marca')
+                            ->placeholder('Ej: Samsung, Apple, Motorola')
+                            ->maxLength(60),
+
+                        TextInput::make('device_model')
+                            ->label('Modelo')
+                            ->placeholder('Ej: Galaxy A54')
+                            ->maxLength(100),
+
+                        TextInput::make('device_serial')
+                            ->label('Número de Serie')
+                            ->maxLength(100),
+
+                        TextInput::make('device_mac')
+                            ->label('Dirección MAC')
+                            ->placeholder('AA:BB:CC:DD:EE:FF')
+                            ->maxLength(17)
+                            ->regex('/^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/')
+                            ->validationMessages(['regex' => 'Ingrese una dirección MAC válida. Ej: AA:BB:CC:DD:EE:FF']),
+
+                        Textarea::make('device_notes')
+                            ->label('Notas del dispositivo')
+                            ->placeholder('Ej: Celular personal, pantalla de 6.5"')
+                            ->rows(2)
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2),
+
+                Section::make('Vinculación')
+                    ->icon('heroicon-o-link')
+                    ->compact()
+                    ->schema([
+                        Placeholder::make('employee_name')
+                            ->label('Empleado')
+                            ->content(fn (EmployeeDevice $record) => $record->employee->full_name),
+
+                        Placeholder::make('linked_at_display')
+                            ->label('Vinculado el')
+                            ->content(fn (EmployeeDevice $record) => $record->linked_at->format('d/m/Y H:i')),
+
+                        Placeholder::make('unlinked_at_display')
+                            ->label('Desvinculado el')
+                            ->content(fn (EmployeeDevice $record) => $record->unlinked_at?->format('d/m/Y H:i') ?? 'Sigue vinculado'),
+                    ])
+                    ->columns(3),
+            ]);
+    }
+
+    /**
+     * Infolist de visualización del dispositivo.
+     */
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                InfoSection::make('Vinculación')
+                    ->schema([
+                        InfoGrid::make(3)->schema([
+                            TextEntry::make('employee.full_name')
+                                ->label('Empleado')
+                                ->icon('heroicon-o-user')
+                                ->url(fn (EmployeeDevice $record) => EmployeeResource::getUrl('view', ['record' => $record->employee_id])),
+
+                            TextEntry::make('status')
+                                ->label('Estado')
+                                ->badge()
+                                ->formatStateUsing(fn (string $state) => EmployeeDevice::getStatusLabels()[$state] ?? $state)
+                                ->color(fn (string $state) => EmployeeDevice::getStatusColors()[$state] ?? 'gray'),
+
+                            TextEntry::make('user_agent')
+                                ->label('Navegador')
+                                ->placeholder('Sin datos')
+                                ->limit(40),
+                        ]),
+
+                        InfoGrid::make(2)->schema([
+                            TextEntry::make('linked_at')
+                                ->label('Vinculado el')
+                                ->dateTime('d/m/Y H:i'),
+
+                            TextEntry::make('unlinked_at')
+                                ->label('Desvinculado el')
+                                ->dateTime('d/m/Y H:i')
+                                ->placeholder('Sigue vinculado'),
+                        ]),
+                    ]),
+
+                InfoSection::make('Dispositivo')
+                    ->schema([
+                        InfoGrid::make(3)->schema([
+                            TextEntry::make('device_brand')
+                                ->label('Marca')
+                                ->placeholder('Sin datos'),
+
+                            TextEntry::make('device_model')
+                                ->label('Modelo')
+                                ->placeholder('Sin datos'),
+
+                            TextEntry::make('device_serial')
+                                ->label('Número de Serie')
+                                ->copyable()
+                                ->placeholder('Sin datos'),
+                        ]),
+
+                        TextEntry::make('device_mac')
+                            ->label('Dirección MAC')
+                            ->copyable()
+                            ->placeholder('Sin datos'),
+
+                        TextEntry::make('device_notes')
+                            ->label('Notas')
+                            ->placeholder('Sin notas')
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    /**
+     * Tabla con el historial de dispositivos de todos los empleados.
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('employee.full_name')
+                    ->label('Empleado')
+                    ->searchable(query: fn (Builder $query, string $search) => $query->whereHas(
+                        'employee',
+                        fn (Builder $q) => $q->where('first_name', 'like', "%{$search}%")
+                            ->orWhere('last_name', 'like', "%{$search}%")
+                    ))
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->label('Estado')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => EmployeeDevice::getStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => EmployeeDevice::getStatusColors()[$state] ?? 'gray'),
+
+                TextColumn::make('device_description')
+                    ->label('Dispositivo')
+                    ->placeholder('Sin datos')
+                    ->toggleable(),
+
+                TextColumn::make('linked_at')
+                    ->label('Vinculado')
+                    ->dateTime('d/m/Y H:i')
+                    ->since()
+                    ->sortable(),
+
+                TextColumn::make('unlinked_at')
+                    ->label('Desvinculado')
+                    ->since()
+                    ->placeholder('Sigue vinculado')
+                    ->sortable()
+                    ->toggleable(),
+
+                TextColumn::make('device_mac')
+                    ->label('MAC')
+                    ->placeholder('Sin datos')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('employee_id')
+                    ->label('Empleado')
+                    ->relationship('employee', 'first_name')
+                    ->getOptionLabelFromRecordUsing(
+                        fn ($record) => $record->first_name.' '.$record->last_name.' (CI: '.$record->ci.')'
+                    )
+                    ->searchable(['first_name', 'last_name', 'ci'])
+                    ->preload(false)
+                    ->native(false),
+
+                SelectFilter::make('status')
+                    ->label('Estado')
+                    ->options(EmployeeDevice::getStatusLabels())
+                    ->native(false)
+                    ->query(function (Builder $query, array $data) {
+                        if (blank($data['value'] ?? null)) {
+                            return $query;
+                        }
+
+                        return match ($data['value']) {
+                            'active' => $query->whereNull('unlinked_at'),
+                            'unlinked' => $query->whereNotNull('unlinked_at'),
+                            default => $query,
+                        };
+                    }),
+            ])
+            ->actions([
+                Action::make('revoke')
+                    ->label('Revocar')
+                    ->tooltip('Invalida el acceso de este dispositivo a la marcación offline — el empleado deberá vincularse de nuevo con CI + fecha de nacimiento')
+                    ->icon('heroicon-o-shield-exclamation')
+                    ->color('danger')
+                    ->visible(fn (EmployeeDevice $record) => $record->isActive())
+                    ->requiresConfirmation()
+                    ->modalHeading('Revocar dispositivo')
+                    ->modalDescription(fn (EmployeeDevice $record) => "El dispositivo vinculado de {$record->employee->full_name} perderá acceso a la marcación offline de inmediato. Deberá vincularse de nuevo con CI + fecha de nacimiento.")
+                    ->modalSubmitActionLabel('Sí, revocar')
+                    ->action(function (EmployeeDevice $record) {
+                        $record->employee->revokeMobileToken();
+
+                        Notification::make()
+                            ->success()
+                            ->title('Dispositivo revocado')
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([])
+            ->defaultSort('linked_at', 'desc')
+            ->emptyStateHeading('Sin dispositivos vinculados')
+            ->emptyStateDescription('Los dispositivos aparecen acá automáticamente cuando un empleado se vincula desde /vincular-dispositivo.')
+            ->emptyStateIcon('heroicon-o-device-phone-mobile');
+    }
+
+    /**
+     * Relaciones del recurso.
+     *
+     * @return array<class-string>
+     */
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * Páginas del recurso — sin 'create': los registros se generan
+     * automáticamente al vincular un dispositivo, nunca a mano.
+     *
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListEmployeeDevices::route('/'),
+            'view' => Pages\ViewEmployeeDevice::route('/{record}'),
+            'edit' => Pages\EditEmployeeDevice::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * Badge de navegación: cantidad de dispositivos actualmente vinculados.
+     */
+    public static function getNavigationBadge(): ?string
+    {
+        $active = EmployeeDevice::whereNull('unlinked_at')->count();
+
+        return $active > 0 ? (string) $active : null;
+    }
+}

--- a/app/Filament/Resources/EmployeeDeviceResource/Pages/EditEmployeeDevice.php
+++ b/app/Filament/Resources/EmployeeDeviceResource/Pages/EditEmployeeDevice.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Resources\EmployeeDeviceResource\Pages;
+
+use App\Filament\Resources\EmployeeDeviceResource;
+use Filament\Resources\Pages\EditRecord;
+
+/**
+ * Edición de un dispositivo vinculado — solo los campos anotables a mano
+ * (marca/modelo/serie/MAC/notas). Sin DeleteAction: es un registro de
+ * historial, no se elimina — el ciclo de vida real (vincular/revocar) lo
+ * maneja `Employee::claimMobileToken()`/`revokeMobileToken()`.
+ */
+class EditEmployeeDevice extends EditRecord
+{
+    protected static string $resource = EmployeeDeviceResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('view', ['record' => $this->getRecord()]);
+    }
+}

--- a/app/Filament/Resources/EmployeeDeviceResource/Pages/ListEmployeeDevices.php
+++ b/app/Filament/Resources/EmployeeDeviceResource/Pages/ListEmployeeDevices.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\EmployeeDeviceResource\Pages;
+
+use App\Filament\Resources\EmployeeDeviceResource;
+use Filament\Resources\Pages\ListRecords;
+
+/** Lista de dispositivos personales vinculados por empleados (histórico) — sin creación manual. */
+class ListEmployeeDevices extends ListRecords
+{
+    protected static string $resource = EmployeeDeviceResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/EmployeeDeviceResource/Pages/ViewEmployeeDevice.php
+++ b/app/Filament/Resources/EmployeeDeviceResource/Pages/ViewEmployeeDevice.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\EmployeeDeviceResource\Pages;
+
+use App\Filament\Resources\EmployeeDeviceResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+/** Detalle de un dispositivo vinculado — solo permite editar marca/modelo/serie/MAC/notas. */
+class ViewEmployeeDevice extends ViewRecord
+{
+    protected static string $resource = EmployeeDeviceResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make()->icon('heroicon-o-pencil-square'),
+        ];
+    }
+}

--- a/app/Filament/Resources/EmployeeResource.php
+++ b/app/Filament/Resources/EmployeeResource.php
@@ -1218,6 +1218,7 @@ class EmployeeResource extends Resource
             RelationManagers\EmployeePerceptionsRelationManager::class,
             RelationManagers\BankAccountsRelationManager::class,
             RelationManagers\WarningsRelationManager::class,
+            RelationManagers\DevicesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/EmployeeResource/RelationManagers/DevicesRelationManager.php
+++ b/app/Filament/Resources/EmployeeResource/RelationManagers/DevicesRelationManager.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Resources\EmployeeResource\RelationManagers;
+
+use App\Filament\Resources\EmployeeDeviceResource;
+use App\Models\EmployeeDevice;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * Historial de dispositivos personales vinculados por el empleado — solo
+ * lectura. Los registros los crea automáticamente
+ * `Employee::claimMobileToken()`/`revokeMobileToken()`; para anotar
+ * marca/modelo/serie/MAC/notas o revocar, se entra al detalle del
+ * dispositivo en `EmployeeDeviceResource`.
+ */
+class DevicesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'devices';
+
+    protected static ?string $title = 'Dispositivos';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordUrl(fn (EmployeeDevice $record) => EmployeeDeviceResource::getUrl('view', ['record' => $record]))
+            ->columns([
+                TextColumn::make('status')
+                    ->label('Estado')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => EmployeeDevice::getStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => EmployeeDevice::getStatusColors()[$state] ?? 'gray'),
+
+                TextColumn::make('device_description')
+                    ->label('Dispositivo')
+                    ->placeholder('Sin datos'),
+
+                TextColumn::make('linked_at')
+                    ->label('Vinculado')
+                    ->dateTime('d/m/Y H:i')
+                    ->since()
+                    ->sortable(),
+
+                TextColumn::make('unlinked_at')
+                    ->label('Desvinculado')
+                    ->since()
+                    ->placeholder('Sigue vinculado')
+                    ->sortable(),
+            ])
+            ->defaultSort('linked_at', 'desc')
+            ->paginationPageOptions([10, 25, 50, 100])
+            ->actions([])
+            ->bulkActions([])
+            ->emptyStateHeading('Sin dispositivos vinculados')
+            ->emptyStateDescription('Los dispositivos aparecen acá automáticamente cuando el empleado se vincula desde /vincular-dispositivo.')
+            ->emptyStateIcon('heroicon-o-device-phone-mobile');
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -1182,6 +1183,18 @@ class Employee extends Model implements AuthenticatableContract
     // MARCACIÓN OFFLINE POR DISPOSITIVO — VINCULACIÓN Y TOKEN SANCTUM
     // =========================================================================
 
+    /** Historial completo de dispositivos vinculados (uno por cada vinculación real). */
+    public function devices(): HasMany
+    {
+        return $this->hasMany(EmployeeDevice::class)->latest('linked_at');
+    }
+
+    /** Dispositivo actualmente vinculado (unlinked_at null) — a lo sumo uno por empleado. */
+    public function activeDevice(): HasOne
+    {
+        return $this->hasOne(EmployeeDevice::class)->whereNull('unlinked_at')->latest('linked_at');
+    }
+
     /**
      * Emite un token Sanctum (ability `mobile:sync`) para el dispositivo personal
      * del empleado, tras validarse con CI + fecha de nacimiento (ver
@@ -1197,10 +1210,23 @@ class Employee extends Model implements AuthenticatableContract
         // CI+fecha es una credencial débil, esto da visibilidad a un admin ante un
         // posible acoso/DoS dirigido).
         $isRelink = $this->hasMobileLinked();
+        $linkedAt = now();
 
         $this->tokens()->where('name', 'like', 'mobile:%')->delete();
 
-        $this->forceFill(['mobile_linked_at' => now()])->save();
+        // Cierra el dispositivo activo anterior (si había) antes de abrir uno
+        // nuevo — nunca quedan dos registros con unlinked_at null a la vez.
+        $this->activeDevice?->update(['unlinked_at' => $linkedAt]);
+        $newDevice = $this->devices()->create([
+            'linked_at' => $linkedAt,
+            'user_agent' => $userAgent,
+        ]);
+        // setRelation en vez de dejar que quede cacheado el activeDevice anterior (o
+        // null) en esta misma instancia — sin esto, $employee->activeDevice después de
+        // llamar a este método devolvería el valor viejo hasta un refresh() explícito.
+        $this->setRelation('activeDevice', $newDevice);
+
+        $this->forceFill(['mobile_linked_at' => $linkedAt])->save();
 
         $notification = $isRelink
             ? new MobileDeviceRelinkedNotification($this, $userAgent)
@@ -1215,6 +1241,8 @@ class Employee extends Model implements AuthenticatableContract
     public function revokeMobileToken(): void
     {
         $this->tokens()->where('name', 'like', 'mobile:%')->delete();
+        $this->activeDevice?->update(['unlinked_at' => now()]);
+        $this->setRelation('activeDevice', null);
         $this->forceFill(['mobile_linked_at' => null, 'mobile_last_heartbeat_at' => null])->save();
     }
 

--- a/app/Models/EmployeeDevice.php
+++ b/app/Models/EmployeeDevice.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Historial de dispositivos personales vinculados por un empleado para
+ * marcación offline vía PWA (ver `Employee::claimMobileToken()`). A
+ * diferencia de `Terminal` (un solo registro por kiosko, editado a mano),
+ * acá cada vinculación real crea un registro nuevo — `unlinked_at` null
+ * identifica el dispositivo actualmente activo (a lo sumo uno por
+ * empleado). Marca/modelo/serie/MAC/notas quedan vacíos hasta que un
+ * admin los completa a mano, igual que en `Terminal`.
+ */
+class EmployeeDevice extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'employee_id',
+        'linked_at',
+        'unlinked_at',
+        'user_agent',
+        'device_brand',
+        'device_model',
+        'device_serial',
+        'device_mac',
+        'device_notes',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'linked_at' => 'datetime',
+            'unlinked_at' => 'datetime',
+        ];
+    }
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    /** Indica si este es el dispositivo actualmente vinculado (no reemplazado ni revocado). */
+    public function isActive(): bool
+    {
+        return $this->unlinked_at === null;
+    }
+
+    /** Estado derivado de `unlinked_at`, para mostrar como badge (ver getStatusLabels/Colors). */
+    public function getStatusAttribute(): string
+    {
+        return $this->isActive() ? 'active' : 'unlinked';
+    }
+
+    /** Descripción del dispositivo (marca + modelo) — mismo patrón que `Terminal::device_description`. */
+    public function getDeviceDescriptionAttribute(): ?string
+    {
+        $parts = array_filter([$this->device_brand, $this->device_model]);
+
+        return $parts ? implode(' ', $parts) : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getStatusLabels(): array
+    {
+        return ['active' => 'Vinculado', 'unlinked' => 'Desvinculado'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getStatusColors(): array
+    {
+        return ['active' => 'success', 'unlinked' => 'gray'];
+    }
+}

--- a/database/migrations/2026_08_24_095247_create_employee_devices_table.php
+++ b/database/migrations/2026_08_24_095247_create_employee_devices_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Employee;
+use App\Models\EmployeeDevice;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_devices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('linked_at');
+            // null = dispositivo activo (todavía no reemplazado ni revocado) — un
+            // empleado solo puede tener un registro con unlinked_at null a la vez,
+            // igual que el `mobile_linked_at` único que reemplaza este historial.
+            $table->timestamp('unlinked_at')->nullable();
+            $table->string('user_agent')->nullable();
+            $table->string('device_brand', 60)->nullable();
+            $table->string('device_model', 100)->nullable();
+            $table->string('device_serial', 100)->nullable();
+            $table->string('device_mac', 17)->nullable();
+            $table->text('device_notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['employee_id', 'unlinked_at']);
+        });
+
+        // Backfill: empleados con un dispositivo ya vinculado antes de este historial
+        // (mobile_linked_at venía siendo el único registro, sin historial). Sin esto,
+        // el historial arrancaría vacío pese a vinculaciones reales ya en uso.
+        Employee::query()
+            ->whereNotNull('mobile_linked_at')
+            ->select(['id', 'mobile_linked_at'])
+            ->each(function (Employee $employee) {
+                EmployeeDevice::create([
+                    'employee_id' => $employee->id,
+                    'linked_at' => $employee->mobile_linked_at,
+                    'unlinked_at' => null,
+                    'user_agent' => null, // no se registraba antes de este historial
+                ]);
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_devices');
+    }
+};

--- a/tests/Feature/EmployeeDeviceTest.php
+++ b/tests/Feature/EmployeeDeviceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Filament\Resources\EmployeeDeviceResource\Pages\EditEmployeeDevice;
+use App\Filament\Resources\EmployeeDeviceResource\Pages\ListEmployeeDevices;
+use App\Filament\Resources\EmployeeDeviceResource\Pages\ViewEmployeeDevice;
+use App\Filament\Resources\EmployeeResource\Pages\ViewEmployee;
+use App\Filament\Resources\EmployeeResource\RelationManagers\DevicesRelationManager;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\EmployeeDevice;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDeviceTestEmployee(): Employee
+{
+    static $ci = 9600000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Device {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Device {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Device {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Device {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Device', 'last_name' => 'Test', 'ci' => (string) $n,
+        'birth_date' => '1990-05-15', 'branch_id' => $branch->id, 'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ]);
+    Contract::create([
+        'employee_id' => $employee->id, 'type' => 'indefinido', 'start_date' => now()->subYear(),
+        'salary_type' => 'mensual', 'salary' => 2_550_000, 'position_id' => $position->id,
+        'department_id' => $department->id, 'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+// ─── Ciclo de vida en Employee ──────────────────────────────────────────────
+
+it('claimMobileToken crea un EmployeeDevice activo', function () {
+    $employee = makeDeviceTestEmployee();
+
+    $employee->claimMobileToken('Mozilla/5.0 Device A');
+
+    expect($employee->devices()->count())->toBe(1)
+        ->and($employee->activeDevice)->not->toBeNull()
+        ->and($employee->activeDevice->user_agent)->toBe('Mozilla/5.0 Device A')
+        ->and($employee->activeDevice->isActive())->toBeTrue();
+});
+
+it('re-vincular cierra el dispositivo anterior y abre uno nuevo', function () {
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $firstDeviceId = $employee->activeDevice->id;
+
+    $employee->claimMobileToken('Device B');
+
+    expect($employee->devices()->count())->toBe(2)
+        ->and(EmployeeDevice::find($firstDeviceId)->unlinked_at)->not->toBeNull()
+        ->and($employee->activeDevice->user_agent)->toBe('Device B')
+        ->and($employee->devices()->whereNull('unlinked_at')->count())->toBe(1);
+});
+
+it('revokeMobileToken cierra el dispositivo activo sin crear uno nuevo', function () {
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $deviceId = $employee->activeDevice->id;
+
+    $employee->revokeMobileToken();
+
+    expect($employee->devices()->count())->toBe(1)
+        ->and($employee->activeDevice)->toBeNull()
+        ->and(EmployeeDevice::find($deviceId)->unlinked_at)->not->toBeNull()
+        ->and($employee->mobile_linked_at)->toBeNull();
+});
+
+it('device_description combina marca y modelo', function () {
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $device = $employee->activeDevice;
+    $device->update(['device_brand' => 'Samsung', 'device_model' => 'Galaxy A54']);
+
+    expect($device->fresh()->device_description)->toBe('Samsung Galaxy A54');
+});
+
+// ─── Recurso Filament ───────────────────────────────────────────────────────
+
+it('la lista de dispositivos muestra al empleado vinculado', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+
+    Livewire::test(ListEmployeeDevices::class)
+        ->assertOk()
+        ->assertSee($employee->full_name);
+});
+
+it('el detalle del dispositivo renderiza', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+
+    Livewire::test(ViewEmployeeDevice::class, ['record' => $employee->activeDevice->id])
+        ->assertOk();
+});
+
+it('editar el dispositivo guarda marca/modelo/mac sin tocar el ciclo de vinculación', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $device = $employee->activeDevice;
+
+    Livewire::test(EditEmployeeDevice::class, ['record' => $device->id])
+        ->fillForm([
+            'device_brand' => 'Samsung',
+            'device_model' => 'Galaxy A54',
+            'device_mac' => 'AA:BB:CC:DD:EE:FF',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $fresh = $device->fresh();
+    expect($fresh->device_brand)->toBe('Samsung')
+        ->and($fresh->device_model)->toBe('Galaxy A54')
+        ->and($fresh->device_mac)->toBe('AA:BB:CC:DD:EE:FF')
+        ->and($fresh->unlinked_at)->toBeNull();
+});
+
+it('la acción "Revocar" de la tabla cierra el dispositivo y limpia mobile_linked_at', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $device = $employee->activeDevice;
+
+    Livewire::test(ListEmployeeDevices::class)
+        ->mountTableAction('revoke', $device)
+        ->callMountedTableAction();
+
+    expect($device->fresh()->unlinked_at)->not->toBeNull()
+        ->and($employee->fresh()->mobile_linked_at)->toBeNull();
+});
+
+it('la acción "Revocar" no aparece para un dispositivo ya desvinculado', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+    $employee->revokeMobileToken();
+    $device = $employee->devices()->first();
+
+    Livewire::test(ListEmployeeDevices::class)
+        ->assertTableActionHidden('revoke', $device);
+});
+
+it('el RelationManager de dispositivos renderiza en la ficha del empleado', function () {
+    $this->actingAs(User::factory()->create());
+    $employee = makeDeviceTestEmployee();
+    $employee->claimMobileToken('Device A');
+
+    Livewire::test(DevicesRelationManager::class, [
+        'ownerRecord' => $employee,
+        'pageClass' => ViewEmployee::class,
+    ])->assertOk();
+});


### PR DESCRIPTION
## Resumen

- Nueva tabla `employee_devices` — registro histórico (no solo el dispositivo actual) de cada vinculación/re-vinculación de celular por empleado, con migración de backfill para los empleados que ya tenían `mobile_linked_at`.
- `Employee::claimMobileToken()`/`revokeMobileToken()` ahora cierran/crean el `EmployeeDevice` correspondiente en cada evento del ciclo de vinculación.
- Nuevo `EmployeeDeviceResource` (Filament) — listado + vista + edición de anotaciones manuales (marca/modelo/serie/MAC/notas), siguiendo el mismo patrón ya usado en `Terminal`. Incluye acción **Revocar** en la tabla (visible solo si el dispositivo está activo).
- Nuevo `DevicesRelationManager` de solo lectura en `EmployeeResource`, enlazando cada fila al detalle en el recurso standalone.
- Fix de un bug real de caché de relación en Eloquent: `$employee->activeDevice` (relación `hasOne`) quedaba con el valor cacheado (stale) inmediatamente después de mutar vía `$employee->devices()->create(...)`/`update(...)` en la misma instancia — se corrige llamando explícitamente a `setRelation()` tras cada mutación.

## Test plan

- [x] `verify_employee_devices.php` (scratch, lógica de modelo pura contra SQLite): 17/17 aserciones OK — primera vinculación, re-vinculación (cierra anterior/abre nuevo), revocar (cierra sin crear), `device_description`, backfill de empleados legacy.
- [x] `verify_employee_device_filament.php` (scratch, Livewire/Filament): 6/6 aserciones OK — listado muestra al empleado, vista de detalle renderiza, edición guarda marca/modelo, acción "Revocar" cierra el dispositivo y limpia `mobile_linked_at`, RelationManager renderiza en la ficha del empleado.
- [x] Nuevo `tests/Feature/EmployeeDeviceTest.php` (Pest) — mismos casos que las verificaciones scratch, usando el patrón estándar `Livewire::test()->fillForm()->assertHasNoFormErrors()`.
- [x] `php -l` en todos los archivos nuevos/modificados — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_