### PR TITLE
Corrige que las notificaciones admin nunca aparecían en la campanita de Filament

### DIFF
--- a/app/Notifications/ContractAlertNotification.php
+++ b/app/Notifications/ContractAlertNotification.php
@@ -3,6 +3,8 @@
 namespace App\Notifications;
 
 use App\Models\Contract;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
@@ -26,6 +28,11 @@ class ContractAlertNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
@@ -36,29 +43,28 @@ class ContractAlertNotification extends Notification
         if ($this->alertType === 'expired') {
             $message = "El contrato de {$employeeName} venció el {$this->contract->end_date->format('d/m/Y')}.";
             $icon = 'heroicon-o-x-circle';
-            $color = 'danger';
+            $status = 'danger';
         } else {
             $days = $this->contract->remaining_days;
             $message = "El contrato de {$employeeName} vence en {$days} ".($days === 1 ? 'día' : 'días')
                 ." ({$this->contract->end_date->format('d/m/Y')}).";
             $icon = 'heroicon-o-clock';
-            $color = 'warning';
+            $status = 'warning';
         }
 
         return [
-            'title'        => $this->alertType === 'expired' ? 'Contrato vencido' : 'Contrato por vencer',
-            'body'         => $message,
-            'icon'         => $icon,
-            'color'        => $color,
-            'actions'      => [
-                [
-                    'label' => 'Ver contrato',
-                    'url'   => "/admin/contratos/{$this->contract->id}",
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title($this->alertType === 'expired' ? 'Contrato vencido' : 'Contrato por vencer')
+                ->body($message)
+                ->icon($icon)
+                ->status($status)
+                ->actions([
+                    FilamentAction::make('view')->label('Ver contrato')->url("/admin/contratos/{$this->contract->id}"),
+                ])
+                ->getDatabaseMessage(),
             // Datos adicionales para lógica de deduplicación
-            'contract_id'  => $this->contract->id,
-            'alert_type'   => $this->alertType,
+            'contract_id' => $this->contract->id,
+            'alert_type' => $this->alertType,
         ];
     }
 }

--- a/app/Notifications/FaceEnrollmentPendingApprovalNotification.php
+++ b/app/Notifications/FaceEnrollmentPendingApprovalNotification.php
@@ -4,6 +4,8 @@ namespace App\Notifications;
 
 use App\Filament\Resources\FaceEnrollmentResource;
 use App\Models\FaceEnrollment;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
@@ -30,6 +32,11 @@ class FaceEnrollmentPendingApprovalNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
@@ -38,16 +45,15 @@ class FaceEnrollmentPendingApprovalNotification extends Notification
         $employeeLabel = $employee ? "{$employee->full_name} (CI: {$employee->ci})" : 'un empleado';
 
         return [
-            'title' => 'Autoenrolamiento facial pendiente de aprobación',
-            'body' => "{$employeeLabel} completó la captura de su rostro y está esperando que apruebes o rechaces la solicitud.",
-            'icon' => 'heroicon-o-face-smile',
-            'color' => 'warning',
-            'actions' => [
-                [
-                    'label' => 'Revisar solicitud',
-                    'url' => FaceEnrollmentResource::getUrl('index'),
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title('Autoenrolamiento facial pendiente de aprobación')
+                ->body("{$employeeLabel} completó la captura de su rostro y está esperando que apruebes o rechaces la solicitud.")
+                ->icon('heroicon-o-face-smile')
+                ->warning()
+                ->actions([
+                    FilamentAction::make('view')->label('Revisar solicitud')->url(FaceEnrollmentResource::getUrl('index')),
+                ])
+                ->getDatabaseMessage(),
             'enrollment_id' => $this->enrollment->id,
         ];
     }

--- a/app/Notifications/MobileDeviceLinkedNotification.php
+++ b/app/Notifications/MobileDeviceLinkedNotification.php
@@ -4,6 +4,8 @@ namespace App\Notifications;
 
 use App\Filament\Resources\EmployeeResource;
 use App\Models\Employee;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
@@ -31,6 +33,11 @@ class MobileDeviceLinkedNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
@@ -42,16 +49,15 @@ class MobileDeviceLinkedNotification extends Notification
         }
 
         return [
-            'title' => 'Dispositivo vinculado',
-            'body' => $body,
-            'icon' => 'heroicon-o-device-phone-mobile',
-            'color' => 'success',
-            'actions' => [
-                [
-                    'label' => 'Ver empleado',
-                    'url' => EmployeeResource::getUrl('view', ['record' => $this->employee]),
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title('Dispositivo vinculado')
+                ->body($body)
+                ->icon('heroicon-o-device-phone-mobile')
+                ->success()
+                ->actions([
+                    FilamentAction::make('view')->label('Ver empleado')->url(EmployeeResource::getUrl('view', ['record' => $this->employee])),
+                ])
+                ->getDatabaseMessage(),
             'employee_id' => $this->employee->id,
         ];
     }

--- a/app/Notifications/MobileDeviceRelinkedNotification.php
+++ b/app/Notifications/MobileDeviceRelinkedNotification.php
@@ -4,6 +4,8 @@ namespace App\Notifications;
 
 use App\Filament\Resources\EmployeeResource;
 use App\Models\Employee;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -57,6 +59,11 @@ class MobileDeviceRelinkedNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
@@ -68,16 +75,15 @@ class MobileDeviceRelinkedNotification extends Notification
         }
 
         return [
-            'title' => 'Dispositivo re-vinculado',
-            'body' => $body,
-            'icon' => 'heroicon-o-device-phone-mobile',
-            'color' => 'warning',
-            'actions' => [
-                [
-                    'label' => 'Ver empleado',
-                    'url' => EmployeeResource::getUrl('view', ['record' => $this->employee]),
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title('Dispositivo re-vinculado')
+                ->body($body)
+                ->icon('heroicon-o-device-phone-mobile')
+                ->warning()
+                ->actions([
+                    FilamentAction::make('view')->label('Ver empleado')->url(EmployeeResource::getUrl('view', ['record' => $this->employee])),
+                ])
+                ->getDatabaseMessage(),
             'employee_id' => $this->employee->id,
         ];
     }

--- a/app/Notifications/MobileLinkThrottledNotification.php
+++ b/app/Notifications/MobileLinkThrottledNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
@@ -32,17 +33,22 @@ class MobileLinkThrottledNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
     {
         $ciLabel = filled($this->lastCiAttempted) ? " (último CI intentado: {$this->lastCiAttempted})" : '';
 
-        return [
-            'title' => 'Límite diario de vinculación de dispositivo agotado',
-            'body' => "La IP {$this->ip} alcanzó el límite de 15 intentos de vinculación hoy{$ciLabel}. Puede ser un empleado con datos incorrectos o un intento de acceso indebido — revisar los logs si es necesario.",
-            'icon' => 'heroicon-o-shield-exclamation',
-            'color' => 'warning',
-        ];
+        return FilamentNotification::make()
+            ->title('Límite diario de vinculación de dispositivo agotado')
+            ->body("La IP {$this->ip} alcanzó el límite de 15 intentos de vinculación hoy{$ciLabel}. Puede ser un empleado con datos incorrectos o un intento de acceso indebido — revisar los logs si es necesario.")
+            ->icon('heroicon-o-shield-exclamation')
+            ->warning()
+            ->getDatabaseMessage();
     }
 }

--- a/app/Notifications/SyncConflictPendingNotification.php
+++ b/app/Notifications/SyncConflictPendingNotification.php
@@ -4,6 +4,8 @@ namespace App\Notifications;
 
 use App\Filament\Resources\AttendanceMarkFailureResource;
 use App\Models\AttendanceMarkFailure;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 
@@ -33,6 +35,11 @@ class SyncConflictPendingNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) — la campanita del panel filtra por `data->format =
+     * 'filament'`, que solo ese builder genera (ver
+     * TerminalProvisionedNotification::toDatabase() para el detalle del gotcha).
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
@@ -42,16 +49,15 @@ class SyncConflictPendingNotification extends Notification
         $modeLabel = AttendanceMarkFailure::getModeLabel($this->failure->mode);
 
         return [
-            'title' => 'Conflicto al sincronizar una marcación offline',
-            'body' => "Una marcación de {$employeeLabel} desde {$modeLabel} no se pudo aplicar al reconectarse — la secuencia ya no era válida en el servidor. Requiere revisión manual.",
-            'icon' => 'heroicon-o-exclamation-triangle',
-            'color' => 'danger',
-            'actions' => [
-                [
-                    'label' => 'Revisar conflicto',
-                    'url' => AttendanceMarkFailureResource::getUrl('view', ['record' => $this->failure]),
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title('Conflicto al sincronizar una marcación offline')
+                ->body("Una marcación de {$employeeLabel} desde {$modeLabel} no se pudo aplicar al reconectarse — la secuencia ya no era válida en el servidor. Requiere revisión manual.")
+                ->icon('heroicon-o-exclamation-triangle')
+                ->danger()
+                ->actions([
+                    FilamentAction::make('view')->label('Revisar conflicto')->url(AttendanceMarkFailureResource::getUrl('view', ['record' => $this->failure])),
+                ])
+                ->getDatabaseMessage(),
             'failure_id' => $this->failure->id,
         ];
     }

--- a/app/Notifications/TerminalProvisionedNotification.php
+++ b/app/Notifications/TerminalProvisionedNotification.php
@@ -4,6 +4,8 @@ namespace App\Notifications;
 
 use App\Filament\Resources\TerminalResource;
 use App\Models\Terminal;
+use Filament\Notifications\Actions\Action as FilamentAction;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -44,21 +46,27 @@ class TerminalProvisionedNotification extends Notification
     }
 
     /**
+     * Se arma con el builder de `Filament\Notifications\Notification` (no un
+     * array plano) porque la campanita del panel filtra explícitamente por
+     * `data->format = 'filament'` (ver
+     * `Filament\Notifications\Livewire\DatabaseNotifications::getNotificationsQuery()`)
+     * — un array a mano sin esa clave se guarda en la tabla `notifications`
+     * sin error, pero la campanita nunca lo muestra.
+     *
      * @return array<string, mixed>
      */
     public function toDatabase(object $notifiable): array
     {
         return [
-            'title' => 'Terminal provisionado',
-            'body' => "El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.",
-            'icon' => 'heroicon-o-computer-desktop',
-            'color' => 'success',
-            'actions' => [
-                [
-                    'label' => 'Ver terminal',
-                    'url' => TerminalResource::getUrl('view', ['record' => $this->terminal]),
-                ],
-            ],
+            ...FilamentNotification::make()
+                ->title('Terminal provisionado')
+                ->body("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.")
+                ->icon('heroicon-o-computer-desktop')
+                ->success()
+                ->actions([
+                    FilamentAction::make('view')->label('Ver terminal')->url(TerminalResource::getUrl('view', ['record' => $this->terminal])),
+                ])
+                ->getDatabaseMessage(),
             'terminal_id' => $this->terminal->id,
         ];
     }

--- a/tests/Feature/AdminNotificationsTest.php
+++ b/tests/Feature/AdminNotificationsTest.php
@@ -13,9 +13,11 @@ use App\Models\FaceEnrollment;
 use App\Models\Position;
 use App\Models\Terminal;
 use App\Models\User;
+use App\Notifications\ContractAlertNotification;
 use App\Notifications\FaceEnrollmentPendingApprovalNotification;
 use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
+use App\Notifications\MobileLinkThrottledNotification;
 use App\Notifications\SyncConflictPendingNotification;
 use App\Notifications\TerminalProvisionedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -201,4 +203,52 @@ it('la notificación de re-vinculación también se envía por email, la de prim
     expect($mail->subject)->toBe("Dispositivo re-vinculado — {$employee->full_name}")
         ->and($mail->actionUrl)->toBe(EmployeeResource::getUrl('view', ['record' => $employee]))
         ->and(collect($mail->introLines)->implode(' '))->toContain('Dispositivo nuevo: Mozilla/5.0 Test');
+});
+
+// ─── format=filament (regresión: campanita del panel vacía) ────────────────
+
+/**
+ * Regresión: `Filament\Notifications\Livewire\DatabaseNotifications::getNotificationsQuery()`
+ * filtra explícitamente por `data->format = 'filament'`. Un `toDatabase()`
+ * construido como array plano (sin ese formato, generado únicamente por el
+ * builder `Filament\Notifications\Notification`) se persiste sin error en la
+ * tabla `notifications`, pero la campanita del panel Filament nunca lo
+ * muestra — quedaba invisible para los admins sin ningún error visible en
+ * consola ni en el log, hasta que se reportó como "la campanita no muestra
+ * nada" para un caso puntual (terminal recién vinculado).
+ */
+it('toDatabase() de cada notificación admin usa el formato de Filament (visible en la campanita)', function () {
+    $employee = makeNotifiableEmployee();
+    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $enrollment = FaceEnrollment::create([
+        'employee_id' => $employee->id,
+        'token' => Str::random(40),
+        'status' => 'pending_capture',
+        'expires_at' => now()->addHours(48),
+    ]);
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'mobile',
+        'failure_type' => 'sync_conflict',
+        'employee_id' => $employee->id,
+        'branch_id' => $employee->branch_id,
+        'attempted_event_type' => 'break_start',
+        'failure_message' => 'test',
+    ]);
+    $contract = $employee->contracts()->first();
+    $contract->update(['type' => 'plazo_fijo', 'end_date' => now()->addDays(5)]);
+
+    $notifications = [
+        new TerminalProvisionedNotification($terminal),
+        new MobileDeviceLinkedNotification($employee),
+        new MobileDeviceRelinkedNotification($employee),
+        new SyncConflictPendingNotification($failure),
+        new FaceEnrollmentPendingApprovalNotification($enrollment),
+        new ContractAlertNotification($contract, 'expiring'),
+        new MobileLinkThrottledNotification('203.0.113.1', null),
+    ];
+
+    foreach ($notifications as $notification) {
+        expect($notification->toDatabase(new User)['format'])
+            ->toBe('filament', $notification::class.' debe usar el builder de Filament\\Notifications\\Notification');
+    }
 });


### PR DESCRIPTION
## Summary

- Al investigar por qué la notificación de terminal provisionado no aparecía en la campanita del panel (confirmado por email, pero ausente en la campanita), se encontró que **ninguna de las 7 notificaciones admin del sistema aparece jamás en la campanita**, y nunca lo hizo — sin ningún error visible.
- Causa: `Filament\Notifications\Livewire\DatabaseNotifications::getNotificationsQuery()` filtra explícitamente `->where('data->format', 'filament')`. Esa clave solo la genera el builder `Filament\Notifications\Notification::make()->...->getDatabaseMessage()`. Las 7 clases (`TerminalProvisionedNotification`, `MobileDeviceLinkedNotification`, `MobileDeviceRelinkedNotification`, `SyncConflictPendingNotification`, `FaceEnrollmentPendingApprovalNotification`, `ContractAlertNotification`, `MobileLinkThrottledNotification`) construían `toDatabase()` como un array plano (`'title'`, `'body'`, `'icon'`, `'color'`, `'actions'`) — se persiste sin error en la tabla `notifications`, pero la query de la campanita lo excluye siempre.
- Se reescriben las 7 usando el builder de Filament, preservando las claves adicionales de deduplicación (`contract_id`, `employee_id`, `enrollment_id`, `failure_id`, `terminal_id`) vía array spread sobre `getDatabaseMessage()`.

## Test plan

- [x] `php artisan test tests/Feature/AdminNotificationsTest.php` — incluye un test nuevo de regresión que verifica `data['format'] === 'filament'` en las 7 clases.
- [x] `php artisan test tests/Feature/AdminNotificationsTest.php tests/Feature/TerminalProvisioningUiTest.php tests/Feature/MobileAttendanceLinkTest.php tests/Feature/EmployeeDeviceTest.php` — 65 tests, sin regresiones.
- [x] `php artisan test` (suite completa) — 552 passed, 1 failed preexistente y no relacionado (falta `public/build/manifest.json`, assets de Vite no compilados en este entorno de pruebas).
- [x] `vendor/bin/pint --dirty` — sin cambios de formato pendientes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_