### PR TITLE
Logo de la empresa en el header de ambos modos de marcación

### DIFF
--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -54,6 +54,7 @@ class MobileHeartbeatController extends Controller
                 'photo_thumbnail' => $employee->photo_thumbnail,
                 'branch_name' => $employee->branch?->name,
                 'company_name' => $employee->branch?->company?->name,
+                'company_logo' => $employee->branch?->company?->logo_thumbnail,
             ],
         ]);
     }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -19,6 +19,7 @@ class Company extends Model
         'ruc',
         'employer_number',
         'logo',
+        'logo_thumbnail',
         'address',
         'phone',
         'email',

--- a/app/Observers/CompanyObserver.php
+++ b/app/Observers/CompanyObserver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Company;
+use App\Services\CompanyLogoThumbnailService;
+
+class CompanyObserver
+{
+    /**
+     * Regenera `logo_thumbnail` en la misma escritura que cambia `logo` — en
+     * `saving()` (no `updated()`/`created()`) para que quede en el mismo
+     * INSERT/UPDATE, sin una segunda query. Mismo patrón que
+     * EmployeeObserver::saving() para `photo_thumbnail`.
+     */
+    public function saving(Company $company): void
+    {
+        if ($company->isDirty('logo')) {
+            $company->logo_thumbnail = CompanyLogoThumbnailService::generate($company->logo);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,10 +4,12 @@ namespace App\Providers;
 
 use App\Models\AttendanceDay;
 use App\Models\AttendanceEvent;
+use App\Models\Company;
 use App\Models\Contract;
 use App\Models\Employee;
 use App\Observers\AttendanceDayObserver;
 use App\Observers\AttendanceEventObserver;
+use App\Observers\CompanyObserver;
 use App\Observers\ContractObserver;
 use App\Observers\EmployeeObserver;
 use Illuminate\Support\ServiceProvider;
@@ -29,6 +31,7 @@ class AppServiceProvider extends ServiceProvider
     {
         AttendanceDay::observe(AttendanceDayObserver::class);
         AttendanceEvent::observe(AttendanceEventObserver::class);
+        Company::observe(CompanyObserver::class);
         Contract::observe(ContractObserver::class);
         Employee::observe(EmployeeObserver::class);
     }

--- a/app/Services/CompanyLogoThumbnailService.php
+++ b/app/Services/CompanyLogoThumbnailService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Genera un thumbnail de baja resolución del logo de una empresa, codificado
+ * como data URI PNG en base64. Se persiste en `Company::logo_thumbnail` (ver
+ * CompanyObserver) para viajar embebido en el shell cacheado del kiosko
+ * (`window.terminalData`) y en el payload de heartbeat del celular, sin
+ * depender de red para pedir la imagen original por separado.
+ *
+ * A diferencia de EmployeePhotoThumbnailService (recorte cuadrado + JPEG,
+ * apto para un rostro), acá se ajusta preservando la proporción original —
+ * los logos rara vez son cuadrados, un recorte centrado le cortaría contenido
+ * a un logotipo ancho — y se exporta en PNG para conservar transparencia
+ * (el logo convive con headers en tema claro y oscuro).
+ *
+ * SVG no se procesa: GD no puede rasterizar vectores. `imagecreatefromstring`
+ * simplemente falla sobre contenido SVG (no es un formato de imagen binario
+ * reconocible) y esta clase devuelve null, igual que si no hubiera logo.
+ */
+class CompanyLogoThumbnailService
+{
+    /** Ancho máximo del thumbnail, en píxeles. */
+    private const MAX_WIDTH = 240;
+
+    /** Alto máximo del thumbnail, en píxeles. */
+    private const MAX_HEIGHT = 80;
+
+    /** Nivel de compresión PNG (0-9) — 6 es el balance por defecto de GD entre tamaño y velocidad. */
+    private const COMPRESSION = 6;
+
+    /**
+     * @param  string|null  $logoPath  Path relativo en el disco `public` (ej. `companies/logos/foo.png`).
+     * @return string|null Data URI (`data:image/png;base64,...`), o null si el logo no existe, es SVG, o no se pudo procesar.
+     */
+    public static function generate(?string $logoPath): ?string
+    {
+        if (! $logoPath || ! Storage::disk('public')->exists($logoPath)) {
+            return null;
+        }
+
+        $source = @imagecreatefromstring(Storage::disk('public')->get($logoPath));
+
+        if ($source === false) {
+            return null;
+        }
+
+        $width = imagesx($source);
+        $height = imagesy($source);
+
+        // Nunca se agranda un logo más chico que el bounding box — solo se achica si excede.
+        $scale = min(self::MAX_WIDTH / $width, self::MAX_HEIGHT / $height, 1);
+        $newWidth = max(1, (int) round($width * $scale));
+        $newHeight = max(1, (int) round($height * $scale));
+
+        $thumbnail = imagecreatetruecolor($newWidth, $newHeight);
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+        $transparent = imagecolorallocatealpha($thumbnail, 0, 0, 0, 127);
+        imagefill($thumbnail, 0, 0, $transparent);
+
+        imagecopyresampled($thumbnail, $source, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+
+        ob_start();
+        imagepng($thumbnail, null, self::COMPRESSION);
+        $pngData = ob_get_clean();
+
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        return 'data:image/png;base64,'.base64_encode($pngData);
+    }
+}

--- a/database/migrations/2026_08_25_015037_add_logo_thumbnail_to_companies_table.php
+++ b/database/migrations/2026_08_25_015037_add_logo_thumbnail_to_companies_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\Company;
+use App\Services\CompanyLogoThumbnailService;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega `logo_thumbnail` a companies: un data URI base64 (PNG, ajustado
+ * preservando proporción, generado por CompanyLogoThumbnailService) para que
+ * el header persistente de ambos modos de marcación (celular y kiosko) pueda
+ * mostrar el logo real sin depender de red — se sincroniza embebido en el
+ * shell cacheado del kiosko y en el payload de heartbeat del celular, igual
+ * que `photo_thumbnail` en employees (PR #83).
+ *
+ * A diferencia de `photo_thumbnail`, acá sí se hace backfill: la cantidad de
+ * empresas por instalación es chica (a diferencia de miles de empleados), así
+ * que no tiene sentido dejar el logo de una empresa ya configurada sin
+ * thumbnail hasta que un admin la vuelva a guardar.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->text('logo_thumbnail')->nullable()->after('logo');
+        });
+
+        Company::query()->whereNotNull('logo')->select(['id', 'logo'])->each(function (Company $company) {
+            $company->forceFill([
+                'logo_thumbnail' => CompanyLogoThumbnailService::generate($company->logo),
+            ])->save();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropColumn('logo_thumbnail');
+        });
+    }
+};

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -174,6 +174,17 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
     text-overflow: ellipsis;
     min-width: 0;
 }
+/* Logo de la empresa junto al badge de sucursal — PNG con transparencia, se ve
+   bien en ambos temas. object-fit: contain preserva la proporción original.
+   Más chico que en terminal.css: acá compite por espacio con mode-badge +
+   theme-toggle en una pantalla de 375px. */
+.header-logo {
+    height: 20px;
+    max-width: 72px;
+    width: auto;
+    object-fit: contain;
+    flex-shrink: 0;
+}
 
 /* ============================================================
    BANNER OFFLINE

--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -179,6 +179,7 @@ body {
     box-shadow: none;
 }
 .terminal-header--idle .terminal-mode-badge,
+.terminal-header--idle .header-logo,
 .terminal-header--idle .terminal-location-badge,
 .terminal-header--idle .terminal-clock {
     opacity: 0;
@@ -208,6 +209,15 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
+}
+/* Logo de la empresa junto al badge de sucursal — PNG con transparencia, se ve
+   bien en ambos temas. object-fit: contain preserva la proporción original. */
+.header-logo {
+    height: 24px;
+    max-width: 120px;
+    width: auto;
+    object-fit: contain;
+    flex-shrink: 0;
 }
 .theme-toggle {
     display: flex; align-items: center; justify-content: center;

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -2207,6 +2207,7 @@ const statusBar           = document.getElementById("statusBar");
         const splashDateEl     = document.getElementById("splashDate");
         const splashStatusEl   = document.getElementById("splashStatus");
         const headerLocationEl = document.getElementById("headerLocation");
+        const headerLogoEl     = document.getElementById("headerLogo");
 
         // Nombre propio cacheado (mismo dato que ya usa Mis marcaciones) — normalmente
         // ya está en IndexedDB de una sesión anterior, así que suele completarse antes
@@ -2251,6 +2252,12 @@ const statusBar           = document.getElementById("statusBar");
                         headerLocationEl.textContent = [employee.branch_name, employee.company_name]
                             .filter(Boolean)
                             .join(" — ");
+                    }
+                    // Logo de la empresa — ya viaja embebido como data URI en el propio
+                    // heartbeat (mismo caché offline que branch_name/company_name).
+                    if (headerLogoEl && employee?.company_logo) {
+                        headerLogoEl.src = employee.company_logo;
+                        headerLogoEl.classList.remove("hidden");
                     }
                     // Título de pestaña — la empresa no se conoce server-side en esta
                     // página (la identidad del empleado se resuelve recién acá, vía

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -96,6 +96,15 @@ document.addEventListener("DOMContentLoaded", () => {
             .join(" — ");
     }
 
+    // Logo de la empresa — ya viaja embebido como data URI en window.terminalData
+    // (inyectado server-side), así que queda cacheado junto con el shell del kiosko
+    // por el service worker sin necesidad de un fetch aparte.
+    const headerLogo = document.getElementById("terminalHeaderLogo");
+    if (terminalData && headerLogo && terminalData.company_logo) {
+        headerLogo.src = terminalData.company_logo;
+        headerLogo.classList.remove("hidden");
+    }
+
     // ============================================================================
     // ESTADO GLOBAL
     // ============================================================================

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -64,6 +64,7 @@
     <header class="app-header">
         <div class="app-header-brand">
             <span class="app-mode-badge">Marcación Facial</span>
+            <img id="headerLogo" class="header-logo hidden" alt="">
             <span id="headerLocation" class="app-location-badge"></span>
             <button type="button" id="btnThemeToggle" class="theme-toggle" aria-label="Cambiar tema claro/oscuro">
                 <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -20,6 +20,7 @@
         <header class="terminal-header">
             <div class="terminal-header-brand">
                 <span class="terminal-mode-badge">Modo Terminal</span>
+                <img id="terminalHeaderLogo" class="header-logo hidden" alt="">
                 <span id="terminalHeaderLocation" class="terminal-location-badge"></span>
                 <button type="button" id="btnThemeToggle" class="theme-toggle" aria-label="Cambiar tema claro/oscuro">
                     <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -69,6 +70,7 @@
             branch_id: {{ $terminal->branch_id ?? 'null' }},
             branch_name: @json($terminal->branch?->name),
             company_name: @json($terminal->branch?->company?->name),
+            company_logo: @json($terminal->branch?->company?->logo_thumbnail),
         };
     </script>
     @endisset

--- a/tests/Feature/CompanyLogoThumbnailTest.php
+++ b/tests/Feature/CompanyLogoThumbnailTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\Company;
+use App\Services\CompanyLogoThumbnailService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLogoCompany(array $attributes = []): Company
+{
+    static $n = 6000000;
+    $n++;
+
+    return Company::create(array_merge([
+        'name' => "Empresa Logo {$n}",
+        'ruc' => "{$n}-1",
+        'employer_number' => $n,
+    ], $attributes));
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('genera un thumbnail PNG preservando la proporción de un logo rectangular', function () {
+    Storage::fake('public');
+    $image = UploadedFile::fake()->image('logo.png', 800, 200);
+    $path = $image->store('companies/logos', 'public');
+
+    $dataUri = CompanyLogoThumbnailService::generate($path);
+
+    expect($dataUri)->toStartWith('data:image/png;base64,');
+
+    $decoded = base64_decode(substr($dataUri, strlen('data:image/png;base64,')));
+    $gdImage = imagecreatefromstring($decoded);
+
+    // 800x200 ajustado al bounding box 240x80 preservando proporción -> 240x60
+    expect(imagesx($gdImage))->toBe(240)
+        ->and(imagesy($gdImage))->toBe(60);
+});
+
+it('no agranda un logo más chico que el bounding box máximo', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('logo.png', 50, 30)->store('companies/logos', 'public');
+
+    $dataUri = CompanyLogoThumbnailService::generate($path);
+    $decoded = base64_decode(substr($dataUri, strlen('data:image/png;base64,')));
+    $gdImage = imagecreatefromstring($decoded);
+
+    expect(imagesx($gdImage))->toBe(50)
+        ->and(imagesy($gdImage))->toBe(30);
+});
+
+it('devuelve null para un logo SVG (GD no puede rasterizarlo)', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('companies/logos/vector.svg', '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>');
+
+    expect(CompanyLogoThumbnailService::generate('companies/logos/vector.svg'))->toBeNull();
+});
+
+it('devuelve null si el logo no existe o el path es null', function () {
+    Storage::fake('public');
+
+    expect(CompanyLogoThumbnailService::generate('companies/logos/no-existe.png'))->toBeNull()
+        ->and(CompanyLogoThumbnailService::generate(null))->toBeNull();
+});
+
+it('el observer genera logo_thumbnail automáticamente al crear una empresa con logo', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('logo.png', 300, 100)->store('companies/logos', 'public');
+
+    $company = makeLogoCompany(['logo' => $path]);
+
+    expect($company->logo_thumbnail)->not->toBeNull()
+        ->and($company->logo_thumbnail)->toStartWith('data:image/png;base64,');
+});
+
+it('el observer limpia logo_thumbnail cuando se quita el logo', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('logo.png', 300, 100)->store('companies/logos', 'public');
+    $company = makeLogoCompany(['logo' => $path]);
+
+    $company->update(['logo' => null]);
+
+    expect($company->fresh()->logo_thumbnail)->toBeNull();
+});
+
+it('un update que no toca el logo no regenera ni borra el thumbnail existente', function () {
+    Storage::fake('public');
+    $path = UploadedFile::fake()->image('logo.png', 300, 100)->store('companies/logos', 'public');
+    $company = makeLogoCompany(['logo' => $path]);
+    $originalThumbnail = $company->logo_thumbnail;
+
+    $company->update(['name' => 'Otro Nombre']);
+
+    expect($company->fresh()->logo_thumbnail)->toBe($originalThumbnail);
+});

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -171,6 +171,27 @@ it('el heartbeat también devuelve sucursal y empresa para el header de /marcar'
         ->and($response->json('employee.company_name'))->toBe($employee->branch->company->name);
 });
 
+it('el heartbeat también devuelve el logo de la empresa para el header de /marcar', function () {
+    $employee = makeLinkableEmployee();
+    $employee->branch->company->update(['logo_thumbnail' => 'data:image/png;base64,FAKE_LOGO']);
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.company_logo'))->toBe('data:image/png;base64,FAKE_LOGO');
+});
+
+it('el heartbeat devuelve company_logo null si la empresa no tiene logo', function () {
+    $employee = makeLinkableEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.company_logo'))->toBeNull();
+});
+
 it('el heartbeat revoca el token y responde 403 si el empleado ya no está activo', function () {
     $employee = makeLinkableEmployee();
     Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);


### PR DESCRIPTION
## Resumen

Retoma el ítem que había quedado diferido en PR #105 ("¿se podría mostrar el logo de la empresa?"). Sigue el mismo patrón offline-safe que `EmployeePhotoThumbnailService` (PR #83), con tres diferencias deliberadas por las características propias de un logo (vs. una foto de rostro):

- **`CompanyLogoThumbnailService`**: ajusta preservando la proporción original (bounding box 240×80px, nunca agranda) en vez de recortar a cuadrado — un logo ancho no pierde contenido.
- **Salida PNG** (no JPEG) para preservar transparencia — el logo convive con headers en tema claro y oscuro.
- **SVG no se procesa**: GD no puede rasterizar vectores. `imagecreatefromstring` falla sobre contenido SVG y el método devuelve `null` — mismo comportamiento que una empresa sin logo, sin necesidad de sanitizar SVG ni ampliar el modelo de riesgo.

**Persistencia y sync:** `CompanyObserver::saving()` regenera `logo_thumbnail` cuando `logo` cambia (mismo patrón que `EmployeeObserver`). Viaja embebido como data URI:
- Kiosko: en `window.terminalData.company_logo`, cacheado junto con el shell por el service worker (igual que `company_name`, sin sync aparte).
- Celular: en el payload del heartbeat (`employee.company_logo`), cacheado en IndexedDB junto con `branch_name`/`company_name`.

**Backfill**: a diferencia de `photo_thumbnail` (potencialmente miles de empleados), la migración sí hace backfill de las empresas ya existentes con logo — la cantidad de empresas por instalación es chica.

**UI:** logo + texto de sucursal/empresa, uno al lado del otro, en el header persistente de ambos modos (`.header-logo`, altura 24px en terminal / 20px en móvil dado el espacio más angosto). Se oculta en el header idle del kiosko igual que el badge de sucursal.

## Test plan

- [x] Verificado con script scratch contra SQLite real (con archivos PNG/SVG reales, no mocks): 11/11 aserciones — proporción preservada, no agranda logos chicos, SVG devuelve null sin excepción, transparencia preservada (canal alfa), observer regenera/limpia el thumbnail correctamente.
- [x] Migración `up()`/`down()` verificada aparte: agrega la columna, hace backfill de una empresa pre-existente con logo, y el rollback la elimina — 4/4 aserciones.
- [x] Verificado end-to-end con Playwright contra un servidor real (empleado + terminal + empresa con logo real): el logo aparece con el `src` correcto y sin la clase `hidden` en ambos modos — 4/4 aserciones core. Capturas de pantalla confirman el layout sin overflow ni rotura visual en 375px (móvil) y 900px (kiosko).
- [x] Nuevo `tests/Feature/CompanyLogoThumbnailTest.php` (7 tests) + 2 tests nuevos en `tests/Feature/MobileAttendanceLinkTest.php` (heartbeat incluye/omite `company_logo`).
- [x] `npm run build` — sin errores. `php -l` — sin errores. `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_