### PR TITLE
Turnos que cruzan medianoche y filtro de "Inicio de descanso" según horario

### DIFF
--- a/app/Http/Controllers/Api/MobileHeartbeatController.php
+++ b/app/Http/Controllers/Api/MobileHeartbeatController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Employee;
+use App\Services\AttendanceCalculator;
 use App\Settings\GeneralSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -55,6 +56,12 @@ class MobileHeartbeatController extends Controller
                 'branch_name' => $employee->branch?->name,
                 'company_name' => $employee->branch?->company?->name,
                 'company_logo' => $employee->branch?->company?->logo_thumbnail,
+                // Para que mark.js pueda filtrar "Inicio de descanso" localmente sin red —
+                // ver AttendanceCalculator::hasScheduledBreak(). Recalculado en cada
+                // heartbeat (cada ~90s mientras hay conexión): puede quedar desactualizado
+                // si el horario cambia mientras el dispositivo está offline por más tiempo
+                // que eso, hasta el próximo heartbeat exitoso.
+                'has_scheduled_break' => AttendanceCalculator::hasScheduledBreak($employee, now(config('app.timezone'))),
             ],
         ]);
     }

--- a/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\AttendanceDay;
-use App\Models\AttendanceEvent;
 use App\Models\Employee;
 use App\Models\Terminal;
 use App\Services\EmployeeDescriptorSyncService;
@@ -75,18 +74,18 @@ class TerminalEmployeeSyncController extends Controller
             ], 404);
         }
 
-        $today = now(config('app.timezone'))->toDateString();
+        $now = Carbon::now(config('app.timezone'));
 
-        $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today)->first();
-        $last = $day
-            ? AttendanceEvent::where('attendance_day_id', $day->id)->latest('recorded_at')->first()
-            : null;
+        // Mismo criterio que AttendanceFaceMarkController::identify() — considera una
+        // posible jornada nocturna del día anterior todavía abierta y filtra
+        // 'break_start' si el horario del empleado no contempla descanso.
+        $state = AttendanceDay::currentStateFor($employee, $now);
 
         return response()->json([
             'ok' => true,
-            'last_event' => $last?->event_type,
-            'last_event_time' => $last?->recorded_at?->format('H:i'),
-            'allowed_events' => AttendanceEvent::allowedNextEventTypes($last?->event_type),
+            'last_event' => $state['last']?->event_type,
+            'last_event_time' => $state['last']?->recorded_at?->format('H:i'),
+            'allowed_events' => $state['allowed'],
         ]);
     }
 }

--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\AttendanceDay;
-use App\Models\AttendanceEvent;
 use App\Models\AttendanceMarkFailure;
 use App\Models\Employee;
 use App\Models\Terminal;
@@ -165,7 +164,7 @@ class AttendanceFaceMarkController extends Controller
             // Considera una posible jornada nocturna del día anterior todavía abierta
             // (ej: entrada 17:00 → todavía sin salida pasada la medianoche) — ver
             // AttendanceDay::currentStateFor().
-            $state = AttendanceDay::currentStateFor($employee->id, $now);
+            $state = AttendanceDay::currentStateFor($employee, $now);
             $last = $state['last'];
             $allowed = $state['allowed'];
 
@@ -333,8 +332,8 @@ class AttendanceFaceMarkController extends Controller
                 // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si
                 // sigue abierta y la transición pedida solo tiene sentido ahí (turno
                 // nocturno que cruza medianoche). Ver AttendanceDay::resolveForEvent().
-                ['day' => $day, 'last' => $last] = AttendanceDay::resolveForEvent(
-                    $employee->id,
+                ['day' => $day, 'last' => $last, 'allowed' => $allowed] = AttendanceDay::resolveForEvent(
+                    $employee,
                     $now,
                     $data['event_type'],
                     lockForUpdate: true,
@@ -352,8 +351,6 @@ class AttendanceFaceMarkController extends Controller
                 if ($day->status !== 'present') {
                     $day->update(['status' => 'present']);
                 }
-
-                $allowed = $this->allowedNextEvents($last?->event_type);
 
                 if (! in_array($data['event_type'], $allowed, true)) {
                     Log::warning("Marcación fallida — CI {$employee->ci} {$employee->first_name}: evento '{$data['event_type']}' no permitido (último: ".($last ? $last->event_type : 'ninguno').')', [
@@ -665,25 +662,6 @@ class AttendanceFaceMarkController extends Controller
         }
 
         return $distance;
-    }
-
-    /**
-     * Reglas de transición válidas — delega a AttendanceEvent::allowedNextEventTypes(),
-     * compartida con AttendanceEventSyncService (sync de terminales offline) para no
-     * duplicar la máquina de estados en dos lugares.
-     */
-    protected function allowedNextEvents(?string $last): array
-    {
-        // CORRECCIÓN 20: Validar tipos de eventos conocidos
-        $validEventTypes = ['check_in', 'break_start', 'break_end', 'check_out'];
-
-        if ($last !== null && ! in_array($last, $validEventTypes, true)) {
-            Log::warning("Tipo de evento desconocido encontrado: {$last}");
-
-            return ['check_in']; // Fallback seguro
-        }
-
-        return AttendanceEvent::allowedNextEventTypes($last);
     }
 
     /** Traducciones de tipos de eventos a español */

--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -160,20 +160,14 @@ class AttendanceFaceMarkController extends Controller
             }
 
             // CORRECCIÓN 5: Usar timezone de la aplicación
-            $today = Carbon::now(config('app.timezone'))->toDateString();
+            $now = Carbon::now(config('app.timezone'));
 
-            $day = AttendanceDay::where('employee_id', $employee->id)
-                ->where('date', $today)
-                ->first();
-
-            $last = null;
-            if ($day) {
-                $last = AttendanceEvent::where('attendance_day_id', $day->id)
-                    ->latest('recorded_at')
-                    ->first();
-            }
-
-            $allowed = $this->allowedNextEvents($last?->event_type);
+            // Considera una posible jornada nocturna del día anterior todavía abierta
+            // (ej: entrada 17:00 → todavía sin salida pasada la medianoche) — ver
+            // AttendanceDay::currentStateFor().
+            $state = AttendanceDay::currentStateFor($employee->id, $now);
+            $last = $state['last'];
+            $allowed = $state['allowed'];
 
             $photoUrl = $employee->photo
                 ? Storage::url($employee->photo)
@@ -326,7 +320,8 @@ class AttendanceFaceMarkController extends Controller
         }
 
         // CORRECCIÓN 8: Usar timezone de la aplicación
-        $today = Carbon::now(config('app.timezone'))->toDateString();
+        $now = Carbon::now(config('app.timezone'));
+        $today = $now->toDateString();
 
         // Captura de fallos que ocurren dentro de la transacción.
         // recordFailure() NO puede llamarse dentro de DB::transaction() porque el INSERT
@@ -334,23 +329,29 @@ class AttendanceFaceMarkController extends Controller
         $pendingFailure = null;
 
         try {
-            $result = DB::transaction(function () use ($employee, $today, $data, $location, $terminal, &$pendingFailure) {
-                // Asegurar AttendanceDay del día (firstOrCreate es atómico)
-                $day = AttendanceDay::firstOrCreate(
-                    ['employee_id' => $employee->id, 'date' => $today],
-                    ['status' => 'present']
+            $result = DB::transaction(function () use ($employee, $today, $now, $data, $location, $terminal, &$pendingFailure) {
+                // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si
+                // sigue abierta y la transición pedida solo tiene sentido ahí (turno
+                // nocturno que cruza medianoche). Ver AttendanceDay::resolveForEvent().
+                ['day' => $day, 'last' => $last] = AttendanceDay::resolveForEvent(
+                    $employee->id,
+                    $now,
+                    $data['event_type'],
+                    lockForUpdate: true,
                 );
+
+                // Ninguna jornada existente permite la transición pedida — abrir la de hoy.
+                if (! $day) {
+                    $day = AttendanceDay::firstOrCreate(
+                        ['employee_id' => $employee->id, 'date' => $today],
+                        ['status' => 'present']
+                    );
+                }
 
                 // Si existe y el status no es 'present', actualizarlo
                 if ($day->status !== 'present') {
                     $day->update(['status' => 'present']);
                 }
-
-                // Bloquear lectura del último evento para evitar condiciones de carrera
-                $last = AttendanceEvent::where('attendance_day_id', $day->id)
-                    ->lockForUpdate()
-                    ->latest('recorded_at')
-                    ->first();
 
                 $allowed = $this->allowedNextEvents($last?->event_type);
 

--- a/app/Models/AttendanceDay.php
+++ b/app/Models/AttendanceDay.php
@@ -94,6 +94,92 @@ class AttendanceDay extends Model implements Auditable
     }
 
     /**
+     * Resuelve a qué jornada (AttendanceDay) debe asociarse un evento entrante,
+     * soportando turnos que cruzan medianoche (ej: entrada 17:00 → salida 01:00
+     * del día siguiente).
+     *
+     * Primero intenta la jornada del día calendario de `$recordedAt`. Si la
+     * transición pedida no es válida ahí (típicamente porque esa jornada no
+     * tiene marcaciones todavía), revisa la jornada del día calendario
+     * anterior: si sigue abierta (su último evento no es `check_out`) y la
+     * transición pedida sí es válida para ella, el evento continúa esa
+     * jornada en lugar de abrir una nueva. Nunca mira más de un día hacia
+     * atrás — una jornada abierta de hace 2+ días requiere revisión manual
+     * (ver `attendance:check-missing`), no se reabre automáticamente.
+     *
+     * @return array{day: ?self, last: ?AttendanceEvent} `day` es null cuando debe crearse una jornada nueva para hoy (ninguna de las dos jornadas permite la transición pedida, o la de hoy sí la permite pero aún no existe).
+     */
+    public static function resolveForEvent(int $employeeId, Carbon $recordedAt, string $requestedEventType, bool $lockForUpdate = false): array
+    {
+        $resolveLast = function (?self $day) use ($lockForUpdate) {
+            if (! $day) {
+                return null;
+            }
+
+            $query = AttendanceEvent::where('attendance_day_id', $day->id)->latest('recorded_at');
+
+            return $lockForUpdate ? $query->lockForUpdate()->first() : $query->first();
+        };
+
+        $today = static::where('employee_id', $employeeId)->where('date', $recordedAt->toDateString())->first();
+        $todayLast = $resolveLast($today);
+
+        if (in_array($requestedEventType, AttendanceEvent::allowedNextEventTypes($todayLast?->event_type), true)) {
+            return ['day' => $today, 'last' => $todayLast];
+        }
+
+        $yesterday = static::where('employee_id', $employeeId)
+            ->where('date', $recordedAt->copy()->subDay()->toDateString())
+            ->first();
+        $yesterdayLast = $resolveLast($yesterday);
+
+        if ($yesterdayLast
+            && $yesterdayLast->event_type !== 'check_out'
+            && in_array($requestedEventType, AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type), true)
+        ) {
+            return ['day' => $yesterday, 'last' => $yesterdayLast];
+        }
+
+        return ['day' => $today, 'last' => $todayLast];
+    }
+
+    /**
+     * Estado informativo (sin persistir nada) usado por `identify()` para mostrar
+     * al empleado qué puede marcar ahora, considerando una posible jornada
+     * nocturna del día anterior que sigue abierta. `allowed` es la unión de lo
+     * que permitiría continuar hoy y lo que permitiría cerrar/continuar esa
+     * jornada de ayer — refleja exactamente lo que `resolveForEvent()`
+     * aceptaría, sin decidir todavía a qué jornada se asociará.
+     *
+     * @return array{last: ?AttendanceEvent, allowed: array<int, string>}
+     */
+    public static function currentStateFor(int $employeeId, Carbon $recordedAt): array
+    {
+        $today = static::where('employee_id', $employeeId)->where('date', $recordedAt->toDateString())->first();
+        $todayLast = $today ? AttendanceEvent::where('attendance_day_id', $today->id)->latest('recorded_at')->first() : null;
+
+        $yesterday = static::where('employee_id', $employeeId)
+            ->where('date', $recordedAt->copy()->subDay()->toDateString())
+            ->first();
+        $yesterdayLast = $yesterday ? AttendanceEvent::where('attendance_day_id', $yesterday->id)->latest('recorded_at')->first() : null;
+
+        $overnightOpen = $yesterdayLast && $yesterdayLast->event_type !== 'check_out';
+
+        $allowed = AttendanceEvent::allowedNextEventTypes($todayLast?->event_type);
+        if ($overnightOpen) {
+            $allowed = array_values(array_unique(array_merge(
+                $allowed,
+                AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type)
+            )));
+        }
+
+        return [
+            'last' => $todayLast ?? ($overnightOpen ? $yesterdayLast : null),
+            'allowed' => $allowed,
+        ];
+    }
+
+    /**
      * Relación con el modelo Absence, un día de asistencia puede tener una ausencia
      */
     public function absence()

--- a/app/Models/AttendanceDay.php
+++ b/app/Models/AttendanceDay.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\AttendanceCalculator;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -107,9 +108,15 @@ class AttendanceDay extends Model implements Auditable
      * atrás — una jornada abierta de hace 2+ días requiere revisión manual
      * (ver `attendance:check-missing`), no se reabre automáticamente.
      *
-     * @return array{day: ?self, last: ?AttendanceEvent} `day` es null cuando debe crearse una jornada nueva para hoy (ninguna de las dos jornadas permite la transición pedida, o la de hoy sí la permite pero aún no existe).
+     * "Inicio de descanso" además solo se considera válido si el turno/horario
+     * efectivo del empleado para el día en cuestión tiene un descanso
+     * configurado (ver `AttendanceCalculator::hasScheduledBreak()`) — "Fin de
+     * descanso" nunca se filtra así: si el empleado ya está en pausa, siempre
+     * puede cerrarla.
+     *
+     * @return array{day: ?self, last: ?AttendanceEvent, allowed: array<int, string>} `day` es null cuando debe crearse una jornada nueva para hoy (ninguna de las dos jornadas permite la transición pedida, o la de hoy sí la permite pero aún no existe). `allowed` ya viene filtrado por horario/descanso — usarlo para la validación final en el caller, no recalcular con AttendanceEvent::allowedNextEventTypes() directamente.
      */
-    public static function resolveForEvent(int $employeeId, Carbon $recordedAt, string $requestedEventType, bool $lockForUpdate = false): array
+    public static function resolveForEvent(Employee $employee, Carbon $recordedAt, string $requestedEventType, bool $lockForUpdate = false): array
     {
         $resolveLast = function (?self $day) use ($lockForUpdate) {
             if (! $day) {
@@ -121,26 +128,56 @@ class AttendanceDay extends Model implements Auditable
             return $lockForUpdate ? $query->lockForUpdate()->first() : $query->first();
         };
 
-        $today = static::where('employee_id', $employeeId)->where('date', $recordedAt->toDateString())->first();
+        $today = static::where('employee_id', $employee->id)->where('date', $recordedAt->toDateString())->first();
         $todayLast = $resolveLast($today);
+        $todayAllowed = static::filterAllowedByBreakSchedule(
+            AttendanceEvent::allowedNextEventTypes($todayLast?->event_type),
+            $employee,
+            $recordedAt
+        );
 
-        if (in_array($requestedEventType, AttendanceEvent::allowedNextEventTypes($todayLast?->event_type), true)) {
-            return ['day' => $today, 'last' => $todayLast];
+        if (in_array($requestedEventType, $todayAllowed, true)) {
+            return ['day' => $today, 'last' => $todayLast, 'allowed' => $todayAllowed];
         }
 
-        $yesterday = static::where('employee_id', $employeeId)
-            ->where('date', $recordedAt->copy()->subDay()->toDateString())
+        $yesterdayDate = $recordedAt->copy()->subDay();
+        $yesterday = static::where('employee_id', $employee->id)
+            ->where('date', $yesterdayDate->toDateString())
             ->first();
         $yesterdayLast = $resolveLast($yesterday);
+        $yesterdayAllowed = $yesterdayLast
+            ? static::filterAllowedByBreakSchedule(AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type), $employee, $yesterdayDate)
+            : [];
 
         if ($yesterdayLast
             && $yesterdayLast->event_type !== 'check_out'
-            && in_array($requestedEventType, AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type), true)
+            && in_array($requestedEventType, $yesterdayAllowed, true)
         ) {
-            return ['day' => $yesterday, 'last' => $yesterdayLast];
+            return ['day' => $yesterday, 'last' => $yesterdayLast, 'allowed' => $yesterdayAllowed];
         }
 
-        return ['day' => $today, 'last' => $todayLast];
+        return ['day' => $today, 'last' => $todayLast, 'allowed' => $todayAllowed];
+    }
+
+    /**
+     * Quita 'break_start' del listado de transiciones permitidas si el turno del
+     * empleado para esa fecha no tiene descanso configurado. 'break_end' nunca
+     * se filtra — si ya empezó la pausa, siempre debe poder cerrarla.
+     *
+     * @param  array<int, string>  $allowed
+     * @return array<int, string>
+     */
+    private static function filterAllowedByBreakSchedule(array $allowed, Employee $employee, Carbon $date): array
+    {
+        if (! in_array('break_start', $allowed, true)) {
+            return $allowed;
+        }
+
+        if (AttendanceCalculator::hasScheduledBreak($employee, $date)) {
+            return $allowed;
+        }
+
+        return array_values(array_diff($allowed, ['break_start']));
     }
 
     /**
@@ -153,23 +190,28 @@ class AttendanceDay extends Model implements Auditable
      *
      * @return array{last: ?AttendanceEvent, allowed: array<int, string>}
      */
-    public static function currentStateFor(int $employeeId, Carbon $recordedAt): array
+    public static function currentStateFor(Employee $employee, Carbon $recordedAt): array
     {
-        $today = static::where('employee_id', $employeeId)->where('date', $recordedAt->toDateString())->first();
+        $today = static::where('employee_id', $employee->id)->where('date', $recordedAt->toDateString())->first();
         $todayLast = $today ? AttendanceEvent::where('attendance_day_id', $today->id)->latest('recorded_at')->first() : null;
 
-        $yesterday = static::where('employee_id', $employeeId)
-            ->where('date', $recordedAt->copy()->subDay()->toDateString())
+        $yesterdayDate = $recordedAt->copy()->subDay();
+        $yesterday = static::where('employee_id', $employee->id)
+            ->where('date', $yesterdayDate->toDateString())
             ->first();
         $yesterdayLast = $yesterday ? AttendanceEvent::where('attendance_day_id', $yesterday->id)->latest('recorded_at')->first() : null;
 
         $overnightOpen = $yesterdayLast && $yesterdayLast->event_type !== 'check_out';
 
-        $allowed = AttendanceEvent::allowedNextEventTypes($todayLast?->event_type);
+        $allowed = static::filterAllowedByBreakSchedule(
+            AttendanceEvent::allowedNextEventTypes($todayLast?->event_type),
+            $employee,
+            $recordedAt
+        );
         if ($overnightOpen) {
             $allowed = array_values(array_unique(array_merge(
                 $allowed,
-                AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type)
+                static::filterAllowedByBreakSchedule(AttendanceEvent::allowedNextEventTypes($yesterdayLast->event_type), $employee, $yesterdayDate)
             )));
         }
 

--- a/app/Services/AttendanceCalculator.php
+++ b/app/Services/AttendanceCalculator.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\AttendanceDay;
+use App\Models\Employee;
 use App\Models\Holiday;
 use App\Settings\PayrollSettings;
 use Illuminate\Support\Carbon;
@@ -421,17 +422,27 @@ class AttendanceCalculator
     /**
      * Resuelve el turno esperado para la fecha del día dado.
      *
+     * @return array{check_in: string|null, check_out: string|null, break_minutes: int|null}
+     */
+    private static function resolveExpectedShiftData(AttendanceDay $day): array
+    {
+        return self::resolveShiftDataFor($day->employee, Carbon::parse($day->date));
+    }
+
+    /**
+     * Resuelve el turno/horario efectivo de un empleado para una fecha dada, sin
+     * depender de que exista un AttendanceDay — usado tanto por
+     * resolveExpectedShiftData() (cálculo de horas) como por hasScheduledBreak()
+     * (decidir si ofrecer "Inicio de descanso" al marcar asistencia).
+     *
      * Jerarquía:
      *   1. Rotación activa (ShiftTemplate vía RotationService — incluye overrides)
      *   2. Horario fijo por día de semana (sistema anterior)
      *
      * @return array{check_in: string|null, check_out: string|null, break_minutes: int|null}
      */
-    private static function resolveExpectedShiftData(AttendanceDay $day): array
+    public static function resolveShiftDataFor(Employee $employee, \Carbon\Carbon $date): array
     {
-        $date = Carbon::parse($day->date);
-        $employee = $day->employee;
-
         // 1. Sistema de rotación (override > patrón)
         $shift = RotationService::getShiftForDate($employee, $date);
 
@@ -460,6 +471,18 @@ class AttendanceCalculator
         }
 
         return ['check_in' => null, 'check_out' => null, 'break_minutes' => null];
+    }
+
+    /**
+     * True si el turno/horario efectivo del empleado para la fecha tiene un
+     * descanso configurado (break_minutes > 0). Sin horario/rotación asignado,
+     * o con break_minutes = 0/null, no hay descanso — usado para decidir si
+     * ofrecer "Inicio de descanso" al marcar asistencia (ver
+     * AttendanceDay::resolveForEvent() / currentStateFor()).
+     */
+    public static function hasScheduledBreak(Employee $employee, \Carbon\Carbon $date): bool
+    {
+        return (int) (self::resolveShiftDataFor($employee, $date)['break_minutes'] ?? 0) > 0;
     }
 
     /**

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -138,15 +138,22 @@ class AttendanceEventSyncService
         Carbon $recordedAt,
         string $date,
     ): array {
-        $day = AttendanceDay::firstOrCreate(
-            ['employee_id' => $employee->id, 'date' => $date],
-            ['status' => 'present']
+        // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si sigue
+        // abierta y la transición pedida solo tiene sentido ahí (turno nocturno que
+        // cruza medianoche). Ver AttendanceDay::resolveForEvent().
+        ['day' => $day, 'last' => $last] = AttendanceDay::resolveForEvent(
+            $employee->id,
+            $recordedAt,
+            $eventData['event_type'],
+            lockForUpdate: true,
         );
 
-        $last = AttendanceEvent::where('attendance_day_id', $day->id)
-            ->lockForUpdate()
-            ->latest('recorded_at')
-            ->first();
+        if (! $day) {
+            $day = AttendanceDay::firstOrCreate(
+                ['employee_id' => $employee->id, 'date' => $date],
+                ['status' => 'present']
+            );
+        }
 
         $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
 

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -141,8 +141,8 @@ class AttendanceEventSyncService
         // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si sigue
         // abierta y la transición pedida solo tiene sentido ahí (turno nocturno que
         // cruza medianoche). Ver AttendanceDay::resolveForEvent().
-        ['day' => $day, 'last' => $last] = AttendanceDay::resolveForEvent(
-            $employee->id,
+        ['day' => $day, 'last' => $last, 'allowed' => $allowed] = AttendanceDay::resolveForEvent(
+            $employee,
             $recordedAt,
             $eventData['event_type'],
             lockForUpdate: true,
@@ -154,8 +154,6 @@ class AttendanceEventSyncService
                 ['status' => 'present']
             );
         }
-
-        $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
 
         if (! in_array($eventData['event_type'], $allowed, true)) {
             Log::warning("Sync de terminal — evento '{$eventData['event_type']}' ya no es válido para el empleado {$employee->id} (último registrado: ".($last->event_type ?? 'ninguno').')', [

--- a/app/Services/EmployeeDescriptorSyncService.php
+++ b/app/Services/EmployeeDescriptorSyncService.php
@@ -18,6 +18,7 @@ class EmployeeDescriptorSyncService
      * @return array{
      *     employees: array<int, array{id: int, first_name: string, last_name: string, ci: string|null, face_descriptor: array, photo_thumbnail: string|null}>,
      *     tombstones: array<int, int>,
+     *     break_flags: array<int, bool>,
      *     server_time: string,
      *     sync_version: string,
      * }
@@ -49,6 +50,7 @@ class EmployeeDescriptorSyncService
                 'photo_thumbnail' => $employee->photo_thumbnail,
             ])->values()->all(),
             'tombstones' => $since ? $this->tombstonesSince($terminal, $since) : [],
+            'break_flags' => $this->breakFlagsForBranch($terminal),
             'server_time' => now()->toIso8601String(),
             'sync_version' => $queryStartedAt->toIso8601String(),
         ];
@@ -77,6 +79,33 @@ class EmployeeDescriptorSyncService
                 $query->where('status', '!=', 'active')->orWhereNull('face_descriptor');
             })
             ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * "¿Tiene descanso hoy?" para cada empleado activo de la sucursal — se
+     * recalcula completo en CADA sincronización (no solo para los que
+     * cambiaron desde `$since`), porque el horario de un empleado puede
+     * cambiar sin tocar el registro de `Employee` (ej. una nueva rotación
+     * asignada), y además el día calendario avanza. Alimenta el filtro de
+     * "Inicio de descanso" en la resolución local offline (ver
+     * terminal-offline/queue.js, `allowedNextEventTypes()`); mientras el
+     * terminal tiene red se refresca cada ciclo de sync de empleados
+     * (~5 min), así que solo puede quedar desactualizado durante un corte
+     * de conexión más largo que eso.
+     *
+     * @return array<int, bool>
+     */
+    private function breakFlagsForBranch(Terminal $terminal): array
+    {
+        $today = now(config('app.timezone'));
+
+        return Employee::query()
+            ->where('branch_id', $terminal->branch_id)
+            ->where('status', 'active')
+            ->whereNotNull('face_descriptor')
+            ->get(['id'])
+            ->mapWithKeys(fn (Employee $employee) => [$employee->id => AttendanceCalculator::hasScheduledBreak($employee, $today)])
             ->all();
     }
 }

--- a/app/Services/MobileEventSyncService.php
+++ b/app/Services/MobileEventSyncService.php
@@ -98,17 +98,22 @@ class MobileEventSyncService
         Carbon $recordedAt,
         string $date,
     ): array {
-        $day = AttendanceDay::firstOrCreate(
-            ['employee_id' => $employee->id, 'date' => $date],
-            ['status' => 'present']
+        // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si sigue
+        // abierta y la transición pedida solo tiene sentido ahí (turno nocturno que
+        // cruza medianoche). Ver AttendanceDay::resolveForEvent().
+        ['day' => $day, 'last' => $last, 'allowed' => $allowed] = AttendanceDay::resolveForEvent(
+            $employee,
+            $recordedAt,
+            $eventData['event_type'],
+            lockForUpdate: true,
         );
 
-        $last = AttendanceEvent::where('attendance_day_id', $day->id)
-            ->lockForUpdate()
-            ->latest('recorded_at')
-            ->first();
-
-        $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
+        if (! $day) {
+            $day = AttendanceDay::firstOrCreate(
+                ['employee_id' => $employee->id, 'date' => $date],
+                ['status' => 'present']
+            );
+        }
 
         if (! in_array($eventData['event_type'], $allowed, true)) {
             Log::warning("Sync de dispositivo — evento '{$eventData['event_type']}' ya no es válido para el empleado {$employee->id} (último registrado: ".($last->event_type ?? 'ninguno').')', [

--- a/resources/js/attendances/mobile-offline/db.js
+++ b/resources/js/attendances/mobile-offline/db.js
@@ -17,8 +17,11 @@
  *
  * Stores:
  * - mobile_meta            — key/value: api_token, own_employee (id/nombre/CI/
- *                             descriptor), config de reconocimiento facial,
- *                             offset de reloj, timestamps de sync.
+ *                             descriptor/has_scheduled_break — este último
+ *                             usado para filtrar "Inicio de descanso" en la
+ *                             resolución local sin red, ver queue.js),
+ *                             config de reconocimiento facial, offset de
+ *                             reloj, timestamps de sync.
  * - outbound_events        — keyPath 'client_event_id': cola de marcaciones
  *                             capturadas localmente. `status`: 'pending'
  *                             (por sincronizar) | 'conflict' (el servidor la

--- a/resources/js/attendances/mobile-offline/queue.js
+++ b/resources/js/attendances/mobile-offline/queue.js
@@ -17,6 +17,7 @@ import {
     queueEvent,
     getPendingEvents,
     getEventsOnDate,
+    getOwnEmployee,
     removeQueuedEvent,
     markQueuedEventConflict,
     incrementQueuedEventAttempts,
@@ -33,25 +34,36 @@ import { submitEvents, fetchStatus, MobileAuthError } from './sync.js';
  * AttendanceEvent::allowedNextEventTypes() en el backend. Se necesita acá
  * (además de en el servidor) para poder resolver localmente qué botones
  * mostrar cuando no hay red para preguntarle al servidor.
+ *
+ * `hasScheduledBreak` (ver AttendanceCalculator::hasScheduledBreak() /
+ * `own_employee.has_scheduled_break`, cacheado en cada heartbeat) quita
+ * 'break_start' cuando el horario del empleado no contempla descanso —
+ * 'break_end' nunca se filtra así: si ya está en pausa, siempre debe poder
+ * cerrarla.
  * @param {string|null} lastEventType
+ * @param {boolean} [hasScheduledBreak] - default true (mismo comportamiento que antes si no se pasa).
  * @returns {string[]}
  */
-export function allowedNextEventTypes(lastEventType) {
-    switch (lastEventType) {
-        case null:
-        case undefined:
-            return ['check_in'];
-        case 'check_in':
-            return ['break_start', 'check_out'];
-        case 'break_start':
-            return ['break_end'];
-        case 'break_end':
-            return ['break_start', 'check_out'];
-        case 'check_out':
-            return [];
-        default:
-            return ['check_in'];
-    }
+export function allowedNextEventTypes(lastEventType, hasScheduledBreak = true) {
+    const allowed = (() => {
+        switch (lastEventType) {
+            case null:
+            case undefined:
+                return ['check_in'];
+            case 'check_in':
+                return ['break_start', 'check_out'];
+            case 'break_start':
+                return ['break_end'];
+            case 'break_end':
+                return ['break_start', 'check_out'];
+            case 'check_out':
+                return [];
+            default:
+                return ['check_in'];
+        }
+    })();
+
+    return hasScheduledBreak ? allowed : allowed.filter((event) => event !== 'break_start');
 }
 
 /**
@@ -74,35 +86,65 @@ function localDateString(date = new Date()) {
     return `${year}-${month}-${day}`;
 }
 
+/** @returns {string} Fecha local del día anterior a `date`, en formato YYYY-MM-DD. */
+function previousLocalDateString(date) {
+    return localDateString(new Date(date.getTime() - 24 * 60 * 60 * 1000));
+}
+
 /**
  * Resuelve el estado de marcación del propio empleado para hoy, combinando:
  * 1) el último estado que el servidor confirmó (cacheado en la última
- *    consulta online exitosa), con
+ *    consulta online exitosa — no está scopeado por fecha, así que ya
+ *    refleja un turno nocturno si el check_in se sincronizó en línea antes
+ *    de quedar offline), con
  * 2) los eventos que este mismo dispositivo ya encoló hoy pero el servidor
  *    todavía no confirmó — para no repetir ni saltear pasos mientras está
  *    offline.
+ * 3) si ninguno de los dos anteriores aporta un evento de HOY, revisa si hay
+ *    una jornada de AYER encolada localmente (no sincronizada, capturada
+ *    offline de punta a punta) que sigue abierta (su último evento no es
+ *    check_out) — mismo criterio que AttendanceDay::resolveForEvent() en el
+ *    servidor, para que un check_in nocturno capturado sin red no deje al
+ *    empleado sin poder marcar la salida al cruzar la medianoche.
  * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
  */
 export async function resolveOwnStatus() {
     const employeeId = await getMeta('employee_id');
     const cached = employeeId ? await getEmployeeStatusCache(employeeId) : undefined;
-    const today = localDateString(await correctedNow());
-    const localEvents = (await getEventsOnDate(today))
+    const now = await correctedNow();
+    const today = localDateString(now);
+
+    const todayEvents = (await getEventsOnDate(today))
         .filter((event) => event.status === 'pending') // los en conflicto no cuentan como "ya registrados"
         .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
 
     let lastEvent = cached?.last_event ?? null;
     let lastEventTime = cached?.last_event_time ?? null;
 
-    for (const event of localEvents) {
-        lastEvent = event.event_type;
-        lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+    if (todayEvents.length > 0) {
+        for (const event of todayEvents) {
+            lastEvent = event.event_type;
+            lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+        }
+    } else if (lastEvent === null) {
+        const yesterdayEvents = (await getEventsOnDate(previousLocalDateString(now)))
+            .filter((event) => event.status === 'pending')
+            .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+
+        const lastYesterday = yesterdayEvents[yesterdayEvents.length - 1];
+        if (lastYesterday && lastYesterday.event_type !== 'check_out') {
+            lastEvent = lastYesterday.event_type;
+            lastEventTime = new Date(lastYesterday.recorded_at).toTimeString().slice(0, 5);
+        }
     }
+
+    const ownEmployee = await getOwnEmployee();
+    const hasScheduledBreak = ownEmployee?.has_scheduled_break ?? true;
 
     return {
         last_event: lastEvent,
         last_event_time: lastEventTime,
-        allowed_events: allowedNextEventTypes(lastEvent),
+        allowed_events: allowedNextEventTypes(lastEvent, hasScheduledBreak),
     };
 }
 
@@ -159,10 +201,11 @@ export async function enqueueMark(eventType, location = null) {
     // último estado confirmado ANTES de esta marcación) y vuelve a ofrecer
     // los mismos eventos permitidos que antes de marcar.
     if (employeeId) {
+        const ownEmployee = await getOwnEmployee();
         await setEmployeeStatusCache(employeeId, {
             last_event: eventType,
             last_event_time: recordedAt.toTimeString().slice(0, 5),
-            allowed_events: allowedNextEventTypes(eventType),
+            allowed_events: allowedNextEventTypes(eventType, ownEmployee?.has_scheduled_break ?? true),
         });
     }
 

--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -10,6 +10,9 @@
  *                             cursores de sync, config de reconocimiento facial.
  * - employees_cache        — keyPath 'id': empleados activos con descriptor
  *                             facial, scopeados a la sucursal del terminal.
+ *                             Incluye `has_scheduled_break` (ver
+ *                             applyBreakFlags()), usado para filtrar "Inicio
+ *                             de descanso" en la resolución local sin red.
  * - outbound_events        — keyPath 'client_event_id': cola de marcaciones
  *                             capturadas localmente. `status`: 'pending'
  *                             (por sincronizar) | 'conflict' (el servidor la
@@ -146,6 +149,12 @@ export async function getCachedEmployees() {
     return db.getAll('employees_cache');
 }
 
+/** @param {number} employeeId @returns {Promise<object|undefined>} */
+export async function getCachedEmployee(employeeId) {
+    const db = await getDb();
+    return db.get('employees_cache', employeeId);
+}
+
 /**
  * Aplica un delta de sincronización de empleados: upsert de los modificados,
  * borrado de los tombstones.
@@ -160,6 +169,29 @@ export async function applyEmployeesDelta(employees, tombstones) {
     }
     for (const id of tombstones) {
         await tx.store.delete(id);
+    }
+    await tx.done;
+}
+
+/**
+ * Aplica el mapa `has_scheduled_break` (id → bool) a los empleados YA
+ * cacheados — a diferencia de `applyEmployeesDelta()`, esto se recalcula
+ * completo en cada sync (ver EmployeeDescriptorSyncService::breakFlagsForBranch()),
+ * no solo para los que cambiaron, porque el valor depende del día calendario
+ * y de asignaciones de horario que no tocan el registro del empleado. Un id
+ * que todavía no está en la caché (recién sincronizado en el mismo lote) se
+ * ignora silenciosamente — ya llegó con el campo puesto vía `applyEmployeesDelta()`.
+ * @param {Record<number, boolean>} breakFlags
+ */
+export async function applyBreakFlags(breakFlags) {
+    const db = await getDb();
+    const tx = db.transaction('employees_cache', 'readwrite');
+    for (const [idStr, hasScheduledBreak] of Object.entries(breakFlags || {})) {
+        const id = Number(idStr);
+        const employee = await tx.store.get(id);
+        if (employee) {
+            await tx.store.put({ ...employee, has_scheduled_break: hasScheduledBreak });
+        }
     }
     await tx.done;
 }

--- a/resources/js/attendances/terminal-offline/queue.js
+++ b/resources/js/attendances/terminal-offline/queue.js
@@ -17,6 +17,7 @@ import {
     queueEvent,
     getPendingEvents,
     getEventsForEmployeeOnDate,
+    getCachedEmployee,
     removeQueuedEvent,
     markQueuedEventConflict,
     incrementQueuedEventAttempts,
@@ -32,25 +33,36 @@ import { submitEvents, fetchEmployeeStatus } from './sync.js';
  * AttendanceEvent::allowedNextEventTypes() en el backend. Se necesita acá
  * (además de en el servidor) para poder resolver localmente qué botones
  * mostrar cuando no hay red para preguntarle al servidor.
+ *
+ * `hasScheduledBreak` (ver AttendanceCalculator::hasScheduledBreak() /
+ * `employees_cache[id].has_scheduled_break`, cacheado en cada sync de
+ * empleados) quita 'break_start' cuando el horario del empleado no
+ * contempla descanso — 'break_end' nunca se filtra así: si ya está en
+ * pausa, siempre debe poder cerrarla.
  * @param {string|null} lastEventType
+ * @param {boolean} [hasScheduledBreak] - default true (mismo comportamiento que antes si no se pasa).
  * @returns {string[]}
  */
-export function allowedNextEventTypes(lastEventType) {
-    switch (lastEventType) {
-        case null:
-        case undefined:
-            return ['check_in'];
-        case 'check_in':
-            return ['break_start', 'check_out'];
-        case 'break_start':
-            return ['break_end'];
-        case 'break_end':
-            return ['break_start', 'check_out'];
-        case 'check_out':
-            return [];
-        default:
-            return ['check_in'];
-    }
+export function allowedNextEventTypes(lastEventType, hasScheduledBreak = true) {
+    const allowed = (() => {
+        switch (lastEventType) {
+            case null:
+            case undefined:
+                return ['check_in'];
+            case 'check_in':
+                return ['break_start', 'check_out'];
+            case 'break_start':
+                return ['break_end'];
+            case 'break_end':
+                return ['break_start', 'check_out'];
+            case 'check_out':
+                return [];
+            default:
+                return ['check_in'];
+        }
+    })();
+
+    return hasScheduledBreak ? allowed : allowed.filter((event) => event !== 'break_start');
 }
 
 /**
@@ -73,35 +85,65 @@ function localDateString(date = new Date()) {
     return `${year}-${month}-${day}`;
 }
 
+/** @returns {string} Fecha local del día anterior a `date`, en formato YYYY-MM-DD. */
+function previousLocalDateString(date) {
+    return localDateString(new Date(date.getTime() - 24 * 60 * 60 * 1000));
+}
+
 /**
  * Resuelve el estado de marcación de un empleado para hoy, combinando:
  * 1) el último estado que el servidor confirmó (cacheado en la última
- *    consulta online exitosa), con
+ *    consulta online exitosa — no está scopeado por fecha, así que ya
+ *    refleja un turno nocturno si el check_in se sincronizó en línea antes
+ *    de quedar offline), con
  * 2) los eventos que este mismo terminal ya encoló hoy para ese empleado pero
  *    el servidor todavía no confirmó — para no repetir ni saltear pasos
  *    mientras está offline.
+ * 3) si ninguno de los dos anteriores aporta un evento de HOY, revisa si hay
+ *    una jornada de AYER encolada localmente (no sincronizada, capturada
+ *    offline de punta a punta) que sigue abierta (su último evento no es
+ *    check_out) — mismo criterio que AttendanceDay::resolveForEvent() en el
+ *    servidor, para que un check_in nocturno capturado sin red no deje al
+ *    empleado sin poder marcar la salida al cruzar la medianoche.
  * @param {number} employeeId
  * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
  */
 export async function resolveEmployeeStatus(employeeId) {
     const cached = await getEmployeeStatusCache(employeeId);
-    const today = localDateString(await correctedNow());
-    const localEvents = (await getEventsForEmployeeOnDate(employeeId, today))
+    const now = await correctedNow();
+    const today = localDateString(now);
+
+    const todayEvents = (await getEventsForEmployeeOnDate(employeeId, today))
         .filter((event) => event.status === 'pending') // los en conflicto no cuentan como "ya registrados"
         .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
 
     let lastEvent = cached?.last_event ?? null;
     let lastEventTime = cached?.last_event_time ?? null;
 
-    for (const event of localEvents) {
-        lastEvent = event.event_type;
-        lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+    if (todayEvents.length > 0) {
+        for (const event of todayEvents) {
+            lastEvent = event.event_type;
+            lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+        }
+    } else if (lastEvent === null) {
+        const yesterdayEvents = (await getEventsForEmployeeOnDate(employeeId, previousLocalDateString(now)))
+            .filter((event) => event.status === 'pending')
+            .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+
+        const lastYesterday = yesterdayEvents[yesterdayEvents.length - 1];
+        if (lastYesterday && lastYesterday.event_type !== 'check_out') {
+            lastEvent = lastYesterday.event_type;
+            lastEventTime = new Date(lastYesterday.recorded_at).toTimeString().slice(0, 5);
+        }
     }
+
+    const employee = await getCachedEmployee(employeeId);
+    const hasScheduledBreak = employee?.has_scheduled_break ?? true;
 
     return {
         last_event: lastEvent,
         last_event_time: lastEventTime,
-        allowed_events: allowedNextEventTypes(lastEvent),
+        allowed_events: allowedNextEventTypes(lastEvent, hasScheduledBreak),
     };
 }
 
@@ -153,10 +195,11 @@ export async function enqueueMark(employeeId, eventType) {
     // no tiene forma de saber que ya se registró (el caché queda con el
     // último estado confirmado ANTES de esta marcación) y vuelve a ofrecer
     // los mismos eventos permitidos que antes de marcar.
+    const employee = await getCachedEmployee(employeeId);
     await setEmployeeStatusCache(employeeId, {
         last_event: eventType,
         last_event_time: recordedAt.toTimeString().slice(0, 5),
-        allowed_events: allowedNextEventTypes(eventType),
+        allowed_events: allowedNextEventTypes(eventType, employee?.has_scheduled_break ?? true),
     });
 
     return { client_event_id: clientEventId, recorded_at: recordedAt.toISOString() };

--- a/resources/js/attendances/terminal-offline/sync.js
+++ b/resources/js/attendances/terminal-offline/sync.js
@@ -10,7 +10,7 @@
  *               ver TerminalSetupController / terminal-setup.blade.php).
  */
 
-import { getMeta, setMeta, applyEmployeesDelta, logSync, countPendingEvents, countConflictEvents } from './db.js';
+import { getMeta, setMeta, applyEmployeesDelta, applyBreakFlags, logSync, countPendingEvents, countConflictEvents } from './db.js';
 
 const API_BASE = '/api/v1/terminal';
 
@@ -48,7 +48,8 @@ export async function apiFetch(path, options = {}) {
 
 /**
  * Trae el delta de empleados/descriptores desde la última sincronización y
- * lo aplica a la caché local.
+ * lo aplica a la caché local, junto con `break_flags` (siempre completo,
+ * ver EmployeeDescriptorSyncService::breakFlagsForBranch()).
  * @returns {Promise<{employees: number, tombstones: number}>}
  */
 export async function syncEmployees() {
@@ -60,6 +61,7 @@ export async function syncEmployees() {
         if (!data.ok) throw new Error(data.message || 'Error al sincronizar empleados');
 
         await applyEmployeesDelta(data.employees, data.tombstones);
+        await applyBreakFlags(data.break_flags);
         await setMeta('last_employee_sync_version', data.sync_version);
         await setMeta('employees_synced_at', Date.now());
 

--- a/tests/Feature/BreakButtonScheduleTest.php
+++ b/tests/Feature/BreakButtonScheduleTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\ScheduleBreak;
+use App\Models\ScheduleDay;
+use App\Services\ScheduleAssignmentService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: "Inicio de descanso" aparecía siempre después de marcar Entrada,
+ * sin importar si el horario del empleado contempla un descanso o no. Ahora
+ * depende del turno/horario efectivo del empleado (break_minutes > 0) — ver
+ * AttendanceCalculator::hasScheduledBreak() y
+ * AttendanceDay::filterAllowedByBreakSchedule().
+ */
+function makeBreakTestEmployee(): Employee
+{
+    static $ci = 8200000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Break {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create([
+        'name' => "Sucursal Break {$n}",
+        'company_id' => $company->id,
+        'coordinates' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ]);
+    $department = Department::create(['name' => "Depto Break {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Break {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Break',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+/** Asigna un horario fijo los 7 días de la semana, con o sin descanso configurado. */
+function assignScheduleWithBreak(Employee $employee, bool $withBreak): void
+{
+    $schedule = Schedule::create(['name' => 'Horario Break Test', 'shift_type' => 'diurno', 'description' => null]);
+
+    foreach (range(1, 7) as $dayOfWeek) {
+        $day = ScheduleDay::create([
+            'schedule_id' => $schedule->id,
+            'day_of_week' => $dayOfWeek,
+            'is_active' => true,
+            'start_time' => '07:00',
+            'end_time' => '22:00',
+        ]);
+
+        if ($withBreak) {
+            ScheduleBreak::create([
+                'schedule_day_id' => $day->id,
+                'name' => 'Almuerzo',
+                'start_time' => '12:00',
+                'end_time' => '13:00',
+            ]);
+        }
+    }
+
+    ScheduleAssignmentService::assign($employee, $schedule, now()->subYear());
+}
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('sin horario asignado, no ofrece ni acepta "Inicio de descanso"', function () {
+    $employee = makeBreakTestEmployee();
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    $state = AttendanceDay::currentStateFor($employee, Carbon::now());
+    expect($state['allowed'])->not->toContain('break_start')
+        ->and($state['allowed'])->toContain('check_out');
+
+    $response = $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'break_start', 'source' => 'manual']);
+    $response->assertUnprocessable();
+});
+
+it('con horario asignado pero sin descanso configurado (break_minutes = 0), tampoco lo ofrece', function () {
+    $employee = makeBreakTestEmployee();
+    assignScheduleWithBreak($employee, withBreak: false);
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    $state = AttendanceDay::currentStateFor($employee, Carbon::now());
+    expect($state['allowed'])->not->toContain('break_start');
+});
+
+it('con horario que sí tiene descanso configurado, ofrece y acepta "Inicio de descanso"', function () {
+    $employee = makeBreakTestEmployee();
+    assignScheduleWithBreak($employee, withBreak: true);
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    $state = AttendanceDay::currentStateFor($employee, Carbon::now());
+    expect($state['allowed'])->toContain('break_start');
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'break_start', 'source' => 'manual'])
+        ->assertOk();
+});
+
+it('una vez iniciado el descanso, siempre se puede cerrar (break_end nunca se filtra)', function () {
+    $employee = makeBreakTestEmployee();
+
+    // Sin horario asignado — pero el empleado YA está en pausa (dato existente,
+    // ej. cargado antes de este fix o por un horario que después cambió).
+    $day = AttendanceDay::create(['employee_id' => $employee->id, 'date' => now()->toDateString(), 'status' => 'present']);
+    AttendanceEvent::create([
+        'attendance_day_id' => $day->id,
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'recorded_at' => now()->subHours(2),
+        'source' => 'manual',
+    ]);
+    AttendanceEvent::create([
+        'attendance_day_id' => $day->id,
+        'employee_id' => $employee->id,
+        'event_type' => 'break_start',
+        'recorded_at' => now()->subHour(),
+        'source' => 'manual',
+    ]);
+
+    $state = AttendanceDay::currentStateFor($employee, Carbon::now());
+    expect($state['allowed'])->toBe(['break_end']);
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'break_end', 'source' => 'manual'])
+        ->assertOk();
+});

--- a/tests/Feature/MobileAttendanceLinkTest.php
+++ b/tests/Feature/MobileAttendanceLinkTest.php
@@ -8,11 +8,15 @@ use App\Models\Contract;
 use App\Models\Department;
 use App\Models\Employee;
 use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\ScheduleBreak;
+use App\Models\ScheduleDay;
 use App\Models\Terminal;
 use App\Models\User;
 use App\Notifications\MobileDeviceLinkedNotification;
 use App\Notifications\MobileDeviceRelinkedNotification;
 use App\Notifications\MobileLinkThrottledNotification;
+use App\Services\ScheduleAssignmentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\Request;
@@ -57,6 +61,35 @@ function makeLinkableEmployee(array $overrides = []): Employee
     ]);
 
     return $employee->fresh();
+}
+
+/**
+ * Asigna un horario fijo con descanso configurado los 7 días de la semana —
+ * necesario para que AttendanceDay::resolveForEvent() ofrezca 'break_start'
+ * (ver AttendanceCalculator::hasScheduledBreak()).
+ */
+function giveEmployeeBreakSchedule(Employee $employee): void
+{
+    $schedule = Schedule::create(['name' => 'Horario Con Descanso', 'shift_type' => 'diurno', 'description' => null]);
+
+    foreach (range(1, 7) as $dayOfWeek) {
+        $day = ScheduleDay::create([
+            'schedule_id' => $schedule->id,
+            'day_of_week' => $dayOfWeek,
+            'is_active' => true,
+            'start_time' => '07:00',
+            'end_time' => '22:00',
+        ]);
+
+        ScheduleBreak::create([
+            'schedule_day_id' => $day->id,
+            'name' => 'Almuerzo',
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+        ]);
+    }
+
+    ScheduleAssignmentService::assign($employee, $schedule, now()->subYear());
 }
 
 // ─── Vinculación (/vincular-dispositivo) ───────────────────────────────────────
@@ -238,6 +271,7 @@ it('status devuelve el último evento y los eventos permitidos para el propio em
  */
 it('status devuelve la lista completa de eventos de hoy, no solo el último', function () {
     $employee = makeLinkableEmployee();
+    giveEmployeeBreakSchedule($employee);
     Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
 
     $this->postJson('/api/v1/mobile/events/sync', [

--- a/tests/Feature/OfflineSyncBreakAndOvernightTest.php
+++ b/tests/Feature/OfflineSyncBreakAndOvernightTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\ScheduleBreak;
+use App\Models\ScheduleDay;
+use App\Models\Terminal;
+use App\Services\EmployeeDescriptorSyncService;
+use App\Services\ScheduleAssignmentService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el turno nocturno y el filtro de "Inicio de descanso" solo se
+ * habían arreglado en el flujo de marcación online (AttendanceFaceMarkController)
+ * y en el sync de eventos offline (AttendanceEventSyncService/
+ * MobileEventSyncService) — pero TerminalEmployeeSyncController::status()
+ * (consultado por el terminal cuando SÍ hay red, antes de caer al cálculo
+ * local) y los payloads de heartbeat/sync que alimentan la caché offline
+ * (EmployeeDescriptorSyncService, MobileHeartbeatController) seguían con la
+ * lógica vieja.
+ */
+function makeOfflineTestEmployee(): Employee
+{
+    static $ci = 8300000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Offline {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create([
+        'name' => "Sucursal Offline {$n}",
+        'company_id' => $company->id,
+        'coordinates' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ]);
+    $department = Department::create(['name' => "Depto Offline {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Offline {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Offline',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+function assignBreakScheduleToEmployee(Employee $employee): void
+{
+    $schedule = Schedule::create(['name' => 'Horario Offline Test', 'shift_type' => 'diurno', 'description' => null]);
+
+    foreach (range(1, 7) as $dayOfWeek) {
+        $day = ScheduleDay::create([
+            'schedule_id' => $schedule->id,
+            'day_of_week' => $dayOfWeek,
+            'is_active' => true,
+            'start_time' => '07:00',
+            'end_time' => '22:00',
+        ]);
+
+        ScheduleBreak::create([
+            'schedule_day_id' => $day->id,
+            'name' => 'Almuerzo',
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+        ]);
+    }
+
+    ScheduleAssignmentService::assign($employee, $schedule, now()->subYear());
+}
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+// ─── TerminalEmployeeSyncController::status() ──────────────────────────────
+
+it('status() permite marcar salida de un turno nocturno abierto el día anterior', function () {
+    $employee = makeOfflineTestEmployee();
+    $terminal = Terminal::create(['name' => 'Terminal Status Test', 'branch_id' => $employee->branch_id]);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    Carbon::setTestNow(Carbon::parse('2026-08-27 17:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
+    $response = $this->getJson("/api/v1/terminal/employees/{$employee->id}/status");
+
+    $response->assertOk();
+    expect($response->json('allowed_events'))->toContain('check_out')
+        ->and($response->json('last_event'))->toBe('check_in');
+});
+
+it('status() no ofrece "Inicio de descanso" sin horario asignado', function () {
+    $employee = makeOfflineTestEmployee();
+    $terminal = Terminal::create(['name' => 'Terminal Status Test 2', 'branch_id' => $employee->branch_id]);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    $response = $this->getJson("/api/v1/terminal/employees/{$employee->id}/status");
+
+    $response->assertOk();
+    expect($response->json('allowed_events'))->not->toContain('break_start');
+});
+
+// ─── EmployeeDescriptorSyncService::deltaSince() — break_flags ─────────────
+
+it('deltaSince incluye break_flags reflejando si cada empleado tiene descanso configurado', function () {
+    $employeeWithBreak = makeOfflineTestEmployee();
+    assignBreakScheduleToEmployee($employeeWithBreak);
+
+    $employeeWithoutBreak = makeOfflineTestEmployee();
+    $employeeWithoutBreak->update(['branch_id' => $employeeWithBreak->branch_id]);
+
+    $terminal = Terminal::create(['name' => 'Terminal Delta Test', 'branch_id' => $employeeWithBreak->branch_id]);
+
+    $delta = app(EmployeeDescriptorSyncService::class)->deltaSince($terminal, null);
+
+    expect($delta['break_flags'][$employeeWithBreak->id])->toBeTrue()
+        ->and($delta['break_flags'][$employeeWithoutBreak->id])->toBeFalse();
+});
+
+it('deltaSince recalcula break_flags para TODOS los empleados activos, no solo los que cambiaron desde $since', function () {
+    $employee = makeOfflineTestEmployee();
+    $terminal = Terminal::create(['name' => 'Terminal Delta Test 2', 'branch_id' => $employee->branch_id]);
+    $service = app(EmployeeDescriptorSyncService::class);
+
+    // Primera sync completa — el empleado todavía no tiene horario.
+    $first = $service->deltaSince($terminal, null);
+    expect($first['break_flags'][$employee->id])->toBeFalse();
+
+    // Se asigna un horario con descanso DESPUÉS de la primera sync — no toca
+    // employees.updated_at, así que un delta filtrado por $since lo pasaría por alto.
+    $since = Carbon::parse($first['sync_version']);
+    assignBreakScheduleToEmployee($employee);
+
+    $second = $service->deltaSince($terminal, $since);
+    expect($second['employees'])->toBeEmpty() // no cambió el registro del empleado
+        ->and($second['break_flags'][$employee->id])->toBeTrue(); // pero el flag sí se actualiza
+});
+
+// ─── MobileHeartbeatController — has_scheduled_break ───────────────────────
+
+it('el heartbeat móvil incluye has_scheduled_break en el payload del empleado', function () {
+    $employee = makeOfflineTestEmployee();
+    assignBreakScheduleToEmployee($employee);
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.has_scheduled_break'))->toBeTrue();
+});
+
+it('el heartbeat móvil marca has_scheduled_break en false sin horario asignado', function () {
+    $employee = makeOfflineTestEmployee();
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/mobile/heartbeat');
+
+    $response->assertOk();
+    expect($response->json('employee.has_scheduled_break'))->toBeFalse();
+});

--- a/tests/Feature/OvernightShiftAttendanceTest.php
+++ b/tests/Feature/OvernightShiftAttendanceTest.php
@@ -73,7 +73,7 @@ it('permite marcar salida pasada la medianoche de un turno que empezó el día a
     Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
     // currentStateFor() es lo que identify() usa para decidir qué botones mostrar
     // en el front-end (la identificación facial en sí no aplica en este test).
-    $state = AttendanceDay::currentStateFor($employee->id, Carbon::now());
+    $state = AttendanceDay::currentStateFor($employee, Carbon::now());
     expect($state['allowed'])->toContain('check_out');
 
     $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_out', 'source' => 'manual'])

--- a/tests/Feature/OvernightShiftAttendanceTest.php
+++ b/tests/Feature/OvernightShiftAttendanceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use App\Models\AttendanceDay;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Terminal;
+use App\Services\AttendanceEventSyncService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: un turno que cruza medianoche (ej. entrada 17:00 → salida 01:00
+ * del día siguiente) no podía cerrarse — AttendanceDay se armaba por fecha
+ * calendario del momento de marcar, no por la jornada abierta del empleado,
+ * así que la salida caía en un AttendanceDay nuevo sin marcaciones previas
+ * y la transición 'check_out' no era válida ahí. Ver AttendanceDay::resolveForEvent().
+ */
+function makeOvernightEmployee(): Employee
+{
+    static $ci = 8100000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Overnight {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create([
+        'name' => "Sucursal Overnight {$n}",
+        'company_id' => $company->id,
+        'coordinates' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ]);
+    $department = Department::create(['name' => "Depto Overnight {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Overnight {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Overnight',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('permite marcar salida pasada la medianoche de un turno que empezó el día anterior (flujo HTTP)', function () {
+    $employee = makeOvernightEmployee();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-27 17:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])
+        ->assertOk();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
+    // currentStateFor() es lo que identify() usa para decidir qué botones mostrar
+    // en el front-end (la identificación facial en sí no aplica en este test).
+    $state = AttendanceDay::currentStateFor($employee->id, Carbon::now());
+    expect($state['allowed'])->toContain('check_out');
+
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_out', 'source' => 'manual'])
+        ->assertOk();
+
+    $day = AttendanceDay::where('employee_id', $employee->id)->where('date', '2026-08-27')->first();
+    expect($day)->not->toBeNull()
+        ->and($day->events()->count())->toBe(2)
+        ->and($day->events()->pluck('event_type')->toArray())->toBe(['check_in', 'check_out']);
+
+    // No debe haberse creado una jornada para el 28 a partir de la salida.
+    expect(AttendanceDay::where('employee_id', $employee->id)->where('date', '2026-08-28')->exists())->toBeFalse();
+});
+
+it('tras cerrar el turno nocturno, permite una nueva entrada más tarde ese mismo día calendario', function () {
+    $employee = makeOvernightEmployee();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-27 17:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_out', 'source' => 'manual'])->assertOk();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-28 17:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])
+        ->assertOk();
+
+    $newDay = AttendanceDay::where('employee_id', $employee->id)->where('date', '2026-08-28')->first();
+    expect($newDay)->not->toBeNull()
+        ->and($newDay->events()->count())->toBe(1)
+        ->and($newDay->events()->first()->event_type)->toBe('check_in');
+});
+
+it('una jornada abierta de hace 2+ días no se reabre automáticamente', function () {
+    $employee = makeOvernightEmployee();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-20 17:00:00'));
+    $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_in', 'source' => 'manual'])->assertOk();
+
+    // 3 días después, sin haber marcado nada en el medio.
+    Carbon::setTestNow(Carbon::parse('2026-08-23 01:00:00'));
+    $response = $this->postJson('/marcar', ['employee_id' => $employee->id, 'event_type' => 'check_out', 'source' => 'manual']);
+
+    $response->assertUnprocessable();
+    expect($response->json('message'))->toContain('aún no tiene marcaciones hoy');
+});
+
+it('AttendanceEventSyncService también respeta la jornada nocturna abierta al sincronizar offline', function () {
+    $employee = makeOvernightEmployee();
+    $terminal = Terminal::create(['name' => 'Terminal Overnight', 'branch_id' => $employee->branch_id]);
+    $service = new AttendanceEventSyncService;
+
+    $checkIn = [
+        'client_event_id' => (string) Str::uuid(),
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-27T20:00:00Z', // 17:00 America/Asuncion (UTC-3)
+    ];
+    $checkOut = [
+        'client_event_id' => (string) Str::uuid(),
+        'employee_id' => $employee->id,
+        'event_type' => 'check_out',
+        'recorded_at' => '2026-08-28T04:00:00Z', // 01:00 America/Asuncion del día siguiente
+    ];
+
+    $results = $service->syncBatch($terminal, [$checkIn, $checkOut]);
+
+    expect($results[0]['status'])->toBe('synced')
+        ->and($results[1]['status'])->toBe('synced');
+
+    $day = AttendanceDay::where('employee_id', $employee->id)->where('date', '2026-08-27')->first();
+    expect($day)->not->toBeNull()
+        ->and($day->events()->count())->toBe(2);
+});


### PR DESCRIPTION
## Summary

Dos bugs reales reportados por un usuario de producción (Aníbal), reproducidos y corregidos en todos los puntos de entrada del flujo de marcación (online, sync offline de terminal, sync offline de celular, y resolución local sin red).

### 1. Turno nocturno — no se podía marcar salida cruzando medianoche

Un empleado que entraba a las 17:00 y quería marcar salida a la 01:00 del día siguiente **no podía**: el sistema rechazaba la marcación pidiéndole volver a marcar "Entrada", porque `AttendanceDay` se armaba por la fecha calendario del momento de marcar, no por la jornada que el empleado tenía abierta. La entrada de la noche anterior quedaba huérfana para siempre — afectando directamente el cálculo de horas/nómina de cualquier turno nocturno.

- `AttendanceDay::resolveForEvent()` resuelve a qué jornada asociar un evento entrante: la de hoy, o la de ayer si sigue abierta (su último evento no es `check_out`) y la transición pedida solo tiene sentido ahí. Nunca mira más de un día hacia atrás — una jornada abierta de 2+ días requiere revisión manual (`attendance:check-missing`), no se reabre sola.
- `AttendanceDay::currentStateFor()` expone el mismo criterio para `identify()` (qué botones mostrar en el front-end).
- Aplicado en `AttendanceFaceMarkController::store()`, `AttendanceEventSyncService`, `MobileEventSyncService` y `TerminalEmployeeSyncController::status()`.
- La resolución **local sin red** (`terminal-offline/queue.js`, `mobile-offline/queue.js`) también se corrigió — revisa si hay una jornada de ayer encolada localmente (capturada offline de punta a punta) que sigue abierta, sin necesidad de cachear ningún dato nuevo.
- `AttendanceCalculator` ya soportaba turnos nocturnos sin cambios: usa `attendance_day_id` (no un filtro por fecha) para traer los eventos del día.

### 2. "Inicio de descanso" aparecía siempre, sin importar el horario del empleado

Cualquier empleado veía el botón de descanso después de marcar Entrada, sin importar si su horario/turno asignado contempla un descanso o no.

- `AttendanceCalculator::hasScheduledBreak()` expone como método público la misma jerarquía que ya usaba el cálculo de horas (rotación > horario fijo) para resolver si el turno de una fecha tiene `break_minutes > 0`.
- `AttendanceDay::filterAllowedByBreakSchedule()` quita `'break_start'` cuando el empleado no tiene horario asignado, o su horario no define descanso. `'break_end'` nunca se filtra — si ya está en pausa, siempre puede cerrarla.
- Mismos 4 puntos de entrada backend que el fix anterior.
- Offline: se cachea `has_scheduled_break` por empleado (`employees_cache` en el terminal vía `EmployeeDescriptorSyncService::breakFlagsForBranch()`, recalculado completo en cada sync; `own_employee` en el celular vía `MobileHeartbeatController`, refrescado en cada heartbeat ~90s). Tradeoff aceptado y documentado: puede quedar desactualizado si el dispositivo está offline más tiempo que su ciclo de sync habitual — el servidor sigue siendo la fuente de verdad y protege el dato como conflicto al reconectar.

### Documentación
`CLAUDE.md` actualizado con 8 convenciones/gotchas descubiertos durante todo este trabajo de terminales/asistencia (notificaciones de campanita, `notify()` en try/catch, timing de `modalContent()`, `Select::relationship()` + `modifyQueryUsing`, `lockForUpdate()` para tokens de un solo uso, concordancia de género en labels, testing de `ActionGroup`, estado offline cruzado entre dispositivos).

## Test plan

- [x] `OvernightShiftAttendanceTest`, `BreakButtonScheduleTest`, `OfflineSyncBreakAndOvernightTest` — nuevos, cubren turno nocturno + filtro de descanso en todos los puntos de entrada
- [x] Suite completa: 582/583 passed (el único fallo es un problema preexistente de manifest de Vite en el entorno de test, no relacionado a estos cambios)
- [x] `vendor/bin/pint --dirty` — passed
- [x] Sintaxis JS verificada (`node --check`) en los 5 archivos modificados de `terminal-offline/` y `mobile-offline/`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_