### PR TITLE
Endurece el flujo de vinculación/provisión de terminales

### DIFF
--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -465,18 +465,53 @@ class TerminalResource extends Resource
                             Notification::make()->warning()->title('Terminal desactivada')->send();
                         }),
 
+                    Action::make('view_setup_link')
+                        ->label('Ver enlace de configuración')
+                        ->tooltip('Ver el enlace/QR de un solo uso todavía vigente, sin invalidarlo')
+                        ->icon('heroicon-o-qr-code')
+                        ->color('gray')
+                        ->visible(fn (Terminal $record) => static::hasValidSetupLink($record))
+                        ->modalHeading('Enlace de configuración del terminal')
+                        ->modalContent(fn (Terminal $record) => static::renderCurrentSetupLinkModal($record))
+                        ->modalSubmitAction(false)
+                        ->modalCancelActionLabel('Cerrar'),
+
+                    // "Generar enlace" (sin enlace vigente): un solo paso, sin confirmación —
+                    // abre el modal y genera+muestra el QR de inmediato, como ya funcionaba.
                     Action::make('generate_setup_link')
                         ->label('Generar enlace de configuración')
                         ->tooltip('Enlace/QR de un solo uso para vincular el dispositivo a la sincronización offline')
                         ->icon('heroicon-o-qr-code')
                         ->color('gray')
+                        ->visible(fn (Terminal $record) => ! static::hasValidSetupLink($record))
                         ->modalHeading('Enlace de configuración del terminal')
-                        // La generación del token ocurre dentro del propio contenido del modal
-                        // (evaluado al abrir) en vez de mountUsing/action, para no depender de un
-                        // formulario que esta acción no tiene — ver comentario en el método.
                         ->modalContent(fn (Terminal $record) => static::renderSetupLinkModal($record))
                         ->modalSubmitAction(false)
                         ->modalCancelActionLabel('Cerrar'),
+
+                    // "Generar nuevo enlace" (ya hay uno vigente): pide confirmación explícita
+                    // ANTES de generar — modalContent() se evalúa (con su efecto colateral) al
+                    // abrir el modal, no al confirmar, así que no se puede mostrar el QR nuevo
+                    // en el mismo paso sin invalidar el vigente antes de que el admin decida.
+                    // Genera y avisa por notificación; el QR nuevo se ve con "Ver enlace".
+                    Action::make('regenerate_setup_link')
+                        ->label('Generar nuevo enlace de configuración')
+                        ->tooltip('Invalida el enlace vigente y genera uno nuevo')
+                        ->icon('heroicon-o-arrow-path')
+                        ->color('gray')
+                        ->visible(fn (Terminal $record) => static::hasValidSetupLink($record))
+                        ->requiresConfirmation()
+                        ->modalHeading('¿Generar un enlace nuevo?')
+                        ->modalDescription('Ya existe un enlace de configuración vigente para este terminal. Generar uno nuevo invalida el anterior de inmediato, aunque todavía no haya sido usado.')
+                        ->modalSubmitActionLabel('Sí, generar uno nuevo')
+                        ->action(function (Terminal $record) {
+                            $record->generateSetupToken(30);
+                            Notification::make()
+                                ->success()
+                                ->title('Enlace nuevo generado')
+                                ->body('El enlace anterior quedó invalidado. Usá "Ver enlace de configuración" para verlo.')
+                                ->send();
+                        }),
 
                     Action::make('revoke_token')
                         ->label('Revocar token')
@@ -510,6 +545,17 @@ class TerminalResource extends Resource
     }
 
     /**
+     * Indica si el terminal tiene un enlace de configuración vigente sin
+     * reclamar — determina si la acción de tabla/header muestra "Ver enlace"
+     * (no destructivo) o "Generar enlace" (invalida el vigente, si lo hay).
+     */
+    public static function hasValidSetupLink(Terminal $record): bool
+    {
+        return $record->setup_token !== null
+            && $record->setup_token_expires_at?->isFuture();
+    }
+
+    /**
      * Genera un nuevo token de configuración de un solo uso para el terminal y
      * renderiza el modal con su URL/QR. Público porque lo usan tanto la acción
      * de tabla (`ListTerminals`) como el header action equivalente en
@@ -522,11 +568,25 @@ class TerminalResource extends Resource
      */
     public static function renderSetupLinkModal(Terminal $record): View
     {
-        $expiresInMinutes = 30;
-        $setupToken = $record->generateSetupToken($expiresInMinutes);
+        $setupToken = $record->generateSetupToken(30);
         $url = route('terminal.setup.show', ['code' => $record->code, 'setupToken' => $setupToken]);
+        $expiresAt = $record->setup_token_expires_at;
 
-        return view('filament.modals.terminal-setup-link', compact('url', 'expiresInMinutes'));
+        return view('filament.modals.terminal-setup-link', compact('url', 'expiresAt'));
+    }
+
+    /**
+     * Muestra el enlace de configuración YA vigente sin generar uno nuevo —
+     * a diferencia de `renderSetupLinkModal()`, no tiene efecto colateral.
+     * Solo debe usarse cuando `hasValidSetupLink()` es true (la acción que la
+     * invoca controla esa visibilidad).
+     */
+    public static function renderCurrentSetupLinkModal(Terminal $record): View
+    {
+        $url = route('terminal.setup.show', ['code' => $record->code, 'setupToken' => $record->setup_token]);
+        $expiresAt = $record->setup_token_expires_at;
+
+        return view('filament.modals.terminal-setup-link', compact('url', 'expiresAt'));
     }
 
     /**

--- a/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
@@ -73,11 +73,26 @@ class ViewTerminal extends ViewRecord
                     $this->refreshFormData(['status']);
                 }),
 
+            // "Ver enlace" (hay uno vigente sin usar): solo lectura, sin efecto colateral.
+            Action::make('view_setup_link')
+                ->label('Ver enlace de configuración')
+                ->tooltip('Ver el enlace/QR de un solo uso todavía vigente, sin invalidarlo')
+                ->icon('heroicon-o-qr-code')
+                ->color('gray')
+                ->visible(fn () => TerminalResource::hasValidSetupLink($this->record))
+                ->modalHeading('Enlace de configuración del terminal')
+                ->modalContent(fn () => TerminalResource::renderCurrentSetupLinkModal($this->record))
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Cerrar'),
+
+            // "Generar enlace" (sin enlace vigente): un solo paso, sin confirmación —
+            // abre el modal y genera+muestra el QR de inmediato, como ya funcionaba.
             Action::make('generate_setup_link')
                 ->label('Generar enlace de configuración')
                 ->tooltip('Enlace/QR de un solo uso para vincular el dispositivo a la sincronización offline')
                 ->icon('heroicon-o-qr-code')
                 ->color('gray')
+                ->visible(fn () => ! TerminalResource::hasValidSetupLink($this->record))
                 ->modalHeading('Enlace de configuración del terminal')
                 ->modalDescription(fn () => $this->record->tokens()->exists()
                     ? '⚠️ Este terminal ya está vinculado y sincronizando. Si otro dispositivo reclama este enlace, el acceso del terminal actual se revocará automáticamente.'
@@ -85,6 +100,37 @@ class ViewTerminal extends ViewRecord
                 ->modalContent(fn () => TerminalResource::renderSetupLinkModal($this->record))
                 ->modalSubmitAction(false)
                 ->modalCancelActionLabel('Cerrar'),
+
+            // "Generar nuevo enlace" (ya hay uno vigente): pide confirmación explícita
+            // ANTES de generar — modalContent() se evalúa (con su efecto colateral) al
+            // abrir el modal, no al confirmar, así que no se puede mostrar el QR nuevo
+            // en el mismo paso sin invalidar el vigente antes de que el admin decida.
+            // Genera y avisa por notificación; el QR nuevo se ve con "Ver enlace".
+            Action::make('regenerate_setup_link')
+                ->label('Generar nuevo enlace de configuración')
+                ->tooltip('Invalida el enlace vigente y genera uno nuevo')
+                ->icon('heroicon-o-arrow-path')
+                ->color('gray')
+                ->visible(fn () => TerminalResource::hasValidSetupLink($this->record))
+                ->requiresConfirmation()
+                ->modalHeading('¿Generar un enlace nuevo?')
+                ->modalDescription(function () {
+                    $base = 'Ya existe un enlace de configuración vigente para este terminal. Generar uno nuevo invalida el anterior de inmediato, aunque todavía no haya sido usado.';
+                    if ($this->record->tokens()->exists()) {
+                        $base .= ' ⚠️ Además, este terminal ya está vinculado y sincronizando — si otro dispositivo reclama el enlace nuevo, el acceso del terminal actual se revocará automáticamente.';
+                    }
+
+                    return $base;
+                })
+                ->modalSubmitActionLabel('Sí, generar uno nuevo')
+                ->action(function () {
+                    $this->record->generateSetupToken(30);
+                    Notification::make()
+                        ->success()
+                        ->title('Enlace nuevo generado')
+                        ->body('El enlace anterior quedó invalidado. Usá "Ver enlace de configuración" para verlo.')
+                        ->send();
+                }),
 
             EditAction::make()->label('Editar')->icon('heroicon-o-pencil-square')->color('primary'),
 

--- a/app/Http/Controllers/TerminalSetupController.php
+++ b/app/Http/Controllers/TerminalSetupController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Terminal;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 
@@ -30,12 +31,39 @@ class TerminalSetupController extends Controller
         return view('attendances.terminal-setup', compact('terminal', 'setupToken'));
     }
 
-    /** Reclama el enlace y emite el token Sanctum del terminal. Un solo uso. */
+    /**
+     * Reclama el enlace y emite el token Sanctum del terminal. Un solo uso.
+     *
+     * El check-y-consumo del setup_token corre bajo un `lockForUpdate()` en
+     * una transacción propia — sin esto, dos reclamos casi simultáneos del
+     * mismo enlace (ej. el QR escaneado dos veces por error, o un doble tap)
+     * podían pasar `isSetupTokenValid()` ambos antes de que ninguno hubiera
+     * guardado el null-out todavía, dejando dos tokens Sanctum válidos por un
+     * instante para el mismo terminal sin que ningún cliente supiera cuál
+     * quedó realmente vivo (el segundo `claimSanctumToken()` revoca al
+     * primero al crear el suyo). El lock serializa: el segundo reclamo espera
+     * a que el primero confirme el null-out y entonces `isSetupTokenValid()`
+     * ya lo rechaza correctamente con el 422 de siempre.
+     */
     public function claim(Request $request, string $code, string $setupToken): JsonResponse
     {
-        $terminal = Terminal::where('code', $code)->first();
+        $terminal = DB::transaction(function () use ($code, $setupToken) {
+            $terminal = Terminal::where('code', $code)->lockForUpdate()->first();
 
-        if (! $terminal || ! $terminal->isSetupTokenValid($setupToken)) {
+            if (! $terminal || ! $terminal->isSetupTokenValid($setupToken)) {
+                return null;
+            }
+
+            // Consume el setup_token ya dentro del lock — claimSanctumToken() más
+            // abajo (fuera del lock) vuelve a guardar setup_token=null (ya lo está,
+            // no-op) junto con el resto de su trabajo. No hace falta duplicar esa
+            // lógica acá, solo cerrar la ventana de la carrera.
+            $terminal->forceFill(['setup_token' => null, 'setup_token_expires_at' => null])->save();
+
+            return $terminal;
+        });
+
+        if (! $terminal) {
             Log::warning("Intento de reclamo de setup token inválido o expirado para terminal '{$code}'", [
                 'code' => $code,
                 'ip' => $request->ip(),

--- a/app/Notifications/TerminalProvisionedNotification.php
+++ b/app/Notifications/TerminalProvisionedNotification.php
@@ -11,10 +11,16 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 /**
- * Notificación a los admins cuando un terminal completa su
- * provisión (reclama el enlace de configuración de un solo uso y recibe
- * su token Sanctum) — confirma que la instalación física salió bien sin
- * que un admin tenga que entrar a revisar `last_heartbeat_at` a mano.
+ * Notificación a los admins cuando un terminal reclama el enlace de
+ * configuración de un solo uso y recibe su token Sanctum.
+ *
+ * No confirma que la instalación física haya salido bien — solo que el
+ * servidor emitió el token. Si la respuesta HTTP nunca llega al dispositivo
+ * (ej. se corta la red justo después de que el servidor la generó), esta
+ * notificación se dispara igual aunque el terminal físico se haya quedado
+ * sin token — por eso el wording pide verificar Conectividad en vez de dar
+ * la instalación por confirmada. Ver columna "Conectividad" en
+ * `TerminalResource` (`never_connected` hasta el primer heartbeat exitoso).
  */
 class TerminalProvisionedNotification extends Notification
 {
@@ -41,7 +47,8 @@ class TerminalProvisionedNotification extends Notification
     {
         return (new MailMessage)
             ->subject('Terminal provisionado — '.$this->terminal->name)
-            ->line("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.")
+            ->line("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) reclamó su token de sincronización.")
+            ->line('Verificá el estado de Conectividad en unos minutos para confirmar que el dispositivo físico quedó sincronizando con normalidad.')
             ->action('Ver terminal', TerminalResource::getUrl('view', ['record' => $this->terminal]));
     }
 
@@ -60,7 +67,7 @@ class TerminalProvisionedNotification extends Notification
         return [
             ...FilamentNotification::make()
                 ->title('Terminal provisionado')
-                ->body("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) completó su configuración y ya está listo para marcar asistencia.")
+                ->body("El terminal \"{$this->terminal->name}\" ({$this->terminal->branch?->name}) reclamó su token de sincronización. Verificá Conectividad en unos minutos para confirmar que quedó sincronizando.")
                 ->icon('heroicon-o-computer-desktop')
                 ->success()
                 ->actions([

--- a/resources/views/filament/modals/terminal-setup-link.blade.php
+++ b/resources/views/filament/modals/terminal-setup-link.blade.php
@@ -2,7 +2,11 @@
 <div class="space-y-4">
     <p class="text-sm text-gray-600 dark:text-gray-300">
         Abra este enlace <strong>una sola vez, con el dispositivo conectado a internet</strong>, durante la instalación
-        física del terminal. Vence en <strong>{{ $expiresInMinutes }} minutos</strong> y no puede reutilizarse.
+        física del terminal. No puede reutilizarse.
+    </p>
+
+    <p class="text-sm text-gray-600 dark:text-gray-300">
+        Vence: <strong>{{ $expiresAt->translatedFormat('l d/m/Y H:i') }}</strong> ({{ $expiresAt->diffForHumans() }})
     </p>
 
     <div class="flex justify-center">
@@ -11,8 +15,16 @@
         </div>
     </div>
 
-    <div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-3 text-xs break-all font-mono text-gray-700 dark:text-gray-300">
-        {{ $url }}
+    <div x-data="{ copied: false }" class="flex items-center gap-2 rounded-lg bg-gray-50 dark:bg-gray-800 p-3">
+        <span class="flex-1 text-xs break-all font-mono text-gray-700 dark:text-gray-300">{{ $url }}</span>
+        <button
+            type="button"
+            x-on:click="navigator.clipboard.writeText(@js($url)); copied = true; setTimeout(() => copied = false, 2000)"
+            class="shrink-0 rounded-md bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+        >
+            <span x-show="!copied">Copiar</span>
+            <span x-show="copied" x-cloak>¡Copiado!</span>
+        </button>
     </div>
 
     <p class="text-xs text-gray-500 dark:text-gray-400">

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Filament\Resources\TerminalResource;
 use App\Filament\Resources\TerminalResource\Pages\CreateTerminal;
 use App\Filament\Resources\TerminalResource\Pages\ViewTerminal;
 use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
@@ -284,4 +285,70 @@ it('el RelationManager de marcaciones es de solo lectura, sin acciones de fila',
     $manager = new AttendanceEventsRelationManager;
 
     expect($manager->isReadOnly())->toBeTrue();
+});
+
+// ─── Endurecimiento del flujo de vinculación (Ver/Generar enlace, carrera) ──
+
+/**
+ * Regresión: claim() ahora corre el check-y-consumo del setup_token bajo un
+ * lockForUpdate() para cerrar la ventana de carrera entre dos reclamos casi
+ * simultáneos — este test confirma que el comportamiento de un solo uso
+ * sigue intacto para el caso simple (secuencial) tras ese cambio.
+ */
+it('reclamar un enlace de configuración ya usado falla con 422 — un solo uso', function () {
+    $terminal = makeProvisioningTerminal();
+    $setupToken = $terminal->generateSetupToken();
+
+    $this->postJson("/terminal/{$terminal->code}/setup/{$setupToken}/claim")
+        ->assertOk()
+        ->assertJson(['ok' => true]);
+
+    $this->postJson("/terminal/{$terminal->code}/setup/{$setupToken}/claim")
+        ->assertStatus(422)
+        ->assertJson(['ok' => false]);
+});
+
+it('"Generar enlace" está visible sin enlace vigente; "Ver enlace" y "Generar nuevo" aparecen tras generar uno', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    $withoutLink = collect(
+        Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()])->instance()->getCachedHeaderActions()
+    );
+    expect($withoutLink->first(fn ($a) => $a->getName() === 'generate_setup_link')?->isVisible())->toBeTrue();
+    expect($withoutLink->first(fn ($a) => $a->getName() === 'view_setup_link')?->isVisible())->toBeFalse();
+    expect($withoutLink->first(fn ($a) => $a->getName() === 'regenerate_setup_link')?->isVisible())->toBeFalse();
+
+    $terminal->generateSetupToken();
+
+    $withLink = collect(
+        Livewire::test(ViewTerminal::class, ['record' => $terminal->fresh()->getKey()])->instance()->getCachedHeaderActions()
+    );
+    expect($withLink->first(fn ($a) => $a->getName() === 'generate_setup_link')?->isVisible())->toBeFalse();
+    expect($withLink->first(fn ($a) => $a->getName() === 'view_setup_link')?->isVisible())->toBeTrue();
+    expect($withLink->first(fn ($a) => $a->getName() === 'regenerate_setup_link')?->isVisible())->toBeTrue();
+});
+
+it('TerminalResource::renderCurrentSetupLinkModal() no genera un token nuevo, a diferencia de renderSetupLinkModal()', function () {
+    $terminal = makeProvisioningTerminal();
+    $setupToken = $terminal->generateSetupToken();
+
+    TerminalResource::renderCurrentSetupLinkModal($terminal);
+    expect($terminal->fresh()->setup_token)->toBe($setupToken);
+
+    TerminalResource::renderSetupLinkModal($terminal);
+    expect($terminal->fresh()->setup_token)->not->toBe($setupToken);
+});
+
+it('"Generar nuevo enlace" invalida el enlace vigente y notifica en vez de mostrar el QR en el mismo paso', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+    $oldToken = $terminal->generateSetupToken();
+
+    Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()])
+        ->callAction('regenerate_setup_link')
+        ->assertHasNoActionErrors();
+
+    expect($terminal->fresh()->setup_token)->not->toBeNull()
+        ->and($terminal->fresh()->setup_token)->not->toBe($oldToken);
 });


### PR DESCRIPTION
## Summary

Revisión de UX/robustez del flujo completo de vinculación y provisión de terminales, a partir de los bugs cerrados en PRs #112–#115.

- **Botón de copiar** en el modal de "Enlace de configuración" (Alpine.js) — antes había que seleccionar el texto manualmente; el campo "Código de terminal" en la misma ficha ya tenía `->copyable()`, esto lo hace consistente.

- **Separa "Ver enlace de configuración" de "Generar enlace"/"Generar nuevo enlace"**, mismo patrón que ya usa `FaceEnrollmentResource` ("Ver Enlace"/"Regenerar Enlace"):
  - Sin enlace vigente → **"Generar enlace de configuración"**: un solo paso, sin confirmación, igual que antes.
  - Con enlace vigente → **"Ver enlace de configuración"** (solo lectura, sin efecto colateral) y **"Generar nuevo enlace de configuración"** (pide confirmación explícita antes de invalidar el vigente).
  - Antes, cada clic en "Generar enlace" invalidaba de inmediato cualquier enlace anterior sin usar — reabrir el modal por error, o generar uno nuevo mientras el primero seguía en tránsito hacia el técnico instalando el dispositivo, lo rompía sin ningún aviso.
  - Nota técnica: `modalContent()` en Filament se evalúa (con su efecto colateral de generar el token) al *abrir* el modal, no al confirmar — por eso "Generar nuevo enlace" no puede mostrar el QR en el mismo paso sin arriesgarse a invalidar el vigente antes de que el admin decida; genera y notifica, y el QR nuevo se ve después con "Ver enlace".

- **Cierra una race condition real** en `TerminalSetupController::claim()`: el check-y-consumo del `setup_token` ahora corre bajo `lockForUpdate()` dentro de una transacción. Sin esto, dos reclamos casi simultáneos del mismo enlace (doble tap, QR escaneado dos veces) podían pasar la validación ambos antes de que ninguno hubiera guardado el null-out, dejando dos tokens Sanctum válidos por un instante sin que ningún cliente supiera cuál quedó vivo.

- **`TerminalProvisionedNotification` más honesta**: ya no afirma "la instalación física salió bien" — solo confirma que el servidor emitió el token, y pide verificar la columna Conectividad. Si el `claim()` se completa en el servidor pero la respuesta HTTP nunca llega al dispositivo (ej. se corta la red justo después), la notificación anterior sonaba a éxito confirmado aunque el terminal físico se hubiera quedado sin token.

## Test plan

- [x] `php artisan test tests/Feature/TerminalProvisioningUiTest.php` — 18 tests, incluye 4 nuevos: un solo uso del `setup_token` tras el fix de la carrera, visibilidad mutuamente excluyente de Ver/Generar/Generar nuevo enlace, que `renderCurrentSetupLinkModal()` no tiene efecto colateral (a diferencia de `renderSetupLinkModal()`), y que "Generar nuevo enlace" invalida el enlace vigente vía notificación.
- [x] `php artisan test` (suite completa) — 559 passed, único fallo preexistente y no relacionado (falta `public/build/manifest.json`).
- [x] `vendor/bin/pint --dirty` — sin cambios de formato pendientes.
- [x] `php -l` sobre el Blade modificado — sin errores de sintaxis.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_