### PR TITLE
Reorganiza header actions de ViewTerminal, agrega RelationManager de marcaciones y unifica terminología

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Two separate axes that converge in `Contract`:
 | Schedules | `ScheduleAssignmentService` — asignación de horarios fijos con vigencia por fechas |
 | Rotations | `RotationService` — asignación de patrones rotativos y resolución de turno efectivo por fecha |
 | Attendance | `AttendanceDay`, `AttendanceEvent`, observers auto-calculate daily totals |
-| Attendance offline (kiosko/dispositivo) | `Terminal`, `Employee` (Sanctum), `EmployeeDevice` (historial), `AttendanceMarkFailure` — ver "Módulo de Asistencia — Marcación Offline" más abajo |
+| Attendance offline (terminal/dispositivo) | `Terminal`, `Employee` (Sanctum), `EmployeeDevice` (historial), `AttendanceMarkFailure` — ver "Módulo de Asistencia — Marcación Offline" más abajo |
 | Face Recognition | TensorFlow.js (128-element descriptors), `FaceEnrollment`, `FaceCaptureApp.js` |
 | Warnings | `Warning` — registro documental de amonestaciones laborales (sin impacto en nómina por ahora) |
 
@@ -301,12 +301,12 @@ Salario del mes 13, pagadero en diciembre. Se gestiona por `AguinaldoPeriod` (un
 
 **Pago con nómina (`payment_method = 'with_payroll'`):** `PayrollService::resolveVacationPays()` paga la remuneración vacacional **completa como pago único** en el período de nómina que contiene el `start_date` de la vacación — **no se prorratea** aunque el `end_date` caiga en el período de nómina siguiente. Es una convención intencional (lump sum al inicio de la vacación), no un bug. `Vacation.payment_status` es un enum simple `unpaid`/`paid` — no rastrea montos parciales, así que implementar prorrateo real requeriría un cambio de modelo de datos, no solo de lógica.
 
-### Módulo de Asistencia — Marcación Offline (Kiosko y Dispositivo Personal)
+### Módulo de Asistencia — Marcación Offline (Terminal y Dispositivo Personal)
 
 Documento completo con arquitectura, decisiones y deuda técnica: **`docs/marcacion-offline.md`**. Resumen:
 
 Dos dispositivos marcan asistencia por reconocimiento facial (face-api.js, 100% client-side), ambos con soporte offline vía PWA:
-- **Kiosko/terminal** (`Terminal`) — compartido por sucursal, cachea el descriptor de *todos* los empleados activos de esa sucursal. Provisión por enlace de un solo uso generado por un admin.
+- **Terminal** (`Terminal`) — compartido por sucursal, cachea el descriptor de *todos* los empleados activos de esa sucursal. Provisión por enlace de un solo uso generado por un admin.
 - **Dispositivo personal** (`Employee`) — individual, cachea *únicamente* el propio descriptor. Vinculación self-service en `/vincular-dispositivo` con CI + fecha de nacimiento (no es un factor de auth completo — el match facial sigue siendo el control real). Un dispositivo vinculado a la vez: vincular uno nuevo revoca el anterior y notifica a los admins.
 
 **Auth:** un único guard `auth:sanctum` sirve tokens de `Terminal` (`ability: terminal:sync`) y `Employee` (`ability: mobile:sync`) — Sanctum resuelve el `tokenable` de forma polimórfica sin config adicional en `config/auth.php`. Ambos modelos usan `HasApiTokens` + `Illuminate\Auth\Authenticatable` (este último solo necesario para que `Sanctum::actingAs()` funcione en tests).
@@ -323,10 +323,10 @@ Dos dispositivos marcan asistencia por reconocimiento facial (face-api.js, 100% 
 
 **Detección best-effort de marca/modelo (`DeviceHintsParser`):** al vincular un celular o provisionar un terminal, se intenta prellenar `device_brand`/`device_model` (siempre editables) a partir de Client Hints del navegador (`navigator.userAgentData.getHighEntropyValues(['model'])` — solo Chromium + Android, manda `device_model_hint` en el POST de claim) con fallback a parseo del `User-Agent` en el servidor. **MAC address y número de serie nunca son detectables desde ningún navegador** — quedan 100% manuales por diseño, no es una limitación de esta implementación. `Terminal::claimSanctumToken()` nunca pisa una corrección manual previa (mismo registro se reutiliza entre reprovisiones); `Employee::claimMobileToken()` siempre aplica el guess (cada vinculación crea un `EmployeeDevice` nuevo).
 
-**Logo de empresa (`CompanyLogoThumbnailService`):** mismo patrón offline-safe que `EmployeePhotoThumbnailService` (thumbnail pre-generado en `Company.logo_thumbnail` vía `CompanyObserver`, viaja como data URI embebido — en `window.terminalData` para el kiosko, en el payload de heartbeat para el celular) pero con dos diferencias por tratarse de un logo y no una foto de rostro: **ajusta preservando la proporción** (bounding box 240×80px, nunca recorta a cuadrado) y **exporta en PNG** (no JPEG, para conservar transparencia). SVG no se procesa — GD no puede rasterizarlo, degrada a sin logo.
+**Logo de empresa (`CompanyLogoThumbnailService`):** mismo patrón offline-safe que `EmployeePhotoThumbnailService` (thumbnail pre-generado en `Company.logo_thumbnail` vía `CompanyObserver`, viaja como data URI embebido — en `window.terminalData` para el terminal, en el payload de heartbeat para el celular) pero con dos diferencias por tratarse de un logo y no una foto de rostro: **ajusta preservando la proporción** (bounding box 240×80px, nunca recorta a cuadrado) y **exporta en PNG** (no JPEG, para conservar transparencia). SVG no se procesa — GD no puede rasterizarlo, degrada a sin logo.
 
 **UI del modo móvil (`resources/js/attendances/mark.js`):**
-- Header persistente con sucursal/empresa/logo (`#headerLocation`, `#headerLogo`), poblado por `refreshOwnEmployeeUi()` desde el empleado cacheado (heartbeat). Mismo patrón en el kiosko (`terminal.js`, `#terminalHeaderLocation`/`#terminalHeaderLogo`, poblado server-side vía `window.terminalData` ya que el terminal es fijo por sucursal).
+- Header persistente con sucursal/empresa/logo (`#headerLocation`, `#headerLogo`), poblado por `refreshOwnEmployeeUi()` desde el empleado cacheado (heartbeat). Mismo patrón en `terminal.js` (`#terminalHeaderLocation`/`#terminalHeaderLogo`, poblado server-side vía `window.terminalData` ya que el terminal es fijo por sucursal).
 - Splash personalizado: saludo con nombre + tarjeta de estado ("Hoy: Entrada · HH:MM"). **Gotcha corregido:** `returnToSplash()` (se ejecuta al cerrar el modal de éxito tras marcar) debe volver a llamar `refreshOwnEmployeeUi()` explícitamente — sin eso la tarjeta de estado queda con el valor de antes de marcar hasta recargar la página, porque `refreshOwnEmployeeUi` solo se disparaba en la carga inicial.
 - Botón "Pausar cámara" junto a Sincronizar/Desvincular — permite usar la interfaz (ver "Mis marcaciones", sincronizar) sin activar la identificación facial por accidente. Auto-resume a los 2 minutos por seguridad.
 - Modal "Mis marcaciones" — lista de eventos de hoy del propio empleado, consulta `getOwnStatus()` en el momento (no cachea una lista desactualizada offline; sin red muestra aviso en vez de una lista parcial).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Sistema de gestión de recursos humanos y nómina, desarrollado con Laravel y Fi
 ## Características
 
 - Gestión de empleados y departamentos
-- Control de asistencia con reconocimiento facial, con marcación offline vía PWA (kiosko de sucursal y dispositivo personal)
+- Control de asistencia con reconocimiento facial, con marcación offline vía PWA (terminal de sucursal y dispositivo personal)
 - Gestión de nóminas y períodos de pago
 - Administración de vacaciones y ausencias
 - Sistema de préstamos con cuotas

--- a/app/Filament/Pages/ManageGeneralSettings.php
+++ b/app/Filament/Pages/ManageGeneralSettings.php
@@ -107,7 +107,7 @@ class ManageGeneralSettings extends SettingsPage
                     ]),
 
                 Section::make('Terminales de Marcación')
-                    ->description('Configuración de conectividad para kioskos offline (marcación vía PWA)')
+                    ->description('Configuración de conectividad para terminales offline (marcación vía PWA)')
                     ->icon('heroicon-o-wifi')
                     ->schema([
                         TextInput::make('terminal_stale_threshold_hours')

--- a/app/Filament/Resources/EmployeeDeviceResource.php
+++ b/app/Filament/Resources/EmployeeDeviceResource.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * Historial de dispositivos personales vinculados por empleados para
  * marcación offline vía PWA — contraparte de `TerminalResource` para
- * dispositivos propios (no kioskos compartidos). Registros creados
+ * dispositivos propios (no terminales compartidos). Registros creados
  * automáticamente por `Employee::claimMobileToken()`/`revokeMobileToken()`;
  * este recurso solo permite anotar marca/modelo/serie/MAC/notas a mano,
  * igual que ya se hace con los terminales.

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\TerminalResource\Pages;
+use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
 use App\Models\Terminal;
 use App\Settings\GeneralSettings;
 use Filament\Forms\Components\DatePicker;
@@ -533,7 +534,9 @@ class TerminalResource extends Resource
      */
     public static function getRelations(): array
     {
-        return [];
+        return [
+            AttendanceEventsRelationManager::class,
+        ];
     }
 
     /**

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -272,7 +272,7 @@ class TerminalResource extends Resource
                             TextEntry::make('sync_queue_status')
                                 ->label('Cola de sincronización')
                                 ->badge()
-                                ->tooltip('Reportado por el kiosko en cada heartbeat')
+                                ->tooltip('Reportado por el terminal en cada heartbeat')
                                 ->formatStateUsing(fn (string $state) => Terminal::getSyncQueueStatusLabels()[$state] ?? $state)
                                 ->color(fn (string $state) => Terminal::getSyncQueueStatusColors()[$state] ?? 'gray'),
 
@@ -359,7 +359,7 @@ class TerminalResource extends Resource
                 TextColumn::make('sync_queue_status')
                     ->label('Cola de sync')
                     ->badge()
-                    ->tooltip('Marcaciones pendientes o en conflicto reportadas por el kiosko en su último heartbeat')
+                    ->tooltip('Marcaciones pendientes o en conflicto reportadas por el terminal en su último heartbeat')
                     ->formatStateUsing(fn (string $state) => Terminal::getSyncQueueStatusLabels()[$state] ?? $state)
                     ->color(fn (string $state) => Terminal::getSyncQueueStatusColors()[$state] ?? 'gray'),
 

--- a/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\TerminalResource\Pages;
 use App\Filament\Resources\TerminalResource;
 use App\Models\Terminal;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Notifications\Notification;
@@ -60,7 +61,7 @@ class ViewTerminal extends ViewRecord
             Action::make('deactivate')
                 ->label('Desactivar')
                 ->icon('heroicon-o-x-circle')
-                ->color('danger')
+                ->color('warning')
                 ->visible(fn () => $this->record->isActive())
                 ->requiresConfirmation()
                 ->modalHeading('Desactivar terminal')
@@ -70,27 +71,6 @@ class ViewTerminal extends ViewRecord
                     $this->record->update(['status' => 'inactive']);
                     Notification::make()->warning()->title('Terminal desactivada')->send();
                     $this->refreshFormData(['status']);
-                }),
-
-            Action::make('regenerate_code')
-                ->label('Regenerar código')
-                ->icon('heroicon-o-arrow-path')
-                ->color('warning')
-                ->requiresConfirmation()
-                ->modalHeading('Regenerar código de acceso')
-                ->modalDescription('⚠️ Esto cambiará la URL de la terminal. El dispositivo físico dejará de funcionar hasta que sea reconfigurado con la nueva URL.')
-                ->modalSubmitActionLabel('Sí, regenerar')
-                ->action(function () {
-                    $newCode = Terminal::generateUniqueCode();
-                    $this->record->update(['code' => $newCode]);
-
-                    Notification::make()
-                        ->warning()
-                        ->title('Código regenerado')
-                        ->body('Recordá actualizar la URL en el dispositivo físico.')
-                        ->send();
-
-                    $this->refreshFormData(['code']);
                 }),
 
             Action::make('generate_setup_link')
@@ -103,28 +83,56 @@ class ViewTerminal extends ViewRecord
                 ->modalSubmitAction(false)
                 ->modalCancelActionLabel('Cerrar'),
 
-            Action::make('revoke_token')
-                ->label('Revocar token')
-                ->tooltip('Invalida el acceso del terminal a la sincronización offline — requerirá re-provisión')
-                ->icon('heroicon-o-shield-exclamation')
-                ->color('danger')
-                ->visible(fn () => $this->record->tokens()->exists())
-                ->requiresConfirmation()
-                ->modalHeading('Revocar token de sincronización')
-                ->modalDescription('El terminal perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar.')
-                ->modalSubmitActionLabel('Sí, revocar')
-                ->action(function () {
-                    $this->record->revokeSyncTokens();
-                    Notification::make()
-                        ->success()
-                        ->title('Token revocado')
-                        ->body('El terminal deberá re-provisionarse para volver a sincronizar.')
-                        ->send();
-                }),
-
             EditAction::make()->label('Editar')->icon('heroicon-o-pencil-square')->color('primary'),
 
-            DeleteAction::make()->icon('heroicon-o-trash'),
+            ActionGroup::make([
+                Action::make('regenerate_code')
+                    ->label('Regenerar código')
+                    ->tooltip('Cambia la URL pública del terminal — el dispositivo físico deberá reconfigurarse con la nueva URL')
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalHeading('Regenerar código de acceso')
+                    ->modalDescription('⚠️ Esto cambiará la URL de la terminal. El dispositivo físico dejará de funcionar hasta que sea reconfigurado con la nueva URL.')
+                    ->modalSubmitActionLabel('Sí, regenerar')
+                    ->action(function () {
+                        $newCode = Terminal::generateUniqueCode();
+                        $this->record->update(['code' => $newCode]);
+
+                        Notification::make()
+                            ->warning()
+                            ->title('Código regenerado')
+                            ->body('Recordá actualizar la URL en el dispositivo físico.')
+                            ->send();
+
+                        $this->refreshFormData(['code']);
+                    }),
+
+                Action::make('revoke_token')
+                    ->label('Revocar token')
+                    ->tooltip('Invalida el acceso del terminal a la sincronización offline — requerirá re-provisión')
+                    ->icon('heroicon-o-shield-exclamation')
+                    ->color('danger')
+                    ->visible(fn () => $this->record->tokens()->exists())
+                    ->requiresConfirmation()
+                    ->modalHeading('Revocar token de sincronización')
+                    ->modalDescription('El terminal perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar.')
+                    ->modalSubmitActionLabel('Sí, revocar')
+                    ->action(function () {
+                        $this->record->revokeSyncTokens();
+                        Notification::make()
+                            ->success()
+                            ->title('Token revocado')
+                            ->body('El terminal deberá re-provisionarse para volver a sincronizar.')
+                            ->send();
+                    }),
+
+                DeleteAction::make()->icon('heroicon-o-trash'),
+            ])
+                ->label('Más acciones')
+                ->icon('heroicon-m-chevron-down')
+                ->color('gray')
+                ->button(),
         ];
     }
 }

--- a/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
@@ -79,6 +79,9 @@ class ViewTerminal extends ViewRecord
                 ->icon('heroicon-o-qr-code')
                 ->color('gray')
                 ->modalHeading('Enlace de configuración del terminal')
+                ->modalDescription(fn () => $this->record->tokens()->exists()
+                    ? '⚠️ Este terminal ya está vinculado y sincronizando. Si otro dispositivo reclama este enlace, el acceso del terminal actual se revocará automáticamente.'
+                    : null)
                 ->modalContent(fn () => TerminalResource::renderSetupLinkModal($this->record))
                 ->modalSubmitAction(false)
                 ->modalCancelActionLabel('Cerrar'),
@@ -87,22 +90,22 @@ class ViewTerminal extends ViewRecord
 
             ActionGroup::make([
                 Action::make('regenerate_code')
-                    ->label('Regenerar código')
+                    ->label('Cambiar URL del terminal')
                     ->tooltip('Cambia la URL pública del terminal — el dispositivo físico deberá reconfigurarse con la nueva URL')
-                    ->icon('heroicon-o-arrow-path')
+                    ->icon('heroicon-o-link')
                     ->color('warning')
                     ->requiresConfirmation()
-                    ->modalHeading('Regenerar código de acceso')
-                    ->modalDescription('⚠️ Esto cambiará la URL de la terminal. El dispositivo físico dejará de funcionar hasta que sea reconfigurado con la nueva URL.')
-                    ->modalSubmitActionLabel('Sí, regenerar')
+                    ->modalHeading('Cambiar URL del terminal')
+                    ->modalDescription('⚠️ Esto cambiará la URL pública de la terminal. El dispositivo físico dejará de funcionar hasta que sea reconfigurado con la nueva URL. Esto NO afecta el token de sincronización — el terminal seguirá conectado a la API mientras tanto.')
+                    ->modalSubmitActionLabel('Sí, cambiar')
                     ->action(function () {
                         $newCode = Terminal::generateUniqueCode();
                         $this->record->update(['code' => $newCode]);
 
                         Notification::make()
                             ->warning()
-                            ->title('Código regenerado')
-                            ->body('Recordá actualizar la URL en el dispositivo físico.')
+                            ->title('URL del terminal actualizada')
+                            ->body('Recordá reconfigurar el dispositivo físico con la nueva URL.')
                             ->send();
 
                         $this->refreshFormData(['code']);
@@ -116,7 +119,7 @@ class ViewTerminal extends ViewRecord
                     ->visible(fn () => $this->record->tokens()->exists())
                     ->requiresConfirmation()
                     ->modalHeading('Revocar token de sincronización')
-                    ->modalDescription('El terminal perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar.')
+                    ->modalDescription('El terminal perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar. El código y la URL del terminal no cambian.')
                     ->modalSubmitActionLabel('Sí, revocar')
                     ->action(function () {
                         $this->record->revokeSyncTokens();
@@ -127,7 +130,11 @@ class ViewTerminal extends ViewRecord
                             ->send();
                     }),
 
-                DeleteAction::make()->icon('heroicon-o-trash'),
+                DeleteAction::make()
+                    ->label('Eliminar')
+                    ->icon('heroicon-o-trash')
+                    ->modalDescription('Esta acción no se puede deshacer. Las marcaciones ya registradas con este terminal no se eliminan, pero perderán la referencia a qué dispositivo físico las generó.')
+                    ->modalSubmitActionLabel('Sí, eliminar'),
             ])
                 ->label('Más acciones')
                 ->icon('heroicon-m-chevron-down')

--- a/app/Filament/Resources/TerminalResource/RelationManagers/AttendanceEventsRelationManager.php
+++ b/app/Filament/Resources/TerminalResource/RelationManagers/AttendanceEventsRelationManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Resources\TerminalResource\RelationManagers;
+
+use App\Models\AttendanceEvent;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * Historial de marcaciones registradas por este terminal — solo lectura.
+ * `AttendanceEventResource` solo tiene una página `index` (patrón Manage,
+ * sin `ViewRecord` propio), así que no hay a dónde enlazar cada fila con
+ * `->recordUrl()`; se resuelve como tabla puramente informativa, sin
+ * acciones de fila.
+ */
+class AttendanceEventsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'attendanceEvents';
+
+    protected static ?string $title = 'Marcaciones';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('recorded_at')
+                    ->label('Fecha y hora')
+                    ->dateTime('d/m/Y H:i:s')
+                    ->description(fn (AttendanceEvent $record) => $record->recorded_at->diffForHumans())
+                    ->icon('heroicon-o-clock')
+                    ->sortable(),
+
+                TextColumn::make('event_type')
+                    ->label('Tipo de evento')
+                    ->formatStateUsing(fn (string $state) => AttendanceEvent::getEventTypeLabel($state))
+                    ->badge()
+                    ->color(fn (string $state) => AttendanceEvent::getEventTypeColor($state))
+                    ->icon(fn (string $state) => AttendanceEvent::getEventTypeIcon($state))
+                    ->sortable(),
+
+                TextColumn::make('employee_name')
+                    ->label('Empleado')
+                    ->description(fn (AttendanceEvent $record) => $record->employee_ci ? "CI: {$record->employee_ci}" : null)
+                    ->searchable()
+                    ->placeholder('N/A'),
+
+                IconColumn::make('branch_mismatch')
+                    ->label('Sucursal distinta')
+                    ->boolean()
+                    ->trueIcon('heroicon-o-exclamation-triangle')
+                    ->trueColor('warning')
+                    ->falseIcon('heroicon-o-minus')
+                    ->falseColor('gray')
+                    ->tooltip(fn (AttendanceEvent $record) => $record->branch_mismatch
+                        ? 'El empleado pertenece a una sucursal distinta a la del terminal'
+                        : null),
+            ])
+            ->defaultSort('recorded_at', 'desc')
+            ->paginationPageOptions([10, 25, 50, 100])
+            ->actions([])
+            ->bulkActions([])
+            ->emptyStateHeading('Sin marcaciones registradas')
+            ->emptyStateDescription('Las marcaciones aparecerán acá cuando algún empleado marque asistencia desde este terminal.')
+            ->emptyStateIcon('heroicon-o-hand-raised');
+    }
+}

--- a/app/Http/Controllers/Api/MobileStatusController.php
+++ b/app/Http/Controllers/Api/MobileStatusController.php
@@ -16,7 +16,7 @@ use Illuminate\Http\Request;
  * empleados — acá el empleado es implícito, siempre `$request->user()`).
  * El dispositivo prefiere esta consulta en línea; si falla, cae a una
  * resolución local equivalente (ver mobile-offline/queue.js, igual que
- * hace el kiosko desde la Fase 4).
+ * hace el terminal desde la Fase 4).
  *
  * `today_events` (lista completa del día, no solo el último) alimenta la
  * pantalla "Mis marcaciones" en /marcar — a diferencia del resto de esta

--- a/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
@@ -15,7 +15,7 @@ use Throwable;
 
 /**
  * Sincronización incremental de empleados/descriptores faciales para la
- * caché offline del kiosko. Autenticado vía Sanctum (ability `terminal:sync`).
+ * caché offline del terminal. Autenticado vía Sanctum (ability `terminal:sync`).
  */
 class TerminalEmployeeSyncController extends Controller
 {
@@ -24,7 +24,7 @@ class TerminalEmployeeSyncController extends Controller
     /**
      * GET /api/v1/terminal/employees/sync?since=<ISO8601>
      *
-     * Sin `since`, retorna la carga completa (primera sincronización del kiosko).
+     * Sin `since`, retorna la carga completa (primera sincronización del terminal).
      * Con `since`, retorna solo los empleados modificados después de esa fecha,
      * más los `tombstones` (empleados que dejaron de calificar) a eliminar de la caché.
      */
@@ -57,8 +57,8 @@ class TerminalEmployeeSyncController extends Controller
      * GET /api/v1/terminal/employees/{employee}/status
      *
      * Estado de marcación del día en curso para un empleado ya identificado
-     * localmente por el kiosko (matching client-side, ver terminal-offline/matcher.js).
-     * El kiosko prefiere esta consulta en línea cuando hay red; si falla,
+     * localmente por el terminal (matching client-side, ver terminal-offline/matcher.js).
+     * El terminal prefiere esta consulta en línea cuando hay red; si falla,
      * cae a una resolución local equivalente combinando la última respuesta
      * cacheada de este endpoint con sus propios eventos aún no confirmados
      * (ver terminal-offline/queue.js, `resolveEmployeeStatus()`).

--- a/app/Http/Controllers/Api/TerminalHeartbeatController.php
+++ b/app/Http/Controllers/Api/TerminalHeartbeatController.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Request;
  * Heartbeat del terminal — se llama periódicamente mientras hay conexión
  * (y desde el botón "Forzar sincronización") para mantener `last_seen_at`/
  * `last_heartbeat_at` vivos y entregar la configuración vigente de
- * reconocimiento facial, así el kiosko no depende de un sync completo de
+ * reconocimiento facial, así el terminal no depende de un sync completo de
  * empleados para tener el umbral actualizado. Autenticado vía Sanctum
  * (ability `terminal:sync`).
  *
@@ -22,7 +22,7 @@ use Illuminate\Http\Request;
  * conectividad en Filament (ver TerminalResource).
  *
  * También recibe opcionalmente `pending_events`/`conflict_events` — el
- * tamaño de la cola offline del kiosko (`outbound_events` en IndexedDB, ver
+ * tamaño de la cola offline del terminal (`outbound_events` en IndexedDB, ver
  * terminal-offline/queue.js) al momento del heartbeat. Sin esto, un
  * terminal con la cola atascada (ej. eventos en conflicto que requieren
  * revisión) se ve "en línea" igual que uno sano, porque el heartbeat en sí

--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -59,7 +59,7 @@ class AttendanceFaceMarkController extends Controller
 
         $terminal->update(['last_seen_at' => now()]);
 
-        // Sucursal — empresa en el título de pestaña: ayuda a diferenciar kioskos de
+        // Sucursal — empresa en el título de pestaña: ayuda a diferenciar terminales de
         // distintas sucursales cuando un admin monitorea varios a la vez. Sin
         // sucursal/empresa cargada (dato incompleto), cae al nombre del propio terminal.
         $title = collect([$terminal->branch?->name, $terminal->branch?->company?->name])

--- a/app/Http/Controllers/TerminalSetupController.php
+++ b/app/Http/Controllers/TerminalSetupController.php
@@ -11,7 +11,7 @@ use Illuminate\View\View;
 /**
  * Provisión de terminales para la marcación offline vía PWA. El admin genera
  * un enlace de configuración de un solo uso desde TerminalResource; el
- * kiosko lo visita una vez, online, durante la instalación física, y recibe
+ * terminal lo visita una vez, online, durante la instalación física, y recibe
  * a cambio un token Sanctum (ability `terminal:sync`) que usará contra
  * routes/api.php de ahí en adelante — incluso tras largos períodos offline,
  * ya que no depende de la sesión de Laravel (que expira a los 120 minutos).

--- a/app/Models/EmployeeDevice.php
+++ b/app/Models/EmployeeDevice.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * Historial de dispositivos personales vinculados por un empleado para
  * marcación offline vía PWA (ver `Employee::claimMobileToken()`). A
- * diferencia de `Terminal` (un solo registro por kiosko, editado a mano),
+ * diferencia de `Terminal` (un solo registro por terminal, editado a mano),
  * acá cada vinculación real crea un registro nuevo — `unlinked_at` null
  * identifica el dispositivo actualmente activo (a lo sumo uno por
  * empleado). Marca/modelo/serie/MAC/notas quedan vacíos hasta que un

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -256,7 +256,7 @@ class Terminal extends Model implements AuthenticatableContract
     /**
      * Estado de conectividad calculado a partir de `last_heartbeat_at` (a
      * diferencia de `last_seen_at`, que también se actualiza con cada carga
-     * de página vía sesión y por eso no distingue un kiosko que quedó abierto
+     * de página vía sesión y por eso no distingue un terminal que quedó abierto
      * offline días de uno que realmente sigue sincronizando):
      * - 'never_connected': nunca completó un heartbeat exitoso (sin
      *   provisionar, o provisionado pero sin conexión desde entonces).
@@ -276,7 +276,7 @@ class Terminal extends Model implements AuthenticatableContract
     }
 
     /**
-     * Estado de la cola de sincronización offline del kiosko, a partir de lo
+     * Estado de la cola de sincronización offline del terminal, a partir de lo
      * reportado en el último heartbeat exitoso (`last_pending_events_count`/
      * `last_conflict_events_count`) — complementa `connectivity_status`: un
      * terminal puede verse "en línea" (el heartbeat llega con normalidad) y

--- a/app/Notifications/SyncConflictPendingNotification.php
+++ b/app/Notifications/SyncConflictPendingNotification.php
@@ -12,7 +12,7 @@ use Illuminate\Notifications\Notification;
 /**
  * Notificación a los admins cuando se registra un conflicto de
  * sincronización offline (`AttendanceMarkFailure` con `failure_type:
- * sync_conflict`) — kiosko o dispositivo sincronizó una marcación que ya no es
+ * sync_conflict`) — terminal o dispositivo sincronizó una marcación que ya no es
  * válida contra el estado actual del servidor. Sin esto, el registro queda
  * en `AttendanceMarkFailureResource` sin que nadie se entere hasta que un
  * admin entra a mirar manualmente — justo el gap identificado al probar en

--- a/app/Notifications/TerminalProvisionedNotification.php
+++ b/app/Notifications/TerminalProvisionedNotification.php
@@ -11,7 +11,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 /**
- * Notificación a los admins cuando un kiosko/terminal completa su
+ * Notificación a los admins cuando un terminal completa su
  * provisión (reclama el enlace de configuración de un solo uso y recibe
  * su token Sanctum) — confirma que la instalación física salió bien sin
  * que un admin tenga que entrar a revisar `last_heartbeat_at` a mano.
@@ -34,7 +34,7 @@ class TerminalProvisionedNotification extends Notification
 
     /**
      * Envía por email a los admins además de la campanita — confirma la
-     * instalación física del kiosko (o su reprovisión) sin depender de que
+     * instalación física del terminal (o su reprovisión) sin depender de que
      * alguien revise Filament a tiempo.
      */
     public function toMail(object $notifiable): MailMessage

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -95,7 +95,7 @@ class AttendanceEventSyncService
         }
 
         try {
-            // El kiosko manda recorded_at en UTC (Date.toISOString()) — convertir a la
+            // El terminal manda recorded_at en UTC (Date.toISOString()) — convertir a la
             // timezone de la app ANTES de persistir, no solo para calcular $date. Sin esto
             // el evento queda guardado con la hora UTC "cruda" (ej. 3 horas adelantado en
             // America/Asuncion), porque el resto de la app asume que recorded_at ya está en
@@ -249,7 +249,7 @@ class AttendanceEventSyncService
     }
 
     /**
-     * El kiosko no envía GPS (mismo criterio que AttendanceFaceMarkController::store()
+     * El terminal no envía GPS (mismo criterio que AttendanceFaceMarkController::store()
      * en modo terminal) — se usan las coordenadas de la sucursal de la terminal, o
      * las de la sucursal del empleado si la terminal no tiene sucursal asignada.
      */

--- a/app/Services/CompanyLogoThumbnailService.php
+++ b/app/Services/CompanyLogoThumbnailService.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Storage;
 /**
  * Genera un thumbnail de baja resolución del logo de una empresa, codificado
  * como data URI PNG en base64. Se persiste en `Company::logo_thumbnail` (ver
- * CompanyObserver) para viajar embebido en el shell cacheado del kiosko
+ * CompanyObserver) para viajar embebido en el shell cacheado del terminal
  * (`window.terminalData`) y en el payload de heartbeat del celular, sin
  * depender de red para pedir la imagen original por separado.
  *

--- a/app/Services/EmployeeDescriptorSyncService.php
+++ b/app/Services/EmployeeDescriptorSyncService.php
@@ -9,7 +9,7 @@ use Carbon\Carbon;
 /**
  * Sincronización incremental (delta) de descriptores faciales de empleados
  * activos, scopeada por la sucursal del terminal — alimenta la caché offline
- * del kiosko (IndexedDB) para que el reconocimiento facial pueda correr
+ * del terminal (IndexedDB) para que el reconocimiento facial pueda correr
  * localmente sin conexión.
  */
 class EmployeeDescriptorSyncService
@@ -57,14 +57,14 @@ class EmployeeDescriptorSyncService
     /**
      * IDs de empleados de esta sucursal que cambiaron desde `$since` y ya no
      * califican para la caché offline (se desactivaron o perdieron su
-     * descriptor) — el kiosko debe eliminarlos de su copia local.
+     * descriptor) — el terminal debe eliminarlos de su copia local.
      *
      * Limitación conocida: si un empleado se movió a OTRA sucursal, esta
      * consulta no lo detecta porque ya no aparece con branch_id = la
      * sucursal del terminal. Un cambio de sucursal es infrecuente y, en el
-     * peor caso, deja un descriptor obsoleto en la caché del kiosko viejo
+     * peor caso, deja un descriptor obsoleto en la caché del terminal viejo
      * hasta la próxima re-provisión — no un problema de seguridad (el
-     * descriptor ya era visible para ese kiosko), solo de limpieza.
+     * descriptor ya era visible para ese terminal), solo de limpieza.
      *
      * @return array<int, int>
      */

--- a/app/Services/EmployeePhotoThumbnailService.php
+++ b/app/Services/EmployeePhotoThumbnailService.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Storage;
  * Genera un thumbnail cuadrado de baja resolución de la foto de un empleado,
  * codificado como data URI base64. Se persiste en `Employee::photo_thumbnail`
  * (ver EmployeeObserver) para poder viajar embebido en el payload JSON de
- * sincronización offline del kiosko (ver EmployeeDescriptorSyncService) sin
+ * sincronización offline del terminal (ver EmployeeDescriptorSyncService) sin
  * depender de que el dispositivo tenga red para pedir la imagen original por
  * separado — la foto completa (potencialmente varios MB) nunca se sincroniza.
  *

--- a/app/Services/MobileEventSyncService.php
+++ b/app/Services/MobileEventSyncService.php
@@ -164,7 +164,7 @@ class MobileEventSyncService
     /**
      * Persiste un intento fallido de sincronización para revisión en Filament
      * (`AttendanceMarkFailureResource` — mismo flujo de aprobar/descartar que
-     * ya existe para los conflictos del kiosko).
+     * ya existe para los conflictos del terminal).
      *
      * @param  array<string, mixed>  $metadata
      */

--- a/database/migrations/2026_08_18_221031_add_offline_sync_fields_to_attendance_events_table.php
+++ b/database/migrations/2026_08_18_221031_add_offline_sync_fields_to_attendance_events_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * Agrega client_event_id y synced_at para el flujo de sincronización de
- * terminales (kiosko offline vía PWA, ver AttendanceEventSyncController).
+ * terminales (offline vía PWA, ver AttendanceEventSyncController).
  *
  * - client_event_id: UUID generado en el cliente al momento de la captura
  *   (no al sincronizar), usado para deduplicar reintentos con seguridad.

--- a/database/migrations/2026_08_19_031253_add_heartbeat_fields_to_terminals_table.php
+++ b/database/migrations/2026_08_19_031253_add_heartbeat_fields_to_terminals_table.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Facades\Schema;
  * offline vía PWA): a diferencia de `last_seen_at` (se actualiza también con
  * cada carga de página, vía sesión), estos campos solo se actualizan cuando
  * el terminal completa exitosamente cada tipo de sincronización con la API
- * Sanctum — permiten distinguir "el kiosko cargó la página una vez" de "el
- * kiosko está efectivamente sincronizando" en un dispositivo que puede
+ * Sanctum — permiten distinguir "el terminal cargó la página una vez" de "el
+ * terminal está efectivamente sincronizando" en un dispositivo que puede
  * quedar abierto días sin recargar.
  *
  * - last_heartbeat_at: último POST /api/v1/terminal/heartbeat exitoso.

--- a/database/migrations/2026_08_19_085124_add_sync_queue_counts_to_terminals_table.php
+++ b/database/migrations/2026_08_19_085124_add_sync_queue_counts_to_terminals_table.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Agrega los contadores de cola offline que el kiosko reporta en cada
+ * Agrega los contadores de cola offline que el terminal reporta en cada
  * heartbeat (Fase 6 — hardening): sin esto, el badge de conectividad
  * (Fase 5) no distingue un terminal con red intermitente y una cola de
  * marcaciones atascada de uno realmente sano — ambos se ven "en línea"

--- a/database/migrations/2026_08_19_154630_add_resolution_fields_to_attendance_mark_failures_table.php
+++ b/database/migrations/2026_08_19_154630_add_resolution_fields_to_attendance_mark_failures_table.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Agrega el flujo de revisión manual a los fallos de marcación: hasta ahora
  * `AttendanceMarkFailureResource` era de solo lectura — un `sync_conflict`
- * (kiosko offline, ver AttendanceEventSyncService) quedaba registrado pero
+ * (terminal offline, ver AttendanceEventSyncService) quedaba registrado pero
  * sin ninguna acción posible desde Filament. Permite que un admin apruebe
  * (reconstruye el `AttendanceEvent`), o descarte el fallo como revisado.
  */

--- a/database/migrations/2026_08_19_160134_add_photo_thumbnail_to_employees_table.php
+++ b/database/migrations/2026_08_19_160134_add_photo_thumbnail_to_employees_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * Agrega `photo_thumbnail` a employees: un data URI base64 (JPEG 64x64,
- * generado por EmployeePhotoThumbnailService) para que el kiosko offline
+ * generado por EmployeePhotoThumbnailService) para que el terminal offline
  * pueda mostrar la foto real del empleado en la pantalla de éxito sin
  * depender de red — se sincroniza embebido en el payload JSON de
  * EmployeeDescriptorSyncService, igual que `face_descriptor`.

--- a/database/migrations/2026_08_20_150000_add_mobile_last_heartbeat_at_to_employees_table.php
+++ b/database/migrations/2026_08_20_150000_add_mobile_last_heartbeat_at_to_employees_table.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Schema;
  * vinculado — a diferencia de `mobile_linked_at` (fecha de vinculación, no
  * cambia mientras el dispositivo siga siendo el mismo), este campo permite
  * ver en `EmployeeResource` si el dispositivo sigue sincronizando con normalidad.
- * Menor prioridad que el heartbeat/staleness del kiosko (Terminal): acá es
+ * Menor prioridad que el heartbeat/staleness del `Terminal`: acá es
  * un dispositivo personal, no un activo físico de la empresa a monitorear
  * activamente, así que no se agrega un sistema de umbral configurable como
  * el de `Terminal::connectivity_status` — solo se muestra la fecha relativa.

--- a/database/migrations/2026_08_25_015037_add_logo_thumbnail_to_companies_table.php
+++ b/database/migrations/2026_08_25_015037_add_logo_thumbnail_to_companies_table.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Facades\Schema;
 /**
  * Agrega `logo_thumbnail` a companies: un data URI base64 (PNG, ajustado
  * preservando proporción, generado por CompanyLogoThumbnailService) para que
- * el header persistente de ambos modos de marcación (celular y kiosko) pueda
+ * el header persistente de ambos modos de marcación (celular y terminal) pueda
  * mostrar el logo real sin depender de red — se sincroniza embebido en el
- * shell cacheado del kiosko y en el payload de heartbeat del celular, igual
+ * shell cacheado del terminal y en el payload de heartbeat del celular, igual
  * que `photo_thumbnail` en employees (PR #83).
  *
  * A diferencia de `photo_thumbnail`, acá sí se hace backfill: la cantidad de

--- a/database/migrations/2026_08_25_123752_add_user_agent_to_terminals_table.php
+++ b/database/migrations/2026_08_25_123752_add_user_agent_to_terminals_table.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * Agrega `user_agent` a terminals — capturado en TerminalSetupController::claim()
- * al provisionar el kiosko, mismo dato que ya guarda EmployeeDevice desde la
+ * al provisionar el terminal, mismo dato que ya guarda EmployeeDevice desde la
  * Fase 1 de Parte C. Insumo de DeviceHintsParser para prellenar marca/modelo
  * como sugerencia editable, y referencia diagnóstica adicional en el panel.
  */

--- a/docs/marcacion-offline.md
+++ b/docs/marcacion-offline.md
@@ -1,6 +1,6 @@
-# Arquitectura: marcación de asistencia offline (kiosko y dispositivo)
+# Arquitectura: marcación de asistencia offline (terminal y dispositivo)
 
-Documento de referencia de la arquitectura de marcación de asistencia por reconocimiento facial con soporte offline, cubriendo tanto el kiosko/terminal de sucursal como el dispositivo personal del empleado. Consolida el trabajo de tres iniciativas relacionadas: ajuste de reconocimiento facial, marcación offline vía PWA en el kiosko, y marcación offline vía PWA en el dispositivo personal.
+Documento de referencia de la arquitectura de marcación de asistencia por reconocimiento facial con soporte offline, cubriendo tanto el terminal de sucursal como el dispositivo personal del empleado. Consolida el trabajo de tres iniciativas relacionadas: ajuste de reconocimiento facial, marcación offline vía PWA en el terminal, y marcación offline vía PWA en el dispositivo personal.
 
 Para el resumen corto orientado a desarrollo día a día, ver la sección "Módulo de Asistencia — Marcación Offline" en `CLAUDE.md`. Este documento tiene el detalle completo de arquitectura y decisiones.
 
@@ -12,7 +12,7 @@ El reconocimiento facial corre 100% en el navegador (face-api.js, descriptores d
 
 Hay dos dispositivos distintos que marcan asistencia, con modelos de confianza y caché muy diferentes:
 
-| | Kiosko/terminal | Dispositivo personal |
+| | Terminal | Dispositivo personal |
 |---|---|---|
 | Propiedad | De la empresa, en la sucursal | Del empleado |
 | Uso | Compartido, N empleados | Individual, 1 empleado |
@@ -45,12 +45,12 @@ Ajustes basados en datos reales de fallos (`AttendanceMarkFailure`, 30 días, 29
 
 ---
 
-## Parte B — Kiosko/terminal offline
+## Parte B — Terminal offline
 
 ### Capa de API (`routes/api.php`, prefijo `v1/terminal`)
 
 - `GET /employees/sync?since=...` — sync incremental (delta) de empleados activos con descriptor facial de la sucursal del terminal, con tombstones para los que dejaron de calificar.
-- `GET /employees/{employee}/status` — último evento / eventos permitidos de un empleado puntual (el kiosko no tiene esto cacheado localmente para todos).
+- `GET /employees/{employee}/status` — último evento / eventos permitidos de un empleado puntual (el terminal no tiene esto cacheado localmente para todos).
 - `POST /events/sync` — envío en lote (máx. 200) de eventos con `client_event_id` (UUID generado al capturar) para deduplicar reintentos.
 - `POST /heartbeat` — mantiene vivo `last_heartbeat_at`, devuelve config vigente (`face_threshold` etc.) y reporta contadores de cola (`pending_events`/`conflict_events`).
 
@@ -63,11 +63,11 @@ Ajustes basados en datos reales de fallos (`AttendanceMarkFailure`, 30 días, 29
 
 ### Service worker (`public/sw.js`)
 
-Hand-rolled (sin Workbox) — cache-first para `/models/*` y `/build/assets/*`, stale-while-revalidate para el shell HTML del kiosko. `skipWaiting()` + `clients.claim()` en cada deploy, con caché versionada.
+Hand-rolled (sin Workbox) — cache-first para `/models/*` y `/build/assets/*`, stale-while-revalidate para el shell HTML del terminal. `skipWaiting()` + `clients.claim()` en cada deploy, con caché versionada.
 
 ### Resolución de conflictos
 
-Si el kiosko sincroniza un evento offline cuya secuencia ya no es válida en el servidor (ej. otro origen ya registró un evento posterior mientras estaba desconectado), el servidor lo rechaza puntualmente (`AttendanceEventSyncService::recordSyncFailure()`) y lo registra en `AttendanceMarkFailure` (`failure_type: sync_conflict`) — nunca se descarta silenciosamente ni se fuerza. Un admin lo revisa desde Filament (`AttendanceMarkFailureResource`) y puede **aprobar** (reconstruye el evento, revalidando la secuencia contra el estado *actual*, con opción de ajustar tipo/hora) o **descartar**.
+Si el terminal sincroniza un evento offline cuya secuencia ya no es válida en el servidor (ej. otro origen ya registró un evento posterior mientras estaba desconectado), el servidor lo rechaza puntualmente (`AttendanceEventSyncService::recordSyncFailure()`) y lo registra en `AttendanceMarkFailure` (`failure_type: sync_conflict`) — nunca se descarta silenciosamente ni se fuerza. Un admin lo revisa desde Filament (`AttendanceMarkFailureResource`) y puede **aprobar** (reconstruye el evento, revalidando la secuencia contra el estado *actual*, con opción de ajustar tipo/hora) o **descartar**.
 
 ### Heartbeat / staleness (`Terminal`)
 
@@ -101,7 +101,7 @@ Los tres endpoints revocan el token y responden `403` si el empleado ya no está
 
 ### Cliente (`resources/js/attendances/mobile-offline/`)
 
-Reusa `db.js`/`matcher.js`/`queue.js` del kiosko con cambios mínimos (nombre de IndexedDB `nominapp-mobile`, para no chocar si algún día ambos flujos coexistieran en el mismo navegador — `matcher.js` funciona igual con un array de 1 solo candidato). `sync.js` es una variante propia apuntando a `/api/v1/mobile/*` (el original tenía `API_BASE` fijo a `/api/v1/terminal`).
+Reusa `db.js`/`matcher.js`/`queue.js` del terminal con cambios mínimos (nombre de IndexedDB `nominapp-mobile`, para no chocar si algún día ambos flujos coexistieran en el mismo navegador — `matcher.js` funciona igual con un array de 1 solo candidato). `sync.js` es una variante propia apuntando a `/api/v1/mobile/*` (el original tenía `API_BASE` fijo a `/api/v1/terminal`).
 
 ### Integración con `mark.js`
 
@@ -119,19 +119,19 @@ Notificación a admins (`MobileDeviceRelinkedNotification`) cuando un empleado q
 - **Borrado remoto de un dispositivo perdido no es posible** — revocar el token evita que siga *sincronizando*, pero no borra lo que ya tenía cacheado localmente. Ver los runbooks.
 - **CI + fecha de nacimiento como credencial de vinculación** es de baja entropía — mitigado con throttling agresivo y notificación de re-vinculación, no con un segundo factor real (ese rol lo cumple el match facial).
 - **Background Sync API no soportada en Safari/WebKit** — el fallback es que la sincronización ocurre mientras la pestaña/PWA sigue abierta.
-- **Heartbeat/staleness del dispositivo tiene menor prioridad que el del kiosko** — son N:1 por empleado, no un activo físico de la empresa a monitorear activamente; hoy solo hay un timestamp visible en `EmployeeResource`, sin badge de "desconectado" ni alertas.
+- **Heartbeat/staleness del dispositivo tiene menor prioridad que el del terminal** — son N:1 por empleado, no un activo físico de la empresa a monitorear activamente; hoy solo hay un timestamp visible en `EmployeeResource`, sin badge de "desconectado" ni alertas.
 - **`Employee::getAdvanceReferenceSalary()`** y otras áreas no relacionadas con asistencia no se tocaron en esta iniciativa.
 
 ## Runbooks relacionados
 
-- `docs/runbook-terminal-revocacion-reprovision.md` — pérdida/robo/reemplazo de un kiosko.
+- `docs/runbook-terminal-revocacion-reprovision.md` — pérdida/robo/reemplazo de un terminal.
 - `docs/runbook-dispositivo-vinculacion-revocacion.md` — pérdida/robo/reemplazo del dispositivo de un empleado, o revocación manual desde Filament.
 
 ## Archivos clave
 
 **Backend compartido:** `app/Models/AttendanceEvent.php` (máquina de estados `allowedNextEventTypes()`), `app/Models/AttendanceMarkFailure.php` (registro y resolución de conflictos), `app/Filament/Resources/AttendanceMarkFailureResource.php`.
 
-**Kiosko:** `app/Models/Terminal.php`, `app/Http/Controllers/Api/Terminal{EmployeeSync,EventSync,Heartbeat}Controller.php`, `app/Services/{EmployeeDescriptorSyncService,AttendanceEventSyncService}.php`, `app/Filament/Resources/TerminalResource.php`, `resources/js/attendances/{terminal,terminal-offline/*}.js`, `public/sw.js`.
+**Terminal:** `app/Models/Terminal.php`, `app/Http/Controllers/Api/Terminal{EmployeeSync,EventSync,Heartbeat}Controller.php`, `app/Services/{EmployeeDescriptorSyncService,AttendanceEventSyncService}.php`, `app/Filament/Resources/TerminalResource.php`, `resources/js/attendances/{terminal,terminal-offline/*}.js`, `public/sw.js`.
 
 **Dispositivo:** `app/Models/Employee.php` (sección "Marcación offline por dispositivo"), `app/Http/Controllers/MobileLinkController.php`, `app/Http/Controllers/Api/Mobile{Heartbeat,Status,EventSync}Controller.php`, `app/Services/MobileEventSyncService.php`, `resources/js/attendances/{mark,mobile-offline/*}.js`, `resources/views/attendances/device-link.blade.php`.
 

--- a/docs/runbook-dispositivo-vinculacion-revocacion.md
+++ b/docs/runbook-dispositivo-vinculacion-revocacion.md
@@ -12,11 +12,11 @@ Guía operativa para el equipo de soporte/administración de **Nominapp** ante l
 - Se sospecha que alguien vinculó su propio dispositivo usando el CI + fecha de nacimiento de otro empleado (denegación de servicio dirigida — ver [Riesgos aceptados](#riesgos-aceptados)).
 - El empleado causa baja (aunque esto se revoca automáticamente — ver [Revocación automática](#revocación-automática-sin-intervención-manual)).
 
-A diferencia del kiosko de sucursal, acá **no hay enlace de un solo uso generado por un admin**: el propio empleado se vincula en `/vincular-dispositivo` identificándose con su CI + fecha de nacimiento. El token Sanctum del dispositivo (`ability: mobile:sync`) sigue siendo válido hasta que se revoque explícitamente — no expira solo.
+A diferencia del terminal de sucursal, acá **no hay enlace de un solo uso generado por un admin**: el propio empleado se vincula en `/vincular-dispositivo` identificándose con su CI + fecha de nacimiento. El token Sanctum del dispositivo (`ability: mobile:sync`) sigue siendo válido hasta que se revoque explícitamente — no expira solo.
 
 ## Qué NO cubre este runbook
 
-- **Borrado remoto del dispositivo perdido**: no existe hoy un mecanismo para borrar la caché de IndexedDB (el descriptor facial propio del empleado) de un dispositivo físico que ya no está bajo control. Revocar el token evita que ese dispositivo pueda seguir *sincronizando* o *marcando*, pero el descriptor que ya tenía cacheado localmente permanece en el dispositivo — mismo riesgo aceptado que en el kiosko, mitigado acá por el hecho de que solo se cachea el descriptor de UN empleado (no toda la sucursal).
+- **Borrado remoto del dispositivo perdido**: no existe hoy un mecanismo para borrar la caché de IndexedDB (el descriptor facial propio del empleado) de un dispositivo físico que ya no está bajo control. Revocar el token evita que ese dispositivo pueda seguir *sincronizando* o *marcando*, pero el descriptor que ya tenía cacheado localmente permanece en el dispositivo — mismo riesgo aceptado que en el terminal, mitigado acá por el hecho de que solo se cachea el descriptor de UN empleado (no toda la sucursal).
 - Incidentes de seguridad más amplios (compromiso del servidor, credenciales de admin filtradas).
 
 ---

--- a/docs/runbook-terminal-revocacion-reprovision.md
+++ b/docs/runbook-terminal-revocacion-reprovision.md
@@ -1,13 +1,13 @@
 # Runbook: Revocación y reprovisión de terminales offline
 
-Guía operativa para el equipo de soporte/administración de **Nominapp** ante la pérdida, robo o reemplazo de un dispositivo kiosko de marcación de asistencia (terminal offline vía PWA).
+Guía operativa para el equipo de soporte/administración de **Nominapp** ante la pérdida, robo o reemplazo de un terminal de marcación de asistencia (offline vía PWA).
 
 ---
 
 ## Cuándo aplica
 
-- El dispositivo físico del kiosko se perdió o fue robado.
-- Se reemplaza el hardware de un kiosko existente (tablet/PC nueva en la misma sucursal).
+- El dispositivo físico del terminal se perdió o fue robado.
+- Se reemplaza el hardware de un terminal existente (tablet/PC nueva en la misma sucursal).
 - Se sospecha que el token de sincronización de un terminal fue comprometido (ej. acceso no autorizado al dispositivo).
 - Un terminal se va a dar de baja definitivamente (la sucursal cierra, o se reemplaza el proceso de marcación).
 
@@ -25,7 +25,7 @@ En todos estos casos, el token Sanctum del terminal (`ability: terminal:sync`) s
 1. Ir a **Filament → Asistencias → Terminales**.
 2. Ubicar el terminal afectado (por nombre o sucursal).
 3. Abrir el menú de acciones de la fila (`⋮`) y seleccionar **"Revocar token"**.
-4. Confirmar en el modal. Esto invalida inmediatamente el token Sanctum — el próximo intento de sincronización desde ese dispositivo recibirá `401`/`403` y el kiosko mostrará "Terminal sin configurar" (o el mensaje equivalente de re-provisión).
+4. Confirmar en el modal. Esto invalida inmediatamente el token Sanctum — el próximo intento de sincronización desde ese dispositivo recibirá `401`/`403` y el terminal mostrará "Terminal sin configurar" (o el mensaje equivalente de re-provisión).
 
 **No hace falta desactivar el terminal** (`status: inactive`) al revocar el token — son conceptos independientes: `status` controla si el terminal puede usarse para marcar (vía `/terminal/{code}`), mientras que el token controla el acceso a la API de sincronización offline. Si el dispositivo físico se perdió y no se va a recuperar, desactivar el terminal además de revocar el token evita que alguien reactive el acceso reutilizando la URL pública.
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@
  *
  * Hand-rolled, sin Workbox/vite-plugin-pwa. Un mismo script compartido entre
  * dos flujos con scope de registro distinto:
- * - Kiosko de sucursal: /terminal/* (registrado en terminal.blade.php).
+ * - Terminal de sucursal: /terminal/* (registrado en terminal.blade.php).
  * - Dispositivo personal del empleado: /marcar (registrado en mark.blade.php,
  *   Parte C Fase 2 — la vinculación en /vincular-dispositivo NO se cachea, es
  *   una acción intrínsecamente online).
@@ -31,7 +31,7 @@ const CACHE_FIRST_PATTERNS = [
     /^\/build\/assets\//, // todos los bundles JS/CSS de Vite (nombres con hash de contenido — seguros de cachear indefinidamente)
 ];
 
-/** Shell HTML del kiosko y del dispositivo — stale-while-revalidate para que un reload offline funcione. */
+/** Shell HTML del terminal y del dispositivo — stale-while-revalidate para que un reload offline funcione. */
 const SHELL_PATTERNS = [
     /^\/terminal\/?$/,
     /^\/terminal\/[a-z0-9]+\/?$/,
@@ -39,7 +39,7 @@ const SHELL_PATTERNS = [
 ];
 
 self.addEventListener('install', () => {
-    // Kiosko de un solo propósito: aplicar la versión nueva del SW sin esperar
+    // Terminal de un solo propósito: aplicar la versión nueva del SW sin esperar
     // a que se cierren todas las pestañas abiertas.
     self.skipWaiting();
 });

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -62,7 +62,7 @@
 }
 
 /* Tokens oscuros — activados por preferencia del sistema O por toggle manual
-   (#btnThemeToggle, mismo mecanismo que ya usa el kiosko en terminal.css). */
+   (#btnThemeToggle, mismo mecanismo que ya usa el terminal en terminal.css). */
 @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
         --c-bg:          #0f172a;

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -430,7 +430,7 @@ const statusBar           = document.getElementById("statusBar");
 
     // --------------------------------------------------------------------------
     // ESTADO DE SINCRONIZACIÓN OFFLINE — paridad con refreshIdleSyncStatus()
-    // de terminal.js (kiosko): mismo texto/prioridad (conflictos > pendientes >
+    // de terminal.js: mismo texto/prioridad (conflictos > pendientes >
     // sincronizado), pero acá además hay un aviso separado (conflictBanner)
     // porque un conflicto en el dispositivo es del propio empleado, no de un
     // tercero — amerita más que una línea de texto discreta.
@@ -1000,7 +1000,7 @@ const statusBar           = document.getElementById("statusBar");
      * /vincular-dispositivo, ver MobileLinkController) antes de arrancar la
      * cámara — sin token no hay nada que identificar localmente. Migra
      * primero el token que device-link.blade.php deja en localStorage tras
-     * una vinculación exitosa (mismo patrón que terminal.js con el kiosko).
+     * una vinculación exitosa (mismo patrón que ya usa terminal.js).
      * @returns {Promise<boolean>}
      */
     async function ensureLinkedDevice() {
@@ -1043,7 +1043,7 @@ const statusBar           = document.getElementById("statusBar");
 
     /**
      * Reintenta heartbeat y vaciar la cola de marcaciones pendientes en
-     * segundo plano — mismo patrón que terminal.js del kiosko, adaptado sin
+     * segundo plano — mismo patrón que ya usa terminal.js, adaptado sin
      * sync de empleados (acá no existe, ver mobile-offline/sync.js).
      */
     function startBackgroundSync() {
@@ -2651,7 +2651,7 @@ const statusBar           = document.getElementById("statusBar");
     // ==========================================================================
     // TEMA CLARO / OSCURO
     // ==========================================================================
-    // Mismo mecanismo que ya usa el kiosko (terminal.js) — localStorage con clave
+    // Mismo mecanismo que ya usa terminal.js — localStorage con clave
     // propia para no interferir si algún dispositivo llegara a usarse en los dos modos.
     (function initTheme() {
         const saved = localStorage.getItem("mark-theme");

--- a/resources/js/attendances/mobile-offline/db.js
+++ b/resources/js/attendances/mobile-offline/db.js
@@ -9,7 +9,7 @@
  *               flujos puedan coexistir sin chocar si algún dispositivo
  *               llegara a usarse en los dos modos.
  *
- * Diferencia clave con el kiosko: acá NO existe un store de `employees_cache`
+ * Diferencia clave con el terminal: acá NO existe un store de `employees_cache`
  * — el dispositivo vinculado cachea el descriptor facial de un único empleado (el
  * dueño del dispositivo), guardado directamente en `mobile_meta` bajo la key
  * `own_employee`. Todo lo demás (cola de eventos, caché de estado, log de

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -136,7 +136,7 @@ export async function getOwnStatus() {
  * heartbeat exitoso (`server_clock_offset_ms`, ver sync.js). Sin heartbeat
  * previo el offset es 0 (no hay corrección posible).
  * @param {string} eventType
- * @param {{lat: number, lng: number}|null} [location] - GPS real del dispositivo (a diferencia del kiosko, que solo tiene fallback a coordenadas de sucursal).
+ * @param {{lat: number, lng: number}|null} [location] - GPS real del dispositivo (a diferencia del terminal, que solo tiene fallback a coordenadas de sucursal).
  * @returns {Promise<{client_event_id: string, recorded_at: string}>}
  */
 export async function enqueueMark(eventType, location = null) {
@@ -176,8 +176,8 @@ let flushInProgress = false;
  * Máximo de eventos por request de sincronización — debe coincidir con el
  * límite del servidor (`MobileEventSyncController`: `'events' => [...,
  * 'max:200']`). En la práctica un dispositivo personal difícilmente acumule
- * tantas marcaciones (a diferencia de un kiosko con muchos empleados), pero
- * se mantiene el mismo chunking por las dudas y por paridad con el kiosko.
+ * tantas marcaciones (a diferencia de un terminal con muchos empleados), pero
+ * se mantiene el mismo chunking por las dudas y por paridad con el terminal.
  */
 const MAX_BATCH_SIZE = 200;
 

--- a/resources/js/attendances/mobile-offline/sync.js
+++ b/resources/js/attendances/mobile-offline/sync.js
@@ -5,7 +5,7 @@
  *
  * @fileoverview Cliente delgado para /api/v1/mobile/* — heartbeat (que además
  *               devuelve el descriptor facial propio, no hay endpoint de
- *               "sync de empleados" separado como en el kiosko), estado del
+ *               "sync de empleados" separado como en el terminal), estado del
  *               propio empleado, y envío de eventos. Requiere que el dispositivo
  *               ya haya sido vinculado (token en mobile_meta.api_token, ver
  *               MobileLinkController / device-link.blade.php).
@@ -51,7 +51,7 @@ export async function apiFetch(path, options = {}) {
  * Heartbeat: refresca la configuración de reconocimiento facial (umbral/gap)
  * y el descriptor facial propio (propaga automáticamente una re-inscripción
  * sin que el empleado tenga que re-vincular el dispositivo) — no existe un
- * endpoint separado de "sync de empleados" como en el kiosko, porque acá solo
+ * endpoint separado de "sync de empleados" como en el terminal, porque acá solo
  * hace falta cachear un único descriptor: el del dueño del dispositivo.
  * @returns {Promise<void>}
  */
@@ -85,7 +85,7 @@ export async function getFaceConfig() {
 
 /**
  * Estado del día (último evento / eventos permitidos) del propio empleado —
- * a diferencia del kiosko, no recibe `employeeId` por parámetro: el servidor
+ * a diferencia del terminal, no recibe `employeeId` por parámetro: el servidor
  * lo resuelve implícitamente del token. Requiere red — el caller (`queue.js`,
  * `getOwnStatus()`) cae a una resolución local si esta consulta falla.
  * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
@@ -113,7 +113,7 @@ export async function unlinkDevice() {
  * Envía un lote de eventos de marcación — uno solo si se llama justo tras
  * capturar la marcación con red disponible, o varios si se está vaciando la
  * cola offline acumulada (ver mobile-offline/queue.js). A diferencia del
- * kiosko, cada evento NO lleva `employee_id` — el empleado es implícito (el
+ * terminal, cada evento NO lleva `employee_id` — el empleado es implícito (el
  * dueño del token).
  * @param {Array<{client_event_id: string, event_type: string, recorded_at: string, location?: object|null}>} events
  * @returns {Promise<Array<{client_event_id: string, status: string, event_id?: number, message?: string}>>}

--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -3,7 +3,7 @@
  * INDEXEDDB — CACHÉ LOCAL DEL TERMINAL
  * =============================================================================
  *
- * @fileoverview Wrapper delgado sobre `idb` para la base local del kiosko.
+ * @fileoverview Wrapper delgado sobre `idb` para la base local del terminal.
  *
  * Stores:
  * - terminal_meta          — key/value: api_token, terminal_id/code/branch_id,

--- a/resources/js/attendances/terminal-offline/matcher.js
+++ b/resources/js/attendances/terminal-offline/matcher.js
@@ -1,11 +1,11 @@
 /**
  * =============================================================================
- * MATCHING FACIAL CLIENT-SIDE (kiosko offline)
+ * MATCHING FACIAL CLIENT-SIDE (terminal offline)
  * =============================================================================
  *
  * @fileoverview Port a JS de la lógica de identificación por distancia
  *               euclidiana de AttendanceFaceMarkController::identifyEmployeeByDescriptor()
- *               (backend), para poder correr el matching en el kiosko sin
+ *               (backend), para poder correr el matching en el terminal sin
  *               depender del servidor. Mismo algoritmo, mismos criterios de
  *               umbral/gap — la config (threshold/minGap) se sincroniza desde
  *               GeneralSettings vía el endpoint de heartbeat (ver sync.js).

--- a/resources/js/attendances/terminal-offline/queue.js
+++ b/resources/js/attendances/terminal-offline/queue.js
@@ -4,7 +4,7 @@
  * =============================================================================
  *
  * @fileoverview Orquesta la captura, resolución de estado y sincronización en
- *               segundo plano de las marcaciones del kiosko. A diferencia de
+ *               segundo plano de las marcaciones del terminal. A diferencia de
  *               la Fase 3 (matching client-side, pero marcación aún síncrona),
  *               acá el envío puede diferirse: toda marcación se guarda primero
  *               en `outbound_events` (durable) y recién después se intenta
@@ -55,7 +55,7 @@ export function allowedNextEventTypes(lastEventType) {
 
 /**
  * Hora actual corregida con el offset de reloj del último heartbeat exitoso
- * (`server_clock_offset_ms`, ver sync.js) — un kiosko sin NTP configurado
+ * (`server_clock_offset_ms`, ver sync.js) — un terminal sin NTP configurado
  * puede tener el reloj local desviado, lo que arrastraría el error a cada
  * marcación capturada offline. Sin heartbeat previo el offset es 0.
  * @returns {Promise<Date>}
@@ -77,7 +77,7 @@ function localDateString(date = new Date()) {
  * Resuelve el estado de marcación de un empleado para hoy, combinando:
  * 1) el último estado que el servidor confirmó (cacheado en la última
  *    consulta online exitosa), con
- * 2) los eventos que este mismo kiosko ya encoló hoy para ese empleado pero
+ * 2) los eventos que este mismo terminal ya encoló hoy para ese empleado pero
  *    el servidor todavía no confirmó — para no repetir ni saltear pasos
  *    mientras está offline.
  * @param {number} employeeId
@@ -108,7 +108,7 @@ export async function resolveEmployeeStatus(employeeId) {
 /**
  * Estado de marcación de un empleado ya identificado localmente: intenta la
  * consulta en línea (y cachea el resultado para uso offline futuro); si falla
- * por falta de red, cae a resolveEmployeeStatus() con lo que el kiosko ya sabe.
+ * por falta de red, cae a resolveEmployeeStatus() con lo que el terminal ya sabe.
  * @param {number} employeeId
  */
 export async function getEmployeeStatus(employeeId) {
@@ -128,7 +128,7 @@ export async function getEmployeeStatus(employeeId) {
  * pestaña se cierre a mitad de camino.
  *
  * `recorded_at` se corrige con el offset de reloj calculado en el último
- * heartbeat exitoso (`server_clock_offset_ms`, ver sync.js) — un kiosko sin
+ * heartbeat exitoso (`server_clock_offset_ms`, ver sync.js) — un terminal sin
  * NTP configurado puede tener el reloj local desviado varios minutos, y esa
  * desviación se arrastraría a cada marcación capturada mientras estuvo
  * offline. Sin heartbeat previo el offset es 0 (no hay corrección posible).

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -97,7 +97,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // Logo de la empresa — ya viaja embebido como data URI en window.terminalData
-    // (inyectado server-side), así que queda cacheado junto con el shell del kiosko
+    // (inyectado server-side), así que queda cacheado junto con el shell del terminal
     // por el service worker sin necesidad de un fetch aparte.
     const headerLogo = document.getElementById("terminalHeaderLogo");
     if (terminalData && headerLogo && terminalData.company_logo) {
@@ -618,7 +618,7 @@ document.addEventListener("DOMContentLoaded", () => {
      * euclidiana + umbral/gap que corre en el servidor (ver terminal-offline/matcher.js).
      * El estado del día (último evento / eventos permitidos) se resuelve vía
      * getEmployeeStatus(), que intenta la consulta en línea y cae a lo que el
-     * kiosko ya sabe localmente si no hay red — ver terminal-offline/queue.js.
+     * terminal ya sabe localmente si no hay red — ver terminal-offline/queue.js.
      */
     async function identifyEmployee(descriptor) {
         try {
@@ -1104,7 +1104,7 @@ document.addEventListener("DOMContentLoaded", () => {
      * (empleados cacheados, cola de marcaciones pendientes) bajo presión de
      * espacio en disco. Best-effort: no todos los navegadores lo soportan, y
      * la concesión depende de heurísticas del navegador (ej. Chrome la
-     * otorga más fácil en un dispositivo instalado como PWA/kiosko).
+     * otorga más fácil en un dispositivo instalado como PWA/terminal).
      */
     async function requestPersistentStorage() {
         if (!navigator.storage?.persist) return;

--- a/resources/js/shared/face-capture-core.js
+++ b/resources/js/shared/face-capture-core.js
@@ -8,7 +8,7 @@
  *               para que un ajuste de tuning (tamaño mínimo de cara, umbrales) se
  *               haga en un solo lugar. Deliberadamente NO incluye manejo de DOM ni
  *               máquinas de estado de pantalla — cada caller (marcación manual,
- *               terminal/kiosko, enrolamiento) tiene su propio flujo de UI distinto.
+ *               terminal, enrolamiento) tiene su propio flujo de UI distinto.
  *
  * @requires face-api.js cargado globalmente (faceapi) antes de invocar estas funciones.
  */

--- a/resources/views/attendances/device-link.blade.php
+++ b/resources/views/attendances/device-link.blade.php
@@ -175,7 +175,7 @@
 
                 // Almacenamiento provisorio del token — en la fase de sincronización offline
                 // (IndexedDB, módulo mobile-offline/) este valor pasa a vivir en su propio store,
-                // mismo patrón que usó terminal-setup.blade.php para el kiosko.
+                // mismo patrón que usó terminal-setup.blade.php para el terminal.
                 localStorage.setItem('nominapp_mobile_token', data.token);
                 localStorage.setItem('nominapp_mobile_employee_id', String(data.employee.id));
 

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -108,7 +108,7 @@
     </div>
 
     {{-- Estado de sincronización offline + sync manual — paridad con el botón "Sincronizar"
-    del kiosko (terminal-idle.blade.php). --}}
+    del terminal (terminal-idle.blade.php). --}}
     <div class="sync-status-row" id="syncStatusRow">
         <span class="sync-status-text" id="syncStatusText" aria-live="polite"></span>
         <button type="button" id="btnSyncNow" class="sync-status-btn" aria-label="Sincronizar marcaciones pendientes">

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,19 +11,19 @@ use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
-| API Routes — Sincronización offline vía PWA (kiosko y dispositivo personal)
+| API Routes — Sincronización offline vía PWA (terminal y dispositivo personal)
 |--------------------------------------------------------------------------
 |
 | Autenticadas con Laravel Sanctum. Sanctum resuelve el `tokenable` de forma
 | polimórfica (por `personal_access_tokens.tokenable_type`) — un mismo guard
-| `auth:sanctum` sirve tokens de `Terminal` (kiosko) y de `Employee`
+| `auth:sanctum` sirve tokens de `Terminal` y de `Employee`
 | (dispositivo personal) sin necesidad de guards/providers separados en
 | config/auth.php. Cada grupo abajo exige su propia ability.
 |
 */
 
-// Kiosko de sucursal — bearer token emitido al provisionar el terminal (ver
-// TerminalSetupController). Ability requerida: 'terminal:sync'.
+// Terminal compartido por sucursal — bearer token emitido al provisionarlo
+// (ver TerminalSetupController). Ability requerida: 'terminal:sync'.
 Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum'])->group(function () {
     Route::get('/employees/sync', [TerminalEmployeeSyncController::class, 'index'])
         ->middleware('ability:terminal:sync')
@@ -44,7 +44,7 @@ Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum']
 
 // Dispositivo personal del empleado — bearer token emitido al vincular el
 // dispositivo (ver MobileLinkController). Ability requerida: 'mobile:sync'.
-// A diferencia del kiosko (N empleados por terminal), acá el token identifica
+// A diferencia del terminal compartido (N empleados por dispositivo), acá el token identifica
 // a un único empleado (el propio dueño del token vía $request->user()), por
 // eso no existe un endpoint de "sync de empleados" — el heartbeat ya
 // devuelve el descriptor facial actualizado del propio empleado.

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,7 +52,7 @@ Route::get('/terminal', [AttendanceFaceMarkController::class, 'terminal'])->name
 Route::get('/terminal/{code}', [AttendanceFaceMarkController::class, 'terminalByCode'])->name('terminal.show');
 
 // Provisión del terminal como PWA offline — enlace de un solo uso generado desde TerminalResource,
-// emite el token Sanctum que el kiosko usará contra la API de sincronización (routes/api.php).
+// emite el token Sanctum que el terminal usará contra la API de sincronización (routes/api.php).
 // Prefijo explícito en el throttle: sin él, comparte bucket de rate limit (por
 // IP, sin distinguir ruta — ver ThrottleRequests::resolveRequestSignature())
 // con cualquier otra ruta pública que use 'throttle:X,Y' sin prefijo, como

--- a/tests/Feature/AdminNotificationsTest.php
+++ b/tests/Feature/AdminNotificationsTest.php
@@ -58,7 +58,7 @@ function makeNotifiableEmployee(): Employee
 it('notifica a los admins cuando un terminal completa su provisión', function () {
     $employee = makeNotifiableEmployee();
     $admin = User::create(['name' => 'Admin', 'email' => 'admin-term@test.com', 'password' => bcrypt('secret')]);
-    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $terminal = Terminal::create(['name' => 'Terminal Test', 'branch_id' => $employee->branch_id]);
 
     Notification::fake();
     $terminal->claimSanctumToken();
@@ -72,7 +72,7 @@ it('notifica a los admins cuando un terminal completa su provisión', function (
 
 it('la url de la notificación de terminal apunta al detalle real del recurso', function () {
     $employee = makeNotifiableEmployee();
-    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $terminal = Terminal::create(['name' => 'Terminal Test', 'branch_id' => $employee->branch_id]);
 
     $notification = new TerminalProvisionedNotification($terminal);
     $data = $notification->toDatabase(new User);
@@ -82,7 +82,7 @@ it('la url de la notificación de terminal apunta al detalle real del recurso', 
 
 it('la notificación de terminal provisionado también se envía por email', function () {
     $employee = makeNotifiableEmployee();
-    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $terminal = Terminal::create(['name' => 'Terminal Test', 'branch_id' => $employee->branch_id]);
 
     $notification = new TerminalProvisionedNotification($terminal);
 
@@ -90,7 +90,7 @@ it('la notificación de terminal provisionado también se envía por email', fun
 
     $mail = $notification->toMail(new User);
 
-    expect($mail->subject)->toBe('Terminal provisionado — Kiosko Test')
+    expect($mail->subject)->toBe('Terminal provisionado — Terminal Test')
         ->and($mail->actionUrl)->toBe(TerminalResource::getUrl('view', ['record' => $terminal]));
 });
 
@@ -219,7 +219,7 @@ it('la notificación de re-vinculación también se envía por email, la de prim
  */
 it('toDatabase() de cada notificación admin usa el formato de Filament (visible en la campanita)', function () {
     $employee = makeNotifiableEmployee();
-    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $terminal = Terminal::create(['name' => 'Terminal Test', 'branch_id' => $employee->branch_id]);
     $enrollment = FaceEnrollment::create([
         'employee_id' => $employee->id,
         'token' => Str::random(40),

--- a/tests/Feature/AttendanceEventSyncServiceTest.php
+++ b/tests/Feature/AttendanceEventSyncServiceTest.php
@@ -53,7 +53,7 @@ function makeSyncEmployee(): Employee
 function makeSyncTerminal(Employee $employee): Terminal
 {
     return Terminal::create([
-        'name' => 'Kiosko Test',
+        'name' => 'Terminal Test',
         'branch_id' => $employee->branch_id,
     ]);
 }
@@ -82,7 +82,7 @@ it('sincroniza un evento nuevo y lo marca con origen terminal', function () {
 });
 
 /**
- * Regresión: el kiosko manda recorded_at en UTC (Date.toISOString(), ej.
+ * Regresión: el terminal manda recorded_at en UTC (Date.toISOString(), ej.
  * "...T22:30:00.000Z"). Antes del fix, ese valor se persistía tal cual (sin
  * convertir a la timezone de la app), guardando la hora UTC "cruda" — un
  * evento marcado a las 19:30 en Paraguay (UTC-3) quedaba con recorded_at en
@@ -137,7 +137,7 @@ it('rechaza como conflict un evento cuya secuencia ya no es válida en el servid
     $terminal = makeSyncTerminal($employee);
     $service = app(AttendanceEventSyncService::class);
 
-    // El check_out ya llegó al servidor (ej. desde otro origen mientras el kiosko estaba offline).
+    // El check_out ya llegó al servidor (ej. desde otro origen mientras el terminal estaba offline).
     $service->syncBatch($terminal, [[
         'client_event_id' => (string) Str::uuid(),
         'employee_id' => $employee->id,
@@ -145,7 +145,7 @@ it('rechaza como conflict un evento cuya secuencia ya no es válida en el servid
         'recorded_at' => '2026-08-19 17:00:00',
     ]]);
 
-    // El kiosko recién ahora sincroniza un break_start que había capturado offline, antes del check_out.
+    // El terminal recién ahora sincroniza un break_start que había capturado offline, antes del check_out.
     $conflictingClientEventId = (string) Str::uuid();
     $results = $service->syncBatch($terminal, [[
         'client_event_id' => $conflictingClientEventId,

--- a/tests/Feature/EmployeePhotoThumbnailTest.php
+++ b/tests/Feature/EmployeePhotoThumbnailTest.php
@@ -88,14 +88,14 @@ it('un update que no toca la foto no regenera ni borra el thumbnail existente', 
     expect($employee->fresh()->photo_thumbnail)->toBe($originalThumbnail);
 });
 
-it('el delta de sincronización del kiosko incluye photo_thumbnail', function () {
+it('el delta de sincronización del terminal incluye photo_thumbnail', function () {
     Storage::fake('public');
     $path = UploadedFile::fake()->image('foto.jpg', 300, 200)->store('employees/photos', 'public');
     $employee = makePhotoEmployee([
         'photo' => $path,
         'face_descriptor' => array_fill(0, 128, 0.1),
     ]);
-    $terminal = Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $employee->branch_id]);
+    $terminal = Terminal::create(['name' => 'Terminal Test', 'branch_id' => $employee->branch_id]);
 
     $delta = app(EmployeeDescriptorSyncService::class)->deltaSince($terminal, null);
 

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -311,7 +311,7 @@ it('events/sync revoca el token y responde 403 si el empleado ya no está activo
 it('un token de terminal no puede usar las rutas móviles (ability distinta)', function () {
     $employee = makeLinkableEmployee();
     $terminal = Terminal::create([
-        'name' => 'Kiosko Test', 'branch_id' => $employee->branch_id,
+        'name' => 'Terminal Test', 'branch_id' => $employee->branch_id,
     ]);
     Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
 
@@ -347,7 +347,7 @@ it('unlink deja al empleado listo para vincular un dispositivo nuevo', function 
 it('un token de terminal no puede usar el endpoint de unlink móvil (ability distinta)', function () {
     $employee = makeLinkableEmployee();
     $terminal = Terminal::create([
-        'name' => 'Kiosko Test', 'branch_id' => $employee->branch_id,
+        'name' => 'Terminal Test', 'branch_id' => $employee->branch_id,
     ]);
     Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
 

--- a/tests/Feature/TerminalConnectivityTest.php
+++ b/tests/Feature/TerminalConnectivityTest.php
@@ -20,7 +20,7 @@ function makeConnectivityTerminal(): Terminal
     $company = Company::create(['name' => "Empresa Term {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
     $branch = Branch::create(['name' => "Sucursal Term {$n}", 'company_id' => $company->id]);
 
-    return Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $branch->id]);
+    return Terminal::create(['name' => 'Terminal Test', 'branch_id' => $branch->id]);
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -114,7 +114,7 @@ it('con al menos un conflicto, la cola de sync es conflict aunque también haya 
     expect($terminal->fresh()->sync_queue_status)->toBe('conflict');
 });
 
-it('el heartbeat guarda los contadores de cola que reporta el kiosko', function () {
+it('el heartbeat guarda los contadores de cola que reporta el terminal', function () {
     $terminal = makeConnectivityTerminal();
     Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
 
@@ -143,7 +143,7 @@ it('el heartbeat sin contadores no rompe y deja los contadores en null', functio
 });
 
 /**
- * Regresión: el título de pestaña ayuda a diferenciar kioskos de distintas
+ * Regresión: el título de pestaña ayuda a diferenciar terminales de distintas
  * sucursales cuando un admin monitorea varios a la vez — antes solo mostraba
  * el nombre del propio terminal, sin sucursal ni empresa.
  */

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -29,7 +29,7 @@ function makeProvisioningTerminal(): Terminal
     $company = Company::create(['name' => "Empresa Prov {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
     $branch = Branch::create(['name' => "Sucursal Prov {$n}", 'company_id' => $company->id]);
 
-    return Terminal::create(['name' => 'Kiosko Prov', 'branch_id' => $branch->id]);
+    return Terminal::create(['name' => 'Terminal Prov', 'branch_id' => $branch->id]);
 }
 
 function makeAttendanceEventForTerminal(Terminal $terminal, array $overrides = []): AttendanceEvent
@@ -41,7 +41,7 @@ function makeAttendanceEventForTerminal(Terminal $terminal, array $overrides = [
     $position = Position::create(['name' => "Cargo Term {$n}", 'department_id' => $department->id]);
 
     $employee = Employee::create([
-        'first_name' => 'Kiosko', 'last_name' => "Empleado {$n}", 'ci' => (string) $n,
+        'first_name' => 'Terminal', 'last_name' => "Empleado {$n}", 'ci' => (string) $n,
         'birth_date' => '1990-01-01', 'branch_id' => $terminal->branch_id, 'status' => 'active',
     ]);
     Contract::create([
@@ -201,7 +201,7 @@ it('claimSanctumToken() NO pisa marca/modelo cargados manualmente al reprovision
  * Regresión: producción tenía MAIL_MAILER=resend sin RESEND_KEY configurada.
  * claimSanctumToken() ya había consumido el setup_token (single-use) antes de
  * notificar a los admins, así que el TypeError de Resend::client() tumbaba el
- * request con 500 DESPUÉS de invalidar el enlace — el kiosko quedaba con
+ * request con 500 DESPUÉS de invalidar el enlace — el terminal quedaba con
  * "Server Error" y, al recargar, con "enlace inválido" sin haber recibido
  * nunca su token Sanctum. Un fallo de notificación nunca debe poder romper
  * la provisión ya persistida.

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -6,6 +6,7 @@ use App\Models\Branch;
 use App\Models\Company;
 use App\Models\Terminal;
 use App\Models\User;
+use Filament\Actions\ActionGroup;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
@@ -92,12 +93,19 @@ it('el redirect tras crear un terminal apunta a su vista con ?provision=1', func
         ->and($redirectUrl)->toEndWith('?provision=1');
 });
 
+/**
+ * revoke_token vive dentro del ActionGroup "Más acciones" — hay que
+ * aplanar los grupos con getFlatActions() para encontrarla, en vez de
+ * buscar directo en getCachedHeaderActions() (que solo devuelve el nivel
+ * superior: la acción individual quedaría anidada dentro del grupo).
+ */
 it('la acción "Revocar token" solo es visible en el detalle si el terminal tiene un token activo', function () {
     $this->actingAs(User::factory()->create());
     $terminal = makeProvisioningTerminal();
 
     $withoutToken = Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()]);
     $action = collect($withoutToken->instance()->getCachedHeaderActions())
+        ->flatMap(fn ($a) => $a instanceof ActionGroup ? $a->getFlatActions() : [$a])
         ->first(fn ($a) => $a->getName() === 'revoke_token');
 
     expect($action->isVisible())->toBeFalse();
@@ -106,6 +114,7 @@ it('la acción "Revocar token" solo es visible en el detalle si el terminal tien
 
     $withToken = Livewire::test(ViewTerminal::class, ['record' => $terminal->fresh()->getKey()]);
     $action = collect($withToken->instance()->getCachedHeaderActions())
+        ->flatMap(fn ($a) => $a instanceof ActionGroup ? $a->getFlatActions() : [$a])
         ->first(fn ($a) => $a->getName() === 'revoke_token');
 
     expect($action->isVisible())->toBeTrue();

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -2,8 +2,15 @@
 
 use App\Filament\Resources\TerminalResource\Pages\CreateTerminal;
 use App\Filament\Resources\TerminalResource\Pages\ViewTerminal;
+use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
 use App\Models\Branch;
 use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
 use App\Models\Terminal;
 use App\Models\User;
 use Filament\Actions\ActionGroup;
@@ -23,6 +30,41 @@ function makeProvisioningTerminal(): Terminal
     $branch = Branch::create(['name' => "Sucursal Prov {$n}", 'company_id' => $company->id]);
 
     return Terminal::create(['name' => 'Kiosko Prov', 'branch_id' => $branch->id]);
+}
+
+function makeAttendanceEventForTerminal(Terminal $terminal, array $overrides = []): AttendanceEvent
+{
+    static $ci = 9800000;
+    $n = $ci++;
+
+    $department = Department::create(['name' => "Depto Term {$n}", 'company_id' => $terminal->branch->company_id]);
+    $position = Position::create(['name' => "Cargo Term {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Kiosko', 'last_name' => "Empleado {$n}", 'ci' => (string) $n,
+        'birth_date' => '1990-01-01', 'branch_id' => $terminal->branch_id, 'status' => 'active',
+    ]);
+    Contract::create([
+        'employee_id' => $employee->id, 'type' => 'indefinido', 'start_date' => now()->subYear(),
+        'salary_type' => 'mensual', 'salary' => 2_550_000, 'position_id' => $position->id,
+        'department_id' => $department->id, 'status' => 'active',
+    ]);
+
+    $recordedAt = now();
+    $day = AttendanceDay::create(['employee_id' => $employee->id, 'date' => $recordedAt->toDateString(), 'status' => 'present']);
+
+    return AttendanceEvent::create(array_merge([
+        'attendance_day_id' => $day->id,
+        'employee_id' => $employee->id,
+        'employee_name' => $employee->full_name,
+        'employee_ci' => $employee->ci,
+        'event_type' => 'check_in',
+        'recorded_at' => $recordedAt,
+        'source' => 'terminal',
+        'terminal_id' => $terminal->id,
+        'branch_id' => $terminal->branch_id,
+        'branch_name' => $terminal->branch->name,
+    ], $overrides));
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -202,4 +244,44 @@ it('POST .../claim pasa el device_model_hint del cliente hasta el terminal provi
     $terminal->refresh();
     expect($terminal->device_brand)->toBe('Google')
         ->and($terminal->device_model)->toBe('Pixel 8 Pro');
+});
+
+// ─── RelationManager de marcaciones ────────────────────────────────────────
+
+it('el RelationManager de marcaciones renderiza en la ficha del terminal', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+    makeAttendanceEventForTerminal($terminal);
+
+    Livewire::test(AttendanceEventsRelationManager::class, [
+        'ownerRecord' => $terminal,
+        'pageClass' => ViewTerminal::class,
+    ])->assertOk();
+});
+
+it('el RelationManager de marcaciones solo muestra eventos de ese terminal, no de otros', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+    $otherTerminal = makeProvisioningTerminal();
+
+    $ownEvent = makeAttendanceEventForTerminal($terminal);
+    makeAttendanceEventForTerminal($otherTerminal);
+
+    $component = Livewire::test(AttendanceEventsRelationManager::class, [
+        'ownerRecord' => $terminal,
+        'pageClass' => ViewTerminal::class,
+    ]);
+
+    $component->assertCanSeeTableRecords([$ownEvent])
+        ->assertCountTableRecords(1);
+});
+
+it('el RelationManager de marcaciones es de solo lectura, sin acciones de fila', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+    makeAttendanceEventForTerminal($terminal);
+
+    $manager = new AttendanceEventsRelationManager;
+
+    expect($manager->isReadOnly())->toBeTrue();
 });


### PR DESCRIPTION
## Summary

**Reorganización de header actions en `ViewTerminal`** (revisión de UI/UX pedida sobre el detalle del terminal):
- Colores: `Desactivar` pasa de `danger` a `warning` (es reversible con un clic) — `danger` queda reservado para lo irreversible/de alto impacto (`Revocar token`, `Eliminar`).
- Las acciones menos frecuentes (`Regenerar código`/renombrada, `Revocar token`, `Eliminar`) se agrupan en un `ActionGroup` "Más acciones", mismo patrón que ya usa `ViewPayrollPeriod`.
- `"Regenerar código"` → **`"Cambiar URL del terminal"`** (ícono `heroicon-o-link`) — el nombre anterior sugería que afectaba la credencial de sincronización; en realidad son dos mecanismos independientes (URL pública vs. token Sanctum), ahora aclarado explícitamente en ambos modales.
- `"Generar enlace de configuración"` advierte, si el terminal ya tiene un token activo, que reclamar el enlace desde otro dispositivo revoca el acceso actual automáticamente (efecto real de `claimSanctumToken()`, antes sin ningún aviso).
- `"Borrar"` → `"Eliminar"` (consistencia con el resto del header), suma `"Sí, eliminar"` y advierte que las marcaciones históricas del terminal pierden la referencia a qué dispositivo físico las generó (`attendance_events.terminal_id` usa `nullOnDelete`).

**Nuevo `AttendanceEventsRelationManager`** en `TerminalResource` — `Terminal::attendanceEvents()` era la única relación `hasMany` del modelo sin RelationManager. Solo lectura (no hay `recordUrl()` posible: `AttendanceEventResource` solo tiene página `index`, sin `view` propia). Muestra fecha/hora, tipo de evento, empleado e indicador de `branch_mismatch`.

**Unifica "kiosko(s)" → "terminal(es)"** en todo el proyecto (52 archivos: `app/`, `routes/`, `resources/` JS/Blade/CSS, `database/migrations/`, `CLAUDE.md`, `README.md`, `docs/`, `tests/`, `public/sw.js`) — solo texto visible, comentarios/PHPDoc, documentación y fixtures de test. **No se toca** el prefijo interno `'kiosk:'` (inglés) del nombre de token Sanctum en `Terminal::claimSanctumToken()` — cambiarlo afectaría tokens ya emitidos a terminales provisionados en producción (Macro, Bar777, Arca, NextUp Demo), fuera de alcance de un cambio puramente terminológico.

## Test plan

- [x] `php artisan test` (suite completa) — 552+ passed, mismo único fallo preexistente.
- [x] Nuevos tests: `it('la acción "Revocar token" solo es visible...')` actualizado para aplanar el `ActionGroup` con `getFlatActions()`; 3 tests nuevos del `AttendanceEventsRelationManager` (renderiza, solo muestra eventos del propio terminal, es de solo lectura).
- [x] `php artisan test tests/Feature/TerminalProvisioningUiTest.php tests/Feature/TerminalConnectivityTest.php tests/Feature/AdminNotificationsTest.php tests/Feature/MobileAttendanceLinkTest.php tests/Feature/AttendanceEventSyncServiceTest.php tests/Feature/EmployeeDeviceTest.php tests/Feature/EmployeePhotoThumbnailTest.php` — todo pasa salvo un fallo preexistente y no relacionado (falta `public/build/manifest.json`, assets de Vite no compilados en el entorno de pruebas).
- [x] `vendor/bin/pint --dirty` — sin cambios de formato pendientes.
- [x] `node --check` sobre todos los `.js` modificados en el barrido de terminología.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_