### PR TITLE
Fix: tarjeta de última marcación no se actualizaba al volver al idle (modo móvil)

### DIFF
--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -916,6 +916,10 @@ const statusBar           = document.getElementById("statusBar");
         splashHandled = false;
         showSplash();
         window.scrollTo({ top: 0, behavior: "instant" });
+
+        // Refrescar la tarjeta "Hoy: ..." con la marcación recién registrada —
+        // sin esto queda con el texto de antes de marcar hasta recargar la página.
+        refreshOwnEmployeeUi();
     }
 
     /**


### PR DESCRIPTION
## Resumen

En `/marcar`, la tarjeta "Hoy: `<evento>` · HH:MM" del splash/idle (agregada en PR #104) se poblaba una sola vez — al cargar la página y tras el heartbeat inicial — pero `returnToSplash()` (la función que vuelve a mostrar el splash al cerrar el modal de éxito tras una marcación) nunca volvía a llamar a `refreshOwnEmployeeUi()`. El dato en sí ya estaba correcto del lado del cliente (`enqueueMark()` en `mobile-offline/queue.js` actualiza el caché de estado al instante), pero la UI no lo reflejaba hasta que el empleado recargaba la página.

**Fix:** una sola llamada a `refreshOwnEmployeeUi()` al final de `returnToSplash()` — es el único punto de retorno al idle tras marcar, y la función ya era idempotente/segura de re-invocar (se usa así en la carga inicial de la página).

## Test plan

- [x] Verificado end-to-end con Playwright contra un servidor real (empleado seedeado, token Sanctum real, POST real a `/api/v1/mobile/events/sync`): confirmado que **antes** de volver al splash la tarjeta muestra el valor viejo ("Todavía no marcaste hoy") a pesar de que el servidor ya confirmó la marcación, y que **después** de invocar el mismo código real que corre al cerrar el modal de éxito, la tarjeta se actualiza a "Hoy: Entrada · HH:MM" sin recargar la página.
- [x] `npm run build` — sin errores.
- [x] `vendor/bin/pint --dirty` — sin hallazgos (sin cambios PHP en este fix).
- [ ] CI (Pest + MySQL real) — no aplica test Pest nuevo (fix de UI puro, sin lógica de backend); se confirma que el resto de la suite no se ve afectada en el pipeline.

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_