### PR TITLE
Revisión completa de TerminalResource: formulario, listado, infolist y relación con Empresa/Sucursal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,10 @@ Dos dispositivos marcan asistencia por reconocimiento facial (face-api.js, 100% 
 
 **Notificaciones por email:** `MobileDeviceLinkedNotification`/`MobileDeviceRelinkedNotification`/`TerminalProvisionedNotification` tienen canal `mail` además de `database` — llegan a todos los `User::all()`.
 
+**`notify()` nunca debe invalidar una operación ya persistida:** `Terminal::claimSanctumToken()` y `Employee::claimMobileToken()` envuelven la llamada a `User::all()->each->notify(...)` en `try/catch` con `Log::warning()` en el catch. Un fallo del mailer (SMTP caído, credenciales vencidas, etc.) no debe hacer que el endpoint responda 500 y deje sin token a un dispositivo que ya fue provisionado en la base de datos — el dato crítico (token, vínculo) ya está guardado antes de notificar; la notificación es best-effort.
+
+**Estado offline cruzado entre dispositivos (IndexedDB):** antes de confiar en el token cacheado localmente, `terminal.js`/`mark.js` comparan el `terminal_id`/`terminal_code` (o el id del empleado, en el celular) guardado en IndexedDB contra el actual (`window.terminalData` / dato server-side). Si no coinciden, se asume que el navegador tiene el estado de OTRO terminal/dispositivo (mismo navegador reutilizado para abrir dos enlaces de configuración distintos) y se limpia todo el estado local (`clearTerminalState()` en `db.js`: `terminal_meta`, `employees_cache`, `outbound_events`, `employee_status_cache`) antes de sincronizar — de lo contrario el segundo dispositivo terminaría marcando asistencia con el token del primero.
+
 **Gotcha de throttle compartido (recurrente — revisar en cualquier ruta pública nueva):** `Illuminate\Routing\Middleware\ThrottleRequests::resolveRequestSignature()` genera la clave del rate limit solo con dominio+IP, **sin distinguir ruta ni parámetros del middleware** (`maxAttempts`/`decayMinutes`). Dos rutas públicas distintas con `throttle:X,Y` sin prefijo comparten el mismo bucket por IP — agotar el límite de una bloquea también a la otra. **Siempre** usar un tercer parámetro de prefijo único: `throttle:10,1,mi-prefijo-unico`. Ya corregido en `terminal.setup` (`terminal-setup`), `registro-facial` (`face-enrollment`) y `vincular-dispositivo` (`device-link-show`/`device-link-minute`/`device-link-day`) — todas las rutas públicas actuales del proyecto ya tienen prefijo explícito.
 
 ### Service Layer
@@ -635,6 +639,8 @@ public static function getShiftTypeColors(): array   // para colores de badges
 ->color(fn($state) => Schedule::getShiftTypeColors()[$state] ?? 'gray')
 ```
 
+**Concordancia de género gramatical:** los labels deben concordar con el género que el resto del proyecto usa para esa entidad, no con el género "por defecto" de la palabra en español. Ej: `Terminal::getStatusOptions()` decía `'active' => 'Activa'` (femenino, como si "la terminal"), pero todo el código y la documentación del proyecto se refieren a "**el** terminal" (masculino, como el dispositivo/kiosko) — el label correcto es `'Activo'`. Revisar cómo se refiere el resto del código/UI a la entidad antes de fijar el género del label, no asumirlo por la palabra sola.
+
 ### Descargas de archivos desde acciones Filament
 
 Las acciones Filament corren via Livewire (AJAX) y **no pueden retornar respuestas binarias** desde `->action()` — causa `Malformed UTF-8` al serializar a JSON.
@@ -814,6 +820,9 @@ if (filled($state['ic_salary'] ?? null) && filled($state['ic_position_id'] ?? nu
 ```
 
 ### Filament Forms — convenciones adicionales
+
+**`modalContent()` se evalúa al ABRIR el modal, no al confirmar**
+Si `->modalContent()` ejecuta un side-effect (ej. generar y persistir un nuevo token), ese efecto corre **cada vez que el modal se abre** — incluyendo si el usuario lo cierra sin confirmar, o si Livewire vuelve a renderizar el componente. No se puede combinar `->requiresConfirmation()` + `->modalContent()` con side-effects esperando que el efecto ocurra recién al enviar el formulario del modal — eso rompe la semántica de "confirmar antes de ejecutar". Si la acción necesita mostrar el resultado de un side-effect (ej. el QR de un token recién generado) **y** requerir confirmación cuando ya existe un estado previo, separar en dos `Action` distintas con visibilidad mutuamente excluyente: una sin confirmación que genera-y-muestra (caso "no hay nada aún"), otra con `->requiresConfirmation()` que genera en `->action()` (evaluado al confirmar) y notifica en vez de mostrar el contenido inline (caso "ya existe algo, reemplazar"). Ver `TerminalResource::view_setup_link` / `generate_setup_link` / `regenerate_setup_link`.
 
 **`->live()` en lugar de `->reactive()`**
 `->reactive()` está deprecado en Filament 3. Siempre usar `->live()`.
@@ -1374,6 +1383,30 @@ MySQL en modo estricto exige que **todas las columnas no agregadas del SELECT es
 
 Las columnas calculadas por subquery en el SELECT (`DB::raw('(SELECT ...) AS alias')`) **no** necesitan ir en GROUP BY.
 
+### Tokens de un solo uso — evitar race conditions con `lockForUpdate()`
+
+Cualquier flujo de "reclamar/consumir" un token de un solo uso (setup links, invitaciones, etc.) debe leer y anular el token dentro de la **misma transacción con lock**, no en pasos separados — de lo contrario dos requests casi simultáneos (doble click, reintento de red) pueden pasar ambos la validación antes de que el primero anule el token, emitiendo dos credenciales para un solo enlace.
+
+```php
+$terminal = DB::transaction(function () use ($code, $setupToken) {
+    $terminal = Terminal::where('code', $code)->lockForUpdate()->first();
+
+    if (! $terminal || ! $terminal->isSetupTokenValid($setupToken)) {
+        return null;
+    }
+
+    $terminal->forceFill(['setup_token' => null, 'setup_token_expires_at' => null])->save();
+
+    return $terminal;
+});
+
+if (! $terminal) {
+    // token inválido, ya usado, o expirado
+}
+```
+
+El `lockForUpdate()` serializa las transacciones concurrentes sobre esa fila — la segunda espera a que la primera confirme el `forceFill` y entonces ve el token ya nulo. Ver `TerminalSetupController::claim()`.
+
 ### Deployment a producción — Cliente Macro (Sedacosmetica)
 
 **Servidor propio del cliente Macro (Sedacosmetica):** `sedvouco@bh7104` — CentOS, cPanel, PHP 8.2 via `/opt/cpanel/ea-php82/root/usr/bin/php`, Node 16 (sin RAM suficiente para Vite build). Esta sección aplica únicamente a la instalación de Macro; ver la sección siguiente para Bar777/Arca (infraestructura de TechForge, mecanismo distinto).
@@ -1519,6 +1552,25 @@ Select::make('employee_id')
 **Caso límite más grave: `titleAttribute` omitido por completo** (`->relationship('perception', modifyQueryUsing: ...)` sin segundo argumento) — sin `searchable([...])` explícito, `getSearchColumns()` retorna `null` y el buscador queda **completamente inerte**: no filtra nada, ni siquiera devuelve cero resultados, simplemente ignora lo que el usuario escribe.
 
 **Regla:** todo `Select::make(...)->relationship(...)->searchable()` que también tenga `->getOptionLabelFromRecordUsing()` debe pasarle a `searchable()` un array explícito con **todas** las columnas que aparecen en ese label override — nunca dejarlo sin argumentos cuando el label muestra más de una columna. Aplica igual a `SelectFilter::make(...)` en tablas (mismo mecanismo, ver `vendor/filament/tables/src/Filters/SelectFilter.php:260` `getFormField()`).
+
+### `Select::relationship()` con `modifyQueryUsing` puede vaciar el valor ya seleccionado
+
+`modifyQueryUsing` en `->relationship($name, $titleAttribute, $modifyQueryUsing)` no solo filtra las opciones listadas — también filtra la query que Filament usa internamente para resolver el label del valor **ya seleccionado** (`getSelectedRecordUsing()`, ver `vendor/filament/forms/src/Components/Select.php`). Si el closure excluye registros "inactivos" (ej. sucursales de empresas dadas de baja) y el registro editado tiene justo uno de esos como valor actual, el campo se muestra vacío al entrar a editar — aunque el dato siga guardado correctamente en la base.
+
+**Correcto — OR-ear el id ya asignado del record actual** (Filament inyecta `$record` por utility injection en el closure):
+```php
+Select::make('branch_id')
+    ->relationship('branch', 'name', modifyQueryUsing: fn (Builder $query, ?Terminal $record) => $query
+        ->where(function (Builder $query) use ($record) {
+            $query->whereHas('company', fn (Builder $query) => $query->active());
+
+            if ($record?->branch_id) {
+                $query->orWhere('id', $record->branch_id);
+            }
+        }))
+```
+
+Sin el `orWhere`, la sucursal actual desaparece de las opciones **y** del label mostrado en el edit — el usuario vería el select vacío y, si guarda sin darse cuenta, perdería la asignación.
 
 ### Nullsafe en propiedades de relaciones en closures de columnas Filament
 
@@ -1727,6 +1779,12 @@ Cuando un recurso tiene múltiples row actions que pueden aparecer condicionalme
 
 Agregar `->tooltip()` a cada acción cuando varias tienen propósito similar y el label solo no basta para diferenciarlas.
 
+**Testing:** una vez agrupadas dentro de un `ActionGroup` (tabla o header actions de página), `getCachedTableActions()`/`getCachedHeaderActions()` ya no devuelven esas acciones como items de nivel superior — `assertTableActionHidden()`/`assertActionHidden()` sobre el nombre de la acción puede dejar de encontrarla. Si el test necesita inspeccionar acciones dentro de un grupo, aplanarlas primero:
+```php
+$actions = collect($livewire->instance()->getCachedHeaderActions())
+    ->flatMap(fn ($a) => $a instanceof \Filament\Actions\ActionGroup ? $a->getFlatActions() : [$a]);
+```
+
 ### Filtrar solo empleados activos en selects de modales
 
 Cualquier `Select` de empleado en formularios de acciones (modales) debe filtrar `where('status', 'active')` — nunca mostrar empleados desvinculados o inactivos como opción seleccionable:
@@ -1871,6 +1929,32 @@ Schedule::command('foo:expire')->dailyAt('00:05')->withoutOverlapping();
 ```
 
 Usar `now()->startOfDay()` (no `now()`) para evitar que registros que vencen hoy a medianoche se salteen por segundos de diferencia.
+
+### Notificaciones de campanita — construir `toDatabase()` con `Filament\Notifications\Notification`
+
+Una clase `Notification` de Laravel con canal `database` que retorna un **array plano** en `toDatabase()` persiste el registro en `notifications` y el mail (si tiene canal `mail`) llega con normalidad, pero la campanita del panel Filament **no la muestra** — Filament espera que `data` tenga el formato que genera su propio builder (incluye `data->format = 'filament'`, `title`, `body`, `icon`, `iconColor`, `actions`, etc.).
+
+**Correcto:**
+```php
+public function toDatabase(object $notifiable): array
+{
+    return \Filament\Notifications\Notification::make()
+        ->title('Terminal provisionado')
+        ->body("El terminal \"{$this->terminal->name}\" reclamó su token de sincronización.")
+        ->icon('heroicon-o-computer-desktop')
+        ->success() // o ->warning()/->danger()
+        ->actions([
+            \Filament\Notifications\Actions\Action::make('view')
+                ->label('Ver terminal')
+                ->url(TerminalResource::getUrl('view', ['record' => $this->terminal])),
+        ])
+        ->getDatabaseMessage() + [
+            'entity_id' => $this->terminal->id, // claves extra propias, ej. para deduplicación
+        ];
+}
+```
+
+Aplica a toda notificación de BD que deba aparecer en la campanita del panel — no solo a canal `mail`+`database` combinados.
 
 ### Deduplicación de notificaciones de campanita
 

--- a/app/Filament/Resources/BranchResource.php
+++ b/app/Filament/Resources/BranchResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\BranchResource\Pages;
 use App\Filament\Resources\BranchResource\RelationManagers\EmployeesRelationManager;
+use App\Filament\Resources\BranchResource\RelationManagers\TerminalsRelationManager;
 use App\Models\Branch;
 use App\Models\Company;
 use Cheesegrits\FilamentGoogleMaps\Fields\Map;
@@ -321,6 +322,7 @@ class BranchResource extends Resource
     {
         return [
             EmployeesRelationManager::class,
+            TerminalsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/BranchResource/RelationManagers/TerminalsRelationManager.php
+++ b/app/Filament/Resources/BranchResource/RelationManagers/TerminalsRelationManager.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Filament\Resources\BranchResource\RelationManagers;
+
+use App\Filament\Resources\TerminalResource;
+use App\Models\Terminal;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * Terminales de marcación de la sucursal — solo lectura. Crear, editar y
+ * las acciones de ciclo de vida (activar, revocar token, etc.) se hacen
+ * desde el módulo Terminales.
+ */
+class TerminalsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'terminals';
+
+    protected static ?string $title = 'Terminales';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordUrl(fn (Terminal $record) => TerminalResource::getUrl('view', ['record' => $record]))
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Nombre')
+                    ->icon('heroicon-o-computer-desktop')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('code')
+                    ->label('Código')
+                    ->badge()
+                    ->color('gray')
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('status')
+                    ->label('Estado')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state) => Terminal::getStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
+                    ->sortable(),
+
+                TextColumn::make('connectivity_status')
+                    ->label('Conectividad')
+                    ->badge()
+                    ->tooltip('Basado en el último heartbeat exitoso de sincronización offline')
+                    ->formatStateUsing(fn (string $state) => Terminal::getConnectivityStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => Terminal::getConnectivityStatusColors()[$state] ?? 'gray'),
+
+                TextColumn::make('last_heartbeat_at')
+                    ->label('Último heartbeat')
+                    ->since()
+                    ->placeholder('Nunca')
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->paginationPageOptions([10, 25, 50, 100])
+            ->actions([])
+            ->bulkActions([])
+            ->emptyStateHeading('Sin terminales en esta sucursal')
+            ->emptyStateDescription('Los terminales de marcación asignados a esta sucursal aparecerán acá.')
+            ->emptyStateIcon('heroicon-o-computer-desktop');
+    }
+}

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -468,7 +468,7 @@ class TerminalResource extends Resource
                     Action::make('deactivate')
                         ->label('Desactivar')
                         ->icon('heroicon-o-x-circle')
-                        ->color('danger')
+                        ->color('warning')
                         ->visible(fn (Terminal $record) => $record->isActive())
                         ->requiresConfirmation()
                         ->modalHeading('Desactivar terminal')
@@ -549,7 +549,9 @@ class TerminalResource extends Resource
             ])
             ->bulkActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->modalDescription('Esta acción no se puede deshacer. Las marcaciones ya registradas con los terminales seleccionados no se eliminan, pero perderán la referencia a qué dispositivo físico las generó.')
+                        ->modalSubmitActionLabel('Sí, eliminar'),
                 ]),
             ])
             ->defaultSort('created_at', 'desc')

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\TerminalResource\Pages;
 use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
+use App\Models\Company;
 use App\Models\Terminal;
 use App\Settings\GeneralSettings;
 use Filament\Forms\Components\DatePicker;
@@ -335,6 +336,15 @@ class TerminalResource extends Resource
                     ->searchable()
                     ->sortable(),
 
+                TextColumn::make('branch.company.name')
+                    ->label('Empresa')
+                    ->icon('heroicon-o-building-office-2')
+                    ->badge()
+                    ->color('primary')
+                    ->searchable()
+                    ->sortable()
+                    ->visible(fn () => Company::active()->count() > 1),
+
                 TextColumn::make('branch.name')
                     ->label('Sucursal')
                     ->badge()
@@ -399,6 +409,17 @@ class TerminalResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
+                SelectFilter::make('company_id')
+                    ->label('Empresa')
+                    ->options(fn () => Company::active()->orderBy('name')->pluck('name', 'id'))
+                    ->searchable()
+                    ->native(false)
+                    ->visible(fn () => Company::active()->count() > 1)
+                    ->query(fn (Builder $query, array $data) => filled($data['value'] ?? null)
+                        ? $query->whereHas('branch', fn ($q) => $q->where('company_id', $data['value']))
+                        : $query
+                    ),
+
                 SelectFilter::make('branch_id')
                     ->label('Sucursal')
                     ->relationship('branch', 'name')

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -69,7 +69,20 @@ class TerminalResource extends Resource
 
                         Select::make('branch_id')
                             ->label('Sucursal')
-                            ->relationship('branch', 'name')
+                            // Excluye sucursales de empresas inactivas de las opciones — pero
+                            // nunca de la sucursal YA asignada al editar: modifyQueryUsing()
+                            // también filtra la query que resuelve la etiqueta del valor
+                            // actual (Select::getSelectedRecordUsing()), así que sin el OR con
+                            // $record?->branch_id, editar un terminal cuya empresa se
+                            // desactivó después dejaría el campo en blanco.
+                            ->relationship('branch', 'name', modifyQueryUsing: fn (Builder $query, ?Terminal $record) => $query
+                                ->where(function (Builder $query) use ($record) {
+                                    $query->whereHas('company', fn (Builder $query) => $query->active());
+
+                                    if ($record?->branch_id) {
+                                        $query->orWhere('id', $record->branch_id);
+                                    }
+                                }))
                             ->searchable()
                             ->preload()
                             ->native(false)
@@ -78,6 +91,7 @@ class TerminalResource extends Resource
                         Select::make('status')
                             ->label('Estado')
                             ->options(Terminal::getStatusOptions())
+                            ->helperText('Un terminal inactivo no puede marcar asistencia, aunque conserve su token de sincronización.')
                             ->native(false)
                             ->default('active')
                             ->required(),
@@ -209,22 +223,22 @@ class TerminalResource extends Resource
                         InfoGrid::make(3)->schema([
                             TextEntry::make('device_brand')
                                 ->label('Marca')
-                                ->placeholder('-'),
+                                ->placeholder('Sin datos'),
 
                             TextEntry::make('device_model')
                                 ->label('Modelo')
-                                ->placeholder('-'),
+                                ->placeholder('Sin datos'),
 
                             TextEntry::make('device_serial')
                                 ->label('Número de Serie')
                                 ->copyable()
-                                ->placeholder('-'),
+                                ->placeholder('Sin datos'),
                         ]),
 
                         TextEntry::make('device_mac')
                             ->label('Dirección MAC')
                             ->copyable()
-                            ->placeholder('-'),
+                            ->placeholder('Sin datos'),
 
                         TextEntry::make('user_agent')
                             ->label('Navegador (detectado al provisionar)')
@@ -298,11 +312,11 @@ class TerminalResource extends Resource
                             TextEntry::make('installed_at')
                                 ->label('Fecha de instalación')
                                 ->date('d/m/Y')
-                                ->placeholder('-'),
+                                ->placeholder('Sin fecha de instalación'),
 
                             TextEntry::make('installedBy.name')
                                 ->label('Instalado por')
-                                ->placeholder('-'),
+                                ->placeholder('Sin registrar'),
                         ]),
                     ])
                     ->visible(fn (Terminal $record) => $record->installed_at || $record->installed_by_id),
@@ -380,7 +394,7 @@ class TerminalResource extends Resource
                 TextColumn::make('installed_at')
                     ->label('Instalada')
                     ->date('d/m/Y')
-                    ->placeholder('-')
+                    ->placeholder('Sin instalar')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -164,11 +164,19 @@ class TerminalResource extends Resource
         return $infolist
             ->schema([
                 InfoSection::make('Identificación')
+                    ->collapsible()
                     ->schema([
-                        InfoGrid::make(3)->schema([
+                        InfoGrid::make(4)->schema([
                             TextEntry::make('name')
                                 ->label('Nombre')
                                 ->icon('heroicon-o-computer-desktop'),
+
+                            TextEntry::make('branch.company.name')
+                                ->label('Empresa')
+                                ->icon('heroicon-o-building-office-2')
+                                ->badge()
+                                ->color('primary')
+                                ->visible(fn () => Company::active()->count() > 1),
 
                             TextEntry::make('branch.name')
                                 ->label('Sucursal')
@@ -220,6 +228,7 @@ class TerminalResource extends Resource
                     ]),
 
                 InfoSection::make('Dispositivo')
+                    ->collapsible()
                     ->schema([
                         InfoGrid::make(3)->schema([
                             TextEntry::make('device_brand')
@@ -244,7 +253,8 @@ class TerminalResource extends Resource
                         TextEntry::make('user_agent')
                             ->label('Navegador (detectado al provisionar)')
                             ->placeholder('Sin datos')
-                            ->limit(60),
+                            ->limit(60)
+                            ->tooltip(fn (Terminal $record) => $record->user_agent),
 
                         TextEntry::make('device_notes')
                             ->label('Notas')
@@ -256,6 +266,7 @@ class TerminalResource extends Resource
                 InfoSection::make('Conectividad')
                     ->description('Marcación offline vía PWA — heartbeat y sincronización con la API de terminales')
                     ->icon('heroicon-o-wifi')
+                    ->collapsible()
                     ->schema([
                         InfoGrid::make(4)->schema([
                             TextEntry::make('connectivity_status')
@@ -308,6 +319,7 @@ class TerminalResource extends Resource
                     ]),
 
                 InfoSection::make('Instalación')
+                    ->collapsible()
                     ->schema([
                         InfoGrid::make(2)->schema([
                             TextEntry::make('installed_at')

--- a/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
+++ b/app/Filament/Resources/TerminalResource/Pages/ViewTerminal.php
@@ -17,6 +17,14 @@ class ViewTerminal extends ViewRecord
     protected static string $resource = TerminalResource::class;
 
     /**
+     * Precarga las relaciones anidadas que usa el infolist en una sola query.
+     */
+    protected function resolveRecord(int|string $key): Terminal
+    {
+        return Terminal::with(['branch.company', 'installedBy'])->findOrFail($key);
+    }
+
+    /**
      * Al llegar desde la creación con `?provision=1` (ver
      * CreateTerminal::getRedirectUrl()), abre automáticamente el modal de
      * "Generar enlace de configuración" — evita que el admin tenga que volver

--- a/app/Models/Branch.php
+++ b/app/Models/Branch.php
@@ -45,4 +45,12 @@ class Branch extends Model
     {
         return $this->hasMany(Employee::class)->where('status', 'active');
     }
+
+    /**
+     * Terminales de marcación de la sucursal
+     */
+    public function terminals(): HasMany
+    {
+        return $this->hasMany(Terminal::class);
+    }
 }

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -122,8 +122,8 @@ class Terminal extends Model implements AuthenticatableContract
     public static function getStatusOptions(): array
     {
         return [
-            'active' => 'Activa',
-            'inactive' => 'Inactiva',
+            'active' => 'Activo',
+            'inactive' => 'Inactivo',
         ];
     }
 
@@ -135,8 +135,8 @@ class Terminal extends Model implements AuthenticatableContract
     public static function getStatusLabels(): array
     {
         return [
-            'active' => 'Activa',
-            'inactive' => 'Inactiva',
+            'active' => 'Activo',
+            'inactive' => 'Inactivo',
         ];
     }
 

--- a/tests/Feature/BranchTerminalsRelationManagerTest.php
+++ b/tests/Feature/BranchTerminalsRelationManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Filament\Resources\BranchResource\Pages\ViewBranch;
+use App\Filament\Resources\BranchResource\RelationManagers\TerminalsRelationManager;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Terminal;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function makeBranchForTerminalsRm(): Branch
+{
+    static $n = 7700000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa BranchRM {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+
+    return Branch::create(['name' => "Sucursal BranchRM {$n}", 'company_id' => $company->id]);
+}
+
+it('el RelationManager de terminales renderiza en la ficha de la sucursal', function () {
+    $this->actingAs(User::factory()->create());
+    $branch = makeBranchForTerminalsRm();
+    Terminal::create(['name' => 'Terminal Branch RM', 'branch_id' => $branch->id]);
+
+    Livewire::test(TerminalsRelationManager::class, [
+        'ownerRecord' => $branch,
+        'pageClass' => ViewBranch::class,
+    ])->assertOk();
+});
+
+it('el RelationManager de terminales solo muestra los terminales de esa sucursal, no de otras', function () {
+    $this->actingAs(User::factory()->create());
+    $branch = makeBranchForTerminalsRm();
+    $otherBranch = makeBranchForTerminalsRm();
+
+    $ownTerminal = Terminal::create(['name' => 'Terminal Propio', 'branch_id' => $branch->id]);
+    Terminal::create(['name' => 'Terminal Ajeno', 'branch_id' => $otherBranch->id]);
+
+    $component = Livewire::test(TerminalsRelationManager::class, [
+        'ownerRecord' => $branch,
+        'pageClass' => ViewBranch::class,
+    ]);
+
+    $component->assertCanSeeTableRecords([$ownTerminal])
+        ->assertCountTableRecords(1);
+});
+
+it('el RelationManager de terminales es de solo lectura', function () {
+    $manager = new TerminalsRelationManager;
+
+    expect($manager->isReadOnly())->toBeTrue();
+});

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -3,6 +3,7 @@
 use App\Filament\Resources\TerminalResource;
 use App\Filament\Resources\TerminalResource\Pages\CreateTerminal;
 use App\Filament\Resources\TerminalResource\Pages\EditTerminal;
+use App\Filament\Resources\TerminalResource\Pages\ListTerminals;
 use App\Filament\Resources\TerminalResource\Pages\ViewTerminal;
 use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
 use App\Models\AttendanceDay;
@@ -396,4 +397,32 @@ it('editar un terminal mantiene visible su sucursal aunque la empresa se haya de
         ->getFlatFields(withHidden: true)['branch_id'];
 
     expect($field->getOptions())->toHaveKey($branch->id);
+});
+
+it('el listado de terminales oculta la columna y el filtro de Empresa si solo hay una empresa activa', function () {
+    $this->actingAs(User::factory()->create());
+    makeProvisioningTerminal();
+
+    Livewire::test(ListTerminals::class)
+        ->assertTableColumnHidden('branch.company.name')
+        ->assertTableFilterHidden('company_id');
+});
+
+it('el listado de terminales muestra y filtra por Empresa cuando hay 2 o más empresas activas', function () {
+    $this->actingAs(User::factory()->create());
+
+    $companyA = Company::create(['name' => 'Empresa Terminal A', 'ruc' => '7900010-1', 'employer_number' => 7900010]);
+    $companyB = Company::create(['name' => 'Empresa Terminal B', 'ruc' => '7900011-1', 'employer_number' => 7900011]);
+    $branchA = Branch::create(['name' => 'Sucursal Terminal A', 'company_id' => $companyA->id]);
+    $branchB = Branch::create(['name' => 'Sucursal Terminal B', 'company_id' => $companyB->id]);
+    $terminalA = Terminal::create(['name' => 'Terminal A', 'branch_id' => $branchA->id]);
+    $terminalB = Terminal::create(['name' => 'Terminal B', 'branch_id' => $branchB->id]);
+
+    Livewire::test(ListTerminals::class)
+        ->assertTableColumnVisible('branch.company.name')
+        ->assertTableFilterVisible('company_id')
+        ->assertCanSeeTableRecords([$terminalA, $terminalB])
+        ->filterTable('company_id', $companyA->id)
+        ->assertCanSeeTableRecords([$terminalA])
+        ->assertCanNotSeeTableRecords([$terminalB]);
 });

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -2,6 +2,7 @@
 
 use App\Filament\Resources\TerminalResource;
 use App\Filament\Resources\TerminalResource\Pages\CreateTerminal;
+use App\Filament\Resources\TerminalResource\Pages\EditTerminal;
 use App\Filament\Resources\TerminalResource\Pages\ViewTerminal;
 use App\Filament\Resources\TerminalResource\RelationManagers\AttendanceEventsRelationManager;
 use App\Models\AttendanceDay;
@@ -351,4 +352,48 @@ it('"Generar nuevo enlace" invalida el enlace vigente y notifica en vez de mostr
 
     expect($terminal->fresh()->setup_token)->not->toBeNull()
         ->and($terminal->fresh()->setup_token)->not->toBe($oldToken);
+});
+
+// ─── Form: sucursal filtrada por empresa activa ────────────────────────────
+
+it('el select de sucursal excluye sucursales de empresas inactivas al crear un terminal', function () {
+    $this->actingAs(User::factory()->create());
+
+    $activeCompany = Company::create(['name' => 'Empresa Activa Form', 'ruc' => '7900001-1', 'employer_number' => 7900001, 'is_active' => true]);
+    $inactiveCompany = Company::create(['name' => 'Empresa Inactiva Form', 'ruc' => '7900002-1', 'employer_number' => 7900002, 'is_active' => false]);
+    $activeBranch = Branch::create(['name' => 'Sucursal Activa Form', 'company_id' => $activeCompany->id]);
+    $inactiveBranch = Branch::create(['name' => 'Sucursal Inactiva Form', 'company_id' => $inactiveCompany->id]);
+
+    $field = Livewire::test(CreateTerminal::class)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['branch_id'];
+
+    expect($field->getOptions())->toHaveKey($activeBranch->id)
+        ->not->toHaveKey($inactiveBranch->id);
+});
+
+/**
+ * Regresión: Select::relationship()'s modifyQueryUsing() también filtra la
+ * query que resuelve la etiqueta del valor YA seleccionado
+ * (getSelectedRecordUsing()) — sin el OR por $record->branch_id en
+ * TerminalResource::form(), editar un terminal cuya empresa se desactivó
+ * DESPUÉS de asignarle la sucursal dejaría el campo en blanco, aunque
+ * branch_id siga apuntando correctamente en la base de datos.
+ */
+it('editar un terminal mantiene visible su sucursal aunque la empresa se haya desactivado después', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create(['name' => 'Empresa Form X', 'ruc' => '7900003-1', 'employer_number' => 7900003, 'is_active' => true]);
+    $branch = Branch::create(['name' => 'Sucursal Form X', 'company_id' => $company->id]);
+    $terminal = Terminal::create(['name' => 'Terminal Form X', 'branch_id' => $branch->id]);
+
+    $company->update(['is_active' => false]);
+
+    $field = Livewire::test(EditTerminal::class, ['record' => $terminal->getKey()])
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['branch_id'];
+
+    expect($field->getOptions())->toHaveKey($branch->id);
 });

--- a/tests/Feature/TerminalProvisioningUiTest.php
+++ b/tests/Feature/TerminalProvisioningUiTest.php
@@ -426,3 +426,20 @@ it('el listado de terminales muestra y filtra por Empresa cuando hay 2 o más em
         ->assertCanSeeTableRecords([$terminalA])
         ->assertCanNotSeeTableRecords([$terminalB]);
 });
+
+it('el detalle del terminal oculta el nombre de la Empresa si solo hay una empresa activa', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+
+    Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()])
+        ->assertDontSee($terminal->branch->company->name);
+});
+
+it('el detalle del terminal muestra el nombre de la Empresa cuando hay 2 o más empresas activas', function () {
+    $this->actingAs(User::factory()->create());
+    $terminal = makeProvisioningTerminal();
+    Company::create(['name' => 'Otra Empresa Detalle', 'ruc' => '7900012-1', 'employer_number' => 7900012]);
+
+    Livewire::test(ViewTerminal::class, ['record' => $terminal->getKey()])
+        ->assertSee($terminal->branch->company->name);
+});


### PR DESCRIPTION
## Summary

Continuación del trabajo de esta sesión sobre el flujo de terminales (provisión, notificaciones, header actions, RM de asistencia, terminología). Esta tanda revisa lo que quedaba pendiente de `TerminalResource`: formulario, listado, infolist, y su relación con Empresa/Sucursal.

- **Formulario**: placeholders descriptivos en vez de `-`, el `Select` de sucursal excluye sucursales de empresas inactivas (preservando la sucursal ya asignada al editar), corrige el género de los labels de estado (`Activa`/`Inactiva` → `Activo`/`Inactivo`, consistente con "el terminal") y agrega `helperText` explicando que un terminal inactivo no puede marcar asistencia.
- **Listado**: color de "Desactivar" alineado con `ViewTerminal` (`warning`, no `danger`), `DeleteBulkAction` con la misma advertencia sobre pérdida de referencia en marcaciones que ya tenía el `DeleteAction` individual, y nueva columna/filtro de **Empresa** (visible solo con 2+ empresas activas) — `Terminal` no tiene `company_id` propio, se deriva vía `branch_id → branch.company_id`, igual que `Employee`.
- **Infolist**: mismo agregado de "Empresa", las 4 secciones ahora son `->collapsible()` (convención documentada en CLAUDE.md), tooltip con el valor completo de `user_agent` (estaba truncado sin forma de verlo completo), y `ViewTerminal::resolveRecord()` precarga `branch.company`/`installedBy` en una sola query.
- **Relación con Branch**: `Terminal` pertenece a `Branch` pero no había forma de ver los terminales de una sucursal desde su ficha. Se agrega `Branch::terminals()` (faltante) y un `TerminalsRelationManager` de solo lectura en `BranchResource`, mismo patrón que `EmployeesRelationManager`.
- **CLAUDE.md**: documenta 8 gotchas/convenciones descubiertos en todo este trabajo de terminales (notificaciones de campanita, `notify()` en try/catch, timing de `modalContent()`, `Select::relationship()` + `modifyQueryUsing`, `lockForUpdate()` para tokens de un solo uso, concordancia de género en labels, testing de `ActionGroup`, estado offline cruzado entre dispositivos).

## Test plan

- [x] `php artisan test --compact tests/Feature/TerminalProvisioningUiTest.php` — 24/24 passed
- [x] `php artisan test --compact tests/Feature/BranchTerminalsRelationManagerTest.php tests/Feature/BranchResourceSearchTest.php` — 5/5 passed
- [x] Suite ampliada de terminales (`AdminNotificationsTest`, `AttendanceEventSyncServiceTest`, `MobileAttendanceLinkTest`, `EmployeePhotoThumbnailTest`, `TerminalConnectivityTest`) — 63/64 passed (el único fallo es un problema preexistente de manifest de Vite en este entorno, no relacionado a estos cambios)
- [x] `vendor/bin/pint --dirty` — passed en cada commit


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_