### PR TITLE
Corrige que un token de sincronización viejo se reutilizaba en cualquier terminal

### DIFF
--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -87,12 +87,37 @@ export async function migrateTokenFromLocalStorage() {
     const legacyToken = localStorage.getItem('nominapp_terminal_token');
     if (!legacyToken) return;
 
+    const legacyId = localStorage.getItem('nominapp_terminal_id');
     const legacyCode = localStorage.getItem('nominapp_terminal_code');
     await setMeta('api_token', legacyToken);
+    if (legacyId) await setMeta('terminal_id', Number(legacyId));
     if (legacyCode) await setMeta('terminal_code', legacyCode);
 
     localStorage.removeItem('nominapp_terminal_token');
+    localStorage.removeItem('nominapp_terminal_id');
     localStorage.removeItem('nominapp_terminal_code');
+}
+
+/**
+ * Limpia todo el estado local ligado a la identidad de un terminal (token,
+ * empleados cacheados, cola de eventos, estado por empleado) — se usa cuando
+ * `initializeOfflineSync()` detecta que el `terminal_id`/`terminal_code`
+ * guardado no coincide con el de la página actual (`window.terminalData`):
+ * significa que este navegador ya reclamó un token de sincronización para
+ * OTRO terminal en algún momento (esta base de IndexedDB, `nominapp-terminal`,
+ * es única por navegador, no está separada por terminal), y sin esta
+ * limpieza seguiría autenticando/sincronizando en silencio como el terminal
+ * viejo en cualquier `/terminal/{code}` que se abra desde este dispositivo.
+ * @returns {Promise<void>}
+ */
+export async function clearTerminalState() {
+    const db = await getDb();
+    await Promise.all([
+        db.clear('terminal_meta'),
+        db.clear('employees_cache'),
+        db.clear('outbound_events'),
+        db.clear('employee_status_cache'),
+    ]);
 }
 
 /**

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,5 +1,5 @@
 import { captureFaceSamples } from '../shared/face-capture-core.js';
-import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees } from './terminal-offline/db.js';
+import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees, clearTerminalState } from './terminal-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './terminal-offline/matcher.js';
 import { heartbeat, syncEmployees, getFaceConfig, TerminalAuthError } from './terminal-offline/sync.js';
 import { getEmployeeStatus, enqueueMark, flushQueue, countPendingEvents, countConflictEvents } from './terminal-offline/queue.js';
@@ -1122,9 +1122,39 @@ document.addEventListener("DOMContentLoaded", () => {
      * arrancar el reposo. Si el terminal no está provisionado, no bloquea el
      * arranque — solo informa en la pantalla idle, la auto-identificación
      * fallará limpiamente con "terminal sin configurar" hasta que se resuelva.
+     *
+     * Regresión de seguridad: `nominapp-terminal` (IndexedDB) es una única
+     * base por navegador, no separada por terminal — sin este chequeo, un
+     * dispositivo que alguna vez reclamó un token para OTRO terminal seguía
+     * autenticando y sincronizando en silencio como ese terminal viejo al
+     * abrir la URL pública de cualquier terminal nuevo, sin pasar de nuevo
+     * por el enlace de configuración de un solo uso.
+     *
+     * Compara por `terminal_id` (estable) cuando está disponible, no por
+     * `terminal_code` — "Cambiar URL del terminal" cambia el code del MISMO
+     * terminal a propósito sin afectar el token (ver ViewTerminal), así que
+     * comparar solo por code trataría ese caso legítimo como si fuera un
+     * terminal distinto y borraría un token todavía válido. Cae a comparar
+     * por code únicamente en dispositivos provisionados antes de este fix,
+     * que todavía no tienen terminal_id guardado.
      */
     async function initializeOfflineSync() {
         await migrateTokenFromLocalStorage();
+
+        const storedId = await getMeta("terminal_id");
+        const storedCode = await getMeta("terminal_code");
+        const currentId = window.terminalData?.id;
+        const currentCode = window.terminalData?.code;
+
+        const belongsToOtherTerminal = (storedId != null && currentId != null)
+            ? storedId !== currentId
+            : (storedCode != null && currentCode != null && storedCode !== currentCode);
+
+        if (belongsToOtherTerminal) {
+            console.warn(`Datos locales pertenecen a otro terminal (id ${storedId ?? 'desconocido'}, code "${storedCode}") — limpiando antes de continuar.`);
+            await clearTerminalState();
+        }
+
         const token = await getMeta("api_token");
 
         if (!token) {

--- a/resources/views/attendances/terminal-setup.blade.php
+++ b/resources/views/attendances/terminal-setup.blade.php
@@ -107,8 +107,12 @@
 
                 // Almacenamiento provisorio del token — en la fase de sincronización offline
                 // (IndexedDB, módulo terminal-offline/) este valor pasa a vivir en el store
-                // `terminal_meta` en vez de localStorage.
+                // `terminal_meta` en vez de localStorage. Se guarda el id (estable, no cambia
+                // con "Cambiar URL del terminal") además del code (cambia con esa acción) —
+                // terminal.js usa el id para detectar si el estado local pertenece a OTRO
+                // terminal distinto, sin confundir un simple cambio de URL con eso.
                 localStorage.setItem('nominapp_terminal_token', data.token);
+                localStorage.setItem('nominapp_terminal_id', data.terminal.id);
                 localStorage.setItem('nominapp_terminal_code', data.terminal.code);
 
                 statusEl.textContent = 'Dispositivo vinculado correctamente. Redirigiendo...';


### PR DESCRIPTION
## Summary

**Bug de seguridad/integridad de datos reportado en producción (NextUp Demo):** un celular que había reclamado un enlace de configuración para un terminal, al abrir después la URL pública de un terminal **recién creado y nunca provisionado**, activó la cámara y marcó asistencia normalmente — usando el token y los empleados cacheados del terminal anterior.

**Causa raíz:** `nominapp-terminal` (IndexedDB) es una única base por navegador, no separada por terminal. `initializeOfflineSync()` en `terminal.js` leía el `api_token` guardado sin verificar que perteneciera al terminal identificado por la URL actual (`window.terminalData`). Cualquier dispositivo que alguna vez reclamó un enlace de configuración —para cualquier terminal, en cualquier momento— quedaba "armado" para siempre en ese navegador: visitar la URL pública de **otro** terminal (sin pasar por su propio enlace de un solo uso) reactivaba ese token viejo y los empleados cacheados, autenticando y sincronizando en silencio como el terminal equivocado mientras la pantalla mostraba el nombre/sucursal correcto.

**Fix:**
- `initializeOfflineSync()` ahora compara `terminal_id` (estable) contra `window.terminalData.id` antes de confiar en el token guardado; si no coincide, limpia todo el estado local (`clearTerminalState()`, nueva función en `db.js`) y trata el dispositivo como no provisionado para ese terminal.
- Se compara por `terminal_id` en vez de `terminal_code` a propósito: **"Cambiar URL del terminal"** (PR #114) cambia el `code` del MISMO terminal sin afectar el token — comparar solo por `code` habría tratado ese caso legítimo como un terminal distinto y borrado un token todavía válido, contradiciendo lo que ya le prometemos al admin en ese modal ("esto NO afecta el token de sincronización").
- Cae a comparar por `code` únicamente en dispositivos ya provisionados antes de este fix (sin `terminal_id` guardado todavía) — no rompe terminales que ya están funcionando en producción.
- `terminal-setup.blade.php` ahora también guarda `nominapp_terminal_id` en `localStorage` al reclamar un enlace, para que `migrateTokenFromLocalStorage()` lo migre a IndexedDB junto con el token/code.

## Test plan

- [x] `node --check` sobre `terminal.js` y `db.js` — sin errores de sintaxis.
- [x] Lógica de comparación (`belongsToOtherTerminal`) verificada manualmente con un script ad-hoc contra 6 casos límite: dispositivo nuevo, mismo terminal, terminal distinto, mismo terminal tras "Cambiar URL", y las dos variantes legacy sin `terminal_id` guardado — los 6 pasan. **Sin test automatizado in-repo**: el proyecto no tiene test runner de JS configurado (solo Pest/PHP).
- [x] `php artisan test tests/Feature/TerminalProvisioningUiTest.php tests/Feature/TerminalConnectivityTest.php tests/Feature/AdminNotificationsTest.php` — todo pasa salvo el fallo preexistente y no relacionado (falta `public/build/manifest.json`).
- [x] `vendor/bin/pint --dirty` — sin cambios de formato pendientes.
- [ ] **Pendiente de verificación manual real** (requiere `npm run build` + deploy): reproducir el bug reportado (celular con token viejo abre URL de un terminal nuevo) y confirmar que ahora muestra "Terminal sin configurar" en vez de activar la cámara.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_