### PR TITLE
Evita que un fallo de notificación por email rompa la provisión de terminales/celulares

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Log;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -1244,7 +1245,17 @@ class Employee extends Model implements AuthenticatableContract
             ? new MobileDeviceRelinkedNotification($this, $userAgent)
             : new MobileDeviceLinkedNotification($this, $userAgent);
 
-        User::all()->each(fn (User $user) => $user->notify($notification));
+        // La vinculación ya quedó persistida arriba — un fallo al notificar (ej. mailer
+        // mal configurado) no debe convertirse en un 500 que deje el enlace/CI+fecha
+        // consumido sin token emitido (mismo gotcha corregido en
+        // Terminal::claimSanctumToken()).
+        try {
+            User::all()->each(fn (User $user) => $user->notify($notification));
+        } catch (\Throwable $e) {
+            Log::warning("No se pudo notificar la vinculación de dispositivo móvil del empleado #{$this->id}: {$e->getMessage()}", [
+                'employee_id' => $this->id,
+            ]);
+        }
 
         return $this->createToken('mobile:'.$this->id, [self::MOBILE_SYNC_ABILITY])->plainTextToken;
     }

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -402,7 +403,18 @@ class Terminal extends Model implements AuthenticatableContract
 
         $this->forceFill($attributes)->save();
 
-        User::all()->each(fn (User $user) => $user->notify(new TerminalProvisionedNotification($this)));
+        // La provisión del terminal ya quedó persistida arriba — un fallo al notificar
+        // (ej. mailer mal configurado) no debe convertirse en un 500 que deje al enlace
+        // de configuración consumido pero sin token emitido (ver claim() en
+        // TerminalSetupController, que retornaría "Server Error" con el setup_token ya
+        // invalidado, sin forma de reintentar sin generar un enlace nuevo).
+        try {
+            User::all()->each(fn (User $user) => $user->notify(new TerminalProvisionedNotification($this)));
+        } catch (\Throwable $e) {
+            Log::warning("No se pudo notificar la provisión del terminal '{$this->code}': {$e->getMessage()}", [
+                'terminal_id' => $this->id,
+            ]);
+        }
 
         return $this->createToken('kiosk:'.$this->code, [self::SYNC_ABILITY])->plainTextToken;
     }

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -395,6 +395,30 @@ it('notifica a todos los admins cuando un dispositivo ya vinculado se re-vincula
     );
 });
 
+/**
+ * Regresión: mismo gotcha que claimSanctumToken() en Terminal — el
+ * mobile_linked_at (single-use del CI+fecha) ya había quedado persistido
+ * antes de notificar a los admins, así que un mailer roto (MAIL_MAILER=resend
+ * sin RESEND_KEY) tumbaba el request con 500 DESPUÉS de vincular el
+ * dispositivo, dejando al empleado sin el token pero con /vincular-dispositivo
+ * ya consumido.
+ */
+it('vincula el dispositivo aunque falle el envío de la notificación por email', function () {
+    config(['mail.default' => 'resend', 'services.resend.key' => null]);
+    User::create(['name' => 'Admin', 'email' => 'admin-mailfail@test.com', 'password' => bcrypt('secret')]);
+
+    $employee = makeLinkableEmployee();
+
+    $response = $this->postJson('/vincular-dispositivo', [
+        'ci' => $employee->ci,
+        'birth_date' => '1990-05-15',
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    expect($response->json('token'))->not->toBeNull()
+        ->and($employee->fresh()->hasMobileLinked())->toBeTrue();
+});
+
 it('el heartbeat actualiza mobile_last_heartbeat_at', function () {
     $employee = makeLinkableEmployee();
     Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -146,6 +146,42 @@ it('claimSanctumToken() NO pisa marca/modelo cargados manualmente al reprovision
         ->and($terminal->device_model)->toBe('iPad Pro 12.9 2022');
 });
 
+/**
+ * Regresión: producción tenía MAIL_MAILER=resend sin RESEND_KEY configurada.
+ * claimSanctumToken() ya había consumido el setup_token (single-use) antes de
+ * notificar a los admins, así que el TypeError de Resend::client() tumbaba el
+ * request con 500 DESPUÉS de invalidar el enlace — el kiosko quedaba con
+ * "Server Error" y, al recargar, con "enlace inválido" sin haber recibido
+ * nunca su token Sanctum. Un fallo de notificación nunca debe poder romper
+ * la provisión ya persistida.
+ */
+it('claimSanctumToken() sigue provisionando el terminal aunque falle el envío de la notificación por email', function () {
+    config(['mail.default' => 'resend', 'services.resend.key' => null]);
+
+    $terminal = makeProvisioningTerminal();
+    User::factory()->create();
+
+    $token = $terminal->claimSanctumToken();
+
+    expect($token)->not->toBeEmpty();
+
+    $terminal->refresh();
+    expect($terminal->setup_token)->toBeNull()
+        ->and($terminal->tokens()->where('name', 'like', 'kiosk:%')->exists())->toBeTrue();
+});
+
+it('POST .../claim responde ok=true aunque falle el envío de la notificación por email', function () {
+    config(['mail.default' => 'resend', 'services.resend.key' => null]);
+
+    $terminal = makeProvisioningTerminal();
+    User::factory()->create();
+    $setupToken = $terminal->generateSetupToken();
+
+    $this->postJson("/terminal/{$terminal->code}/setup/{$setupToken}/claim")
+        ->assertOk()
+        ->assertJson(['ok' => true]);
+});
+
 it('POST .../claim pasa el device_model_hint del cliente hasta el terminal provisionado', function () {
     $terminal = makeProvisioningTerminal();
     $setupToken = $terminal->generateSetupToken();


### PR DESCRIPTION
## Summary

- Al vincular un terminal (kiosko) o un celular personal, `Terminal::claimSanctumToken()` / `Employee::claimMobileToken()` consumían el `setup_token` (enlace de un solo uso) o vinculaban el dispositivo **antes** de notificar por email a los admins.
- En producción (demo NextUp), `MAIL_MAILER=resend` fallaba en el envío (causa raíz: mismatch de nombre de variable de entorno, `RESEND_API_KEY` vs. `RESEND_KEY` que espera `config/services.php` — ya corregido en el `.env` del servidor), y esa excepción devolvía un 500 **después** de que el enlace ya había quedado invalidado. El usuario veía "Server Error" al vincular, y al recargar la página, "Enlace de configuración inválido" — sin haber recibido nunca su token Sanctum.
- Esto podía repetirse indefinidamente con cualquier problema futuro de notificaciones (timeout de red, rate limit del proveedor de email, etc.), ya que es un fallo ajeno a la provisión en sí.
- Se envuelve el `notify()` a los admins en ambos métodos con un `try/catch`, registrando un `Log::warning` si falla, sin interrumpir el flujo de provisión/vinculación que ya quedó persistido con éxito.

## Test plan

- [x] `php artisan test tests/Feature/TerminalProvisioningUiTest.php tests/Feature/MobileAttendanceLinkTest.php` — 42 tests, incluyendo 3 nuevos de regresión que simulan el mismo fallo de mailer (`MAIL_MAILER=resend` sin `services.resend.key`) y verifican que el terminal queda provisionado / el dispositivo queda vinculado y se retorna el token igual.
- [x] `php artisan test tests/Feature/EmployeeDeviceTest.php tests/Feature/AdminNotificationsTest.php` — 22 tests, sin regresiones.
- [x] `vendor/bin/pint --dirty` — sin cambios de formato pendientes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_