### PR TITLE
Detección automática (best-effort) de marca/modelo al vincular dispositivos

### DIFF
--- a/app/Filament/Resources/EmployeeDeviceResource.php
+++ b/app/Filament/Resources/EmployeeDeviceResource.php
@@ -64,11 +64,13 @@ class EmployeeDeviceResource extends Resource
                         TextInput::make('device_brand')
                             ->label('Marca')
                             ->placeholder('Ej: Samsung, Apple, Motorola')
+                            ->helperText('Se sugiere automáticamente al vincular el dispositivo, cuando el navegador lo permite. Editable.')
                             ->maxLength(60),
 
                         TextInput::make('device_model')
                             ->label('Modelo')
                             ->placeholder('Ej: Galaxy A54')
+                            ->helperText('Igual que la marca: sugerido automáticamente, no siempre disponible (ej. iPhone/iPad nunca lo reportan).')
                             ->maxLength(100),
 
                         TextInput::make('device_serial')

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -90,11 +90,13 @@ class TerminalResource extends Resource
                         TextInput::make('device_brand')
                             ->label('Marca')
                             ->placeholder('Ej: Samsung, Apple, Lenovo')
+                            ->helperText('Se sugiere automáticamente al vincular el dispositivo, cuando el navegador lo permite. Editable.')
                             ->maxLength(60),
 
                         TextInput::make('device_model')
                             ->label('Modelo')
                             ->placeholder('Ej: Galaxy Tab A8')
+                            ->helperText('Igual que la marca: sugerido automáticamente, no siempre disponible (ej. iPhone/iPad nunca lo reportan).')
                             ->maxLength(100),
 
                         TextInput::make('device_serial')
@@ -223,12 +225,17 @@ class TerminalResource extends Resource
                             ->copyable()
                             ->placeholder('-'),
 
+                        TextEntry::make('user_agent')
+                            ->label('Navegador (detectado al provisionar)')
+                            ->placeholder('Sin datos')
+                            ->limit(60),
+
                         TextEntry::make('device_notes')
                             ->label('Notas')
                             ->placeholder('Sin notas')
                             ->columnSpanFull(),
                     ])
-                    ->visible(fn (Terminal $record) => $record->device_brand || $record->device_model || $record->device_serial || $record->device_mac || $record->device_notes),
+                    ->visible(fn (Terminal $record) => $record->device_brand || $record->device_model || $record->device_serial || $record->device_mac || $record->device_notes || $record->user_agent),
 
                 InfoSection::make('Conectividad')
                     ->description('Marcación offline vía PWA — heartbeat y sincronización con la API de terminales')

--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -45,6 +45,7 @@ class MobileLinkController extends Controller
         $data = $request->validate([
             'ci' => ['required', 'string', 'max:20'],
             'birth_date' => ['required', 'date'],
+            'device_model_hint' => ['nullable', 'string', 'max:100'],
         ]);
 
         $employee = Employee::query()
@@ -68,7 +69,7 @@ class MobileLinkController extends Controller
             ], 422);
         }
 
-        $plainTextToken = $employee->claimMobileToken($request->userAgent());
+        $plainTextToken = $employee->claimMobileToken($request->userAgent(), $data['device_model_hint'] ?? null);
 
         Log::info("Dispositivo vinculado para el empleado #{$employee->id} ({$employee->first_name} {$employee->last_name})", [
             'employee_id' => $employee->id,

--- a/app/Http/Controllers/TerminalSetupController.php
+++ b/app/Http/Controllers/TerminalSetupController.php
@@ -47,7 +47,11 @@ class TerminalSetupController extends Controller
             ], 422);
         }
 
-        $plainTextToken = $terminal->claimSanctumToken();
+        $clientHintModel = $request->validate([
+            'device_model_hint' => ['nullable', 'string', 'max:100'],
+        ])['device_model_hint'] ?? null;
+
+        $plainTextToken = $terminal->claimSanctumToken($request->userAgent(), $clientHintModel);
 
         Log::info("Terminal '{$terminal->code}' ({$terminal->name}) provisionado para sincronización offline", [
             'terminal_id' => $terminal->id,

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
+use App\Services\DeviceHintsParser;
 use App\Settings\PayrollSettings;
 use Carbon\Carbon;
 use Illuminate\Auth\Authenticatable;
@@ -1201,9 +1202,12 @@ class Employee extends Model implements AuthenticatableContract
      * `MobileLinkController`). Revoca cualquier token móvil previo — un solo
      * dispositivo vinculado a la vez, igual que `Terminal::claimSanctumToken()`.
      *
+     * @param  string|null  $clientHintModel  Modelo reportado por Client Hints del navegador
+     *                                        (`navigator.userAgentData.getHighEntropyValues(['model'])`), cuando está disponible —
+     *                                        ver DeviceHintsParser para el detalle de qué navegadores lo soportan.
      * @return string Token Sanctum en texto plano — solo se retorna una vez, nunca se persiste en claro.
      */
-    public function claimMobileToken(?string $userAgent = null): string
+    public function claimMobileToken(?string $userAgent = null, ?string $clientHintModel = null): string
     {
         // Se evalúa antes de pisar mobile_linked_at — distingue una vinculación
         // nueva (informativa) de una re-vinculación (ver MobileDeviceRelinkedNotification:
@@ -1217,9 +1221,17 @@ class Employee extends Model implements AuthenticatableContract
         // Cierra el dispositivo activo anterior (si había) antes de abrir uno
         // nuevo — nunca quedan dos registros con unlinked_at null a la vez.
         $this->activeDevice?->update(['unlinked_at' => $linkedAt]);
+        // Marca/modelo sugeridos (best-effort, editables) a partir del User-Agent
+        // y, si el navegador lo soporta, de Client Hints — ver DeviceHintsParser.
+        // Siempre se aplican acá: cada vinculación crea un EmployeeDevice nuevo,
+        // no hay un valor manual previo que pisar (a diferencia de Terminal, que
+        // reutiliza el mismo registro entre reprovisiones).
+        $guess = DeviceHintsParser::guess($userAgent, $clientHintModel);
         $newDevice = $this->devices()->create([
             'linked_at' => $linkedAt,
             'user_agent' => $userAgent,
+            'device_brand' => $guess['brand'],
+            'device_model' => $guess['model'],
         ]);
         // setRelation en vez de dejar que quede cacheado el activeDevice anterior (o
         // null) en esta misma instancia — sin esto, $employee->activeDevice después de

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Notifications\TerminalProvisionedNotification;
+use App\Services\DeviceHintsParser;
 use App\Settings\GeneralSettings;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -44,6 +45,7 @@ class Terminal extends Model implements AuthenticatableContract
         'device_serial',
         'device_mac',
         'device_notes',
+        'user_agent',
         'installed_at',
         'installed_by_id',
         'last_seen_at',
@@ -373,16 +375,32 @@ class Terminal extends Model implements AuthenticatableContract
      * con la ability de sincronización. Revoca tokens `terminal:sync`
      * previos para que solo quede uno activo por terminal.
      *
+     * @param  string|null  $userAgent  User-Agent del dispositivo que provisiona, para diagnóstico
+     *                                  y como insumo de DeviceHintsParser (marca/modelo sugeridos, editables).
+     * @param  string|null  $clientHintModel  Modelo reportado por Client Hints del navegador
+     *                                        (`navigator.userAgentData.getHighEntropyValues(['model'])`), cuando está disponible —
+     *                                        ver DeviceHintsParser para el detalle de qué navegadores lo soportan.
      * @return string Token Sanctum en texto plano — solo se retorna una vez, nunca se persiste en claro.
      */
-    public function claimSanctumToken(): string
+    public function claimSanctumToken(?string $userAgent = null, ?string $clientHintModel = null): string
     {
         $this->tokens()->where('name', 'like', 'kiosk:%')->delete();
 
-        $this->forceFill([
+        $attributes = [
             'setup_token' => null,
             'setup_token_expires_at' => null,
-        ])->save();
+            'user_agent' => $userAgent,
+        ];
+
+        // Solo sugiere marca/modelo si el admin no los cargó ya a mano — nunca pisa una
+        // corrección manual previa (ej. una reprovisión del mismo terminal físico).
+        if (blank($this->device_brand) && blank($this->device_model)) {
+            $guess = DeviceHintsParser::guess($userAgent, $clientHintModel);
+            $attributes['device_brand'] = $guess['brand'];
+            $attributes['device_model'] = $guess['model'];
+        }
+
+        $this->forceFill($attributes)->save();
 
         User::all()->each(fn (User $user) => $user->notify(new TerminalProvisionedNotification($this)));
 

--- a/app/Services/DeviceHintsParser.php
+++ b/app/Services/DeviceHintsParser.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Adivina marca/modelo de un dispositivo a partir de datos que el propio
+ * navegador entrega al vincular/provisionar (User-Agent + Client Hints de
+ * alta entropía, cuando el navegador los soporta). Best-effort, no
+ * autoritativo — el admin puede corregir el resultado a mano en cualquier
+ * momento; los llamadores deciden si sobreescriben un valor ya cargado.
+ *
+ * Límite duro e inevitable: MAC address y número de serie NUNCA son
+ * accesibles desde un navegador, en ningún dispositivo — no hay API web que
+ * los exponga. Esta clase ni lo intenta.
+ *
+ * Precisión por plataforma:
+ * - Android + navegador Chromium (Chrome, Edge...): alta — usa Client Hints
+ *   (`navigator.userAgentData.getHighEntropyValues(['model'])` del lado del
+ *   cliente), que da el modelo real (ej. "Pixel 7", "SM-A536B").
+ * - iOS/Safari, Firefox: baja — esa API no existe ahí. El User-Agent de iOS
+ *   deliberadamente nunca incluye el modelo (siempre "iPhone" genérico).
+ * - Desktop: sin intento de adivinar marca — Windows/Linux son sistemas
+ *   operativos, no marcas de hardware, y Client Hints tampoco identifica al
+ *   fabricante del equipo.
+ */
+class DeviceHintsParser
+{
+    /**
+     * Prefijos de modelo conocidos → marca. Heurística chica y ampliable
+     * cubriendo los fabricantes Android más comunes — no pretende ser
+     * exhaustiva, solo evitar que el admin tenga que tipear la marca cuando
+     * ya es obvia a partir del modelo detectado.
+     *
+     * @var array<string, string>
+     */
+    private const BRAND_PREFIXES = [
+        'SM-' => 'Samsung',
+        'Pixel' => 'Google',
+        'Redmi' => 'Xiaomi',
+        'POCO' => 'Xiaomi',
+        'Mi ' => 'Xiaomi',
+        'moto' => 'Motorola',
+        'Moto' => 'Motorola',
+        'ONEPLUS' => 'OnePlus',
+        'LG-' => 'LG',
+        'HUAWEI' => 'Huawei',
+        'Nokia' => 'Nokia',
+    ];
+
+    /**
+     * @param  string|null  $userAgent  Header User-Agent crudo de la request.
+     * @param  string|null  $clientHintModel  Modelo reportado por
+     *                                        `navigator.userAgentData.getHighEntropyValues(['model'])` en el
+     *                                        cliente, cuando el navegador lo soporta (Chromium + Android). Tiene
+     *                                        prioridad sobre el parseo del User-Agent por ser más confiable.
+     * @return array{brand: string|null, model: string|null}
+     */
+    public static function guess(?string $userAgent, ?string $clientHintModel = null): array
+    {
+        $clientHintModel = trim((string) $clientHintModel);
+
+        if ($clientHintModel !== '') {
+            return [
+                'brand' => self::guessBrandFromModel($clientHintModel),
+                'model' => $clientHintModel,
+            ];
+        }
+
+        if (! $userAgent) {
+            return ['brand' => null, 'model' => null];
+        }
+
+        if (str_contains($userAgent, 'iPad')) {
+            return ['brand' => 'Apple', 'model' => 'iPad'];
+        }
+
+        if (str_contains($userAgent, 'iPhone')) {
+            return ['brand' => 'Apple', 'model' => 'iPhone'];
+        }
+
+        if (str_contains($userAgent, 'Macintosh')) {
+            return ['brand' => 'Apple', 'model' => null];
+        }
+
+        // Android clásico: "...Linux; Android 13; Pixel 7) AppleWebKit..." — el
+        // modelo va entre la versión de Android y el paréntesis de cierre, a
+        // veces con un sufijo " Build/XXXXX" que se recorta.
+        if (preg_match('/Android\s[\d.]+;\s*([^)]+)\)/', $userAgent, $matches)) {
+            $model = trim(preg_replace('/\s+Build\/.*/', '', $matches[1]));
+
+            if ($model !== '' && ! str_starts_with($model, 'wv')) {
+                return ['brand' => self::guessBrandFromModel($model), 'model' => $model];
+            }
+        }
+
+        return ['brand' => null, 'model' => null];
+    }
+
+    private static function guessBrandFromModel(string $model): ?string
+    {
+        foreach (self::BRAND_PREFIXES as $prefix => $brand) {
+            if (str_starts_with($model, $prefix)) {
+                return $brand;
+            }
+        }
+
+        return null;
+    }
+}

--- a/database/migrations/2026_08_25_123752_add_user_agent_to_terminals_table.php
+++ b/database/migrations/2026_08_25_123752_add_user_agent_to_terminals_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega `user_agent` a terminals — capturado en TerminalSetupController::claim()
+ * al provisionar el kiosko, mismo dato que ya guarda EmployeeDevice desde la
+ * Fase 1 de Parte C. Insumo de DeviceHintsParser para prellenar marca/modelo
+ * como sugerencia editable, y referencia diagnóstica adicional en el panel.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->string('user_agent')->nullable()->after('device_notes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->dropColumn('user_agent');
+        });
+    }
+};

--- a/resources/views/attendances/device-link.blade.php
+++ b/resources/views/attendances/device-link.blade.php
@@ -134,6 +134,20 @@
         const statusEl = document.getElementById('status');
         const csrf = document.querySelector('meta[name="csrf-token"]').content;
 
+        // Modelo real del dispositivo, solo disponible vía Client Hints en navegadores
+        // Chromium sobre Android (Chrome, Edge...) — null en iOS/Safari/Firefox/desktop,
+        // donde el servidor cae al parseo del User-Agent (ver DeviceHintsParser). Sirve
+        // solo para prellenar marca/modelo como sugerencia editable en el panel.
+        async function getClientHintModel() {
+            if (!navigator.userAgentData?.getHighEntropyValues) return null;
+            try {
+                const hints = await navigator.userAgentData.getHighEntropyValues(['model']);
+                return hints.model || null;
+            } catch {
+                return null;
+            }
+        }
+
         form.addEventListener('submit', async (event) => {
             event.preventDefault();
             btn.disabled = true;
@@ -147,6 +161,7 @@
                     body: JSON.stringify({
                         ci: document.getElementById('ci').value.trim(),
                         birth_date: document.getElementById('birth_date').value,
+                        device_model_hint: await getClientHintModel(),
                     }),
                 });
                 const data = await response.json();

--- a/resources/views/attendances/terminal-setup.blade.php
+++ b/resources/views/attendances/terminal-setup.blade.php
@@ -71,6 +71,20 @@
         const statusEl = document.getElementById('status');
         const csrf = document.querySelector('meta[name="csrf-token"]').content;
 
+        // Modelo real del dispositivo, solo disponible vía Client Hints en navegadores
+        // Chromium sobre Android (Chrome, Edge...) — null en iOS/Safari/Firefox/desktop,
+        // donde el servidor cae al parseo del User-Agent (ver DeviceHintsParser). Sirve
+        // solo para prellenar marca/modelo como sugerencia editable en el panel.
+        async function getClientHintModel() {
+            if (!navigator.userAgentData?.getHighEntropyValues) return null;
+            try {
+                const hints = await navigator.userAgentData.getHighEntropyValues(['model']);
+                return hints.model || null;
+            } catch {
+                return null;
+            }
+        }
+
         btn.addEventListener('click', async () => {
             btn.disabled = true;
             statusEl.textContent = 'Vinculando...';
@@ -80,6 +94,7 @@
                 const response = await fetch(window.location.pathname.replace(/\/$/, '') + '/claim', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
+                    body: JSON.stringify({ device_model_hint: await getClientHintModel() }),
                 });
                 const data = await response.json();
 

--- a/tests/Feature/EmployeeDeviceTest.php
+++ b/tests/Feature/EmployeeDeviceTest.php
@@ -57,6 +57,33 @@ it('claimMobileToken crea un EmployeeDevice activo', function () {
         ->and($employee->activeDevice->isActive())->toBeTrue();
 });
 
+it('claimMobileToken sugiere marca/modelo a partir del User-Agent (best-effort, sin Client Hint)', function () {
+    $employee = makeDeviceTestEmployee();
+
+    $employee->claimMobileToken('Mozilla/5.0 (Linux; Android 14; SM-S911B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36');
+
+    expect($employee->activeDevice->device_brand)->toBe('Samsung')
+        ->and($employee->activeDevice->device_model)->toBe('SM-S911B');
+});
+
+it('claimMobileToken prioriza el Client Hint del navegador sobre el User-Agent', function () {
+    $employee = makeDeviceTestEmployee();
+
+    $employee->claimMobileToken('Mozilla/5.0 (Linux; Android 14; SM-S911B)', 'Pixel 8 Pro');
+
+    expect($employee->activeDevice->device_brand)->toBe('Google')
+        ->and($employee->activeDevice->device_model)->toBe('Pixel 8 Pro');
+});
+
+it('claimMobileToken sin datos de dispositivo no revienta y deja marca/modelo en null', function () {
+    $employee = makeDeviceTestEmployee();
+
+    $employee->claimMobileToken(null);
+
+    expect($employee->activeDevice->device_brand)->toBeNull()
+        ->and($employee->activeDevice->device_model)->toBeNull();
+});
+
 it('re-vincular cierra el dispositivo anterior y abre uno nuevo', function () {
     $employee = makeDeviceTestEmployee();
     $employee->claimMobileToken('Device A');

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -77,6 +77,19 @@ it('vincula el dispositivo con CI y fecha de nacimiento correctos y emite un tok
     expect($employee->fresh()->hasMobileLinked())->toBeTrue();
 });
 
+it('el device_model_hint enviado por el cliente llega hasta el EmployeeDevice creado', function () {
+    $employee = makeLinkableEmployee();
+
+    $this->postJson('/vincular-dispositivo', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+        'device_model_hint' => 'Pixel 8 Pro',
+    ])->assertOk();
+
+    expect($employee->fresh()->activeDevice->device_model)->toBe('Pixel 8 Pro')
+        ->and($employee->fresh()->activeDevice->device_brand)->toBe('Google');
+});
+
 it('rechaza CI o fecha de nacimiento incorrectos con un mensaje genérico', function () {
     $employee = makeLinkableEmployee();
 

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -121,3 +121,40 @@ it('el detalle del terminal expone la acción "Generar enlace de configuración"
 
     expect($action)->not->toBeNull();
 });
+
+// ─── DeviceHintsParser: marca/modelo sugeridos al provisionar ──────────────
+
+it('claimSanctumToken() guarda el User-Agent y sugiere marca/modelo cuando el terminal no tiene datos cargados', function () {
+    $terminal = makeProvisioningTerminal();
+
+    $terminal->claimSanctumToken('Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15');
+    $terminal->refresh();
+
+    expect($terminal->user_agent)->toContain('iPhone')
+        ->and($terminal->device_brand)->toBe('Apple')
+        ->and($terminal->device_model)->toBe('iPhone');
+});
+
+it('claimSanctumToken() NO pisa marca/modelo cargados manualmente al reprovisionar el mismo terminal', function () {
+    $terminal = makeProvisioningTerminal();
+    $terminal->update(['device_brand' => 'Apple (corregido a mano)', 'device_model' => 'iPad Pro 12.9 2022']);
+
+    $terminal->claimSanctumToken('Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X)');
+    $terminal->refresh();
+
+    expect($terminal->device_brand)->toBe('Apple (corregido a mano)')
+        ->and($terminal->device_model)->toBe('iPad Pro 12.9 2022');
+});
+
+it('POST .../claim pasa el device_model_hint del cliente hasta el terminal provisionado', function () {
+    $terminal = makeProvisioningTerminal();
+    $setupToken = $terminal->generateSetupToken();
+
+    $this->postJson("/terminal/{$terminal->code}/setup/{$setupToken}/claim", [
+        'device_model_hint' => 'Pixel 8 Pro',
+    ])->assertOk()->assertJson(['ok' => true]);
+
+    $terminal->refresh();
+    expect($terminal->device_brand)->toBe('Google')
+        ->and($terminal->device_model)->toBe('Pixel 8 Pro');
+});

--- a/tests/Unit/DeviceHintsParserTest.php
+++ b/tests/Unit/DeviceHintsParserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Services\DeviceHintsParser;
+
+it('un Client Hint de modelo tiene prioridad sobre el User-Agent', function () {
+    $result = DeviceHintsParser::guess('Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X)', 'Pixel 8 Pro');
+
+    expect($result)->toBe(['brand' => 'Google', 'model' => 'Pixel 8 Pro']);
+});
+
+it('reconoce marcas Android comunes por prefijo del modelo', function (string $userAgent, ?string $brand, ?string $model) {
+    expect(DeviceHintsParser::guess($userAgent))->toBe(['brand' => $brand, 'model' => $model]);
+})->with([
+    'Samsung (SM-)' => [
+        'Mozilla/5.0 (Linux; Android 14; SM-S911B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+        'Samsung', 'SM-S911B',
+    ],
+    'Google Pixel' => [
+        'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+        'Google', 'Pixel 7',
+    ],
+    'Motorola (moto)' => [
+        'Mozilla/5.0 (Linux; Android 13; moto g73 5G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+        'Motorola', 'moto g73 5G',
+    ],
+]);
+
+it('iPhone/iPad devuelven marca Apple con modelo genérico (iOS nunca reporta el modelo real)', function (string $userAgent, string $model) {
+    $result = DeviceHintsParser::guess($userAgent);
+
+    expect($result)->toBe(['brand' => 'Apple', 'model' => $model]);
+})->with([
+    'iPhone' => ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15', 'iPhone'],
+    'iPad' => ['Mozilla/5.0 (iPad; CPU OS 17_1 like Mac OS X) AppleWebKit/605.1.15', 'iPad'],
+]);
+
+it('Mac de escritorio da marca Apple sin modelo (no hay forma de saber cuál Mac es)', function () {
+    $result = DeviceHintsParser::guess('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36');
+
+    expect($result)->toBe(['brand' => 'Apple', 'model' => null]);
+});
+
+it('Windows de escritorio no adivina marca ni modelo (Windows no es un fabricante de hardware)', function () {
+    $result = DeviceHintsParser::guess('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
+
+    expect($result)->toBe(['brand' => null, 'model' => null]);
+});
+
+it('sin User-Agent ni Client Hint devuelve null/null sin lanzar excepción', function () {
+    expect(DeviceHintsParser::guess(null))->toBe(['brand' => null, 'model' => null])
+        ->and(DeviceHintsParser::guess(''))->toBe(['brand' => null, 'model' => null]);
+});
+
+it('un modelo detectado sin marca reconocible deja la marca en null para que el admin la complete', function () {
+    $result = DeviceHintsParser::guess(null, 'CustomDevice XYZ');
+
+    expect($result)->toBe(['brand' => null, 'model' => 'CustomDevice XYZ']);
+});


### PR DESCRIPTION
## Resumen

Responde a: "¿hay alguna manera de obtener los datos del dispositivo desde el navegador, tanto para terminales como para dispositivos de empleados?"

**Límite duro, confirmado antes de implementar:** MAC address y número de serie **nunca** son accesibles desde ningún navegador — no hay API web que los exponga, en ningún dispositivo. Esos dos campos quedan manuales sin cambios, como se decidió.

**Lo que sí es posible — `DeviceHintsParser` (nuevo):**
- **Client Hints** (`navigator.userAgentData.getHighEntropyValues(['model'])`) cuando el navegador lo soporta — Chromium + Android da el modelo real (ej. "Pixel 7", "SM-A536B"). No existe en Safari/iOS ni Firefox.
- **Fallback: parseo del User-Agent** — reconoce iPhone/iPad (→ Apple, modelo genérico porque iOS nunca revela más), Mac de escritorio (→ Apple, sin modelo), Android clásico (extrae el device string del UA), y deja Windows/Linux sin adivinar nada (no son marcas de hardware).
- Heurística chica de prefijo→marca para Android (SM- → Samsung, Pixel → Google, moto → Motorola, etc.) — ampliable, no pretende ser exhaustiva.
- Resultado siempre **best-effort y editable** — nunca autoritativo.

**Integración:**
- `Terminal::claimSanctumToken()` y `Employee::claimMobileToken()` prellenan `device_brand`/`device_model` al provisionar/vincular. **Terminal nunca pisa una corrección manual previa** (mismo registro se reutiliza entre reprovisiones — se verificó explícitamente); `EmployeeDevice` siempre aplica el guess (cada vinculación crea un registro nuevo, no hay nada que pisar).
- `Terminal` gana la columna `user_agent` (no la tenía); `EmployeeDevice` ya la capturaba desde la Fase 1 de Parte C.
- `terminal-setup.blade.php` y `device-link.blade.php` intentan Client Hints del lado del cliente y lo mandan como `device_model_hint` en el POST de vinculación/provisión.
- Helper text nuevo en ambos formularios Filament aclarando que el valor es sugerido y editable.

## Test plan

- [x] `tests/Unit/DeviceHintsParserTest.php` (nuevo) — Client Hint gana sobre UA, marcas Android por prefijo, iPhone/iPad/Mac/Windows, sin datos no revienta, modelo sin marca reconocible.
- [x] `tests/Feature/EmployeeDeviceTest.php` — `claimMobileToken()` sugiere marca/modelo, prioriza Client Hint, no revienta sin datos.
- [x] `tests/Feature/MobileAttendanceLinkTest.php` — `device_model_hint` del POST llega hasta el `EmployeeDevice` creado.
- [x] `tests/Feature/TerminalProvisioningUiTest.php` — `claimSanctumToken()` sugiere marca/modelo, **no pisa una corrección manual previa en re-provisión**, `device_model_hint` llega vía HTTP real hasta el terminal.
- [x] Verificado con UAs reales (Samsung, Pixel, iPhone, iPad, Mac, Windows) contra SQLite real — 32 aserciones entre parser, integración con los modelos, migración `up()`/`down()`, y renderizado de los 4 formularios/vistas Filament afectados.
- [x] Verificado end-to-end vía HTTP real (curl con Content-Type/CSRF reales) contra ambos endpoints de claim — confirma que el `device_model_hint` gana sobre el User-Agent, y que sin Client Hint el fallback de UA funciona.
- [x] Verificado en Chromium real (Playwright) que el POST de vinculación incluye `device_model_hint` y que la llamada a Client Hints no lanza excepción aunque el navegador no reporte un modelo (caso desktop).
- [x] `npm run build` — sin errores (sin cambios de bundle, los scripts tocados son inline, no entrypoints Vite). `php -l` — sin errores. `vendor/bin/pint --dirty` — sin hallazgos.
- [ ] CI (Pest + MySQL real) — no se pudo correr `php artisan test` completo en este sandbox (sin MySQL disponible), se confirma en el pipeline.

https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_