### PR TITLE
Extender fix de turno nocturno/descanso a MobileStatusController y approve()

### DIFF
--- a/app/Http/Controllers/Api/MobileStatusController.php
+++ b/app/Http/Controllers/Api/MobileStatusController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\AttendanceDay;
 use App\Models\AttendanceEvent;
 use App\Models\Employee;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -20,7 +21,10 @@ use Illuminate\Http\Request;
  *
  * `today_events` (lista completa del día, no solo el último) alimenta la
  * pantalla "Mis marcaciones" en /marcar — a diferencia del resto de esta
- * respuesta, no tiene resolución local offline equivalente.
+ * respuesta, no tiene resolución local offline equivalente. Si todavía no
+ * hay eventos hoy pero la jornada de ayer sigue abierta (turno nocturno),
+ * muestra los eventos de esa jornada en su lugar — mismo criterio que
+ * AttendanceDay::currentStateFor().
  */
 class MobileStatusController extends Controller
 {
@@ -29,20 +33,28 @@ class MobileStatusController extends Controller
         /** @var Employee $employee */
         $employee = $request->user();
 
-        $today = now(config('app.timezone'))->toDateString();
+        $now = Carbon::now(config('app.timezone'));
 
-        $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today)->first();
-        $events = $day
-            ? AttendanceEvent::where('attendance_day_id', $day->id)->orderBy('recorded_at')->get(['event_type', 'recorded_at'])
+        $today = AttendanceDay::where('employee_id', $employee->id)->where('date', $now->toDateString())->first();
+        $todayEvents = $today
+            ? AttendanceEvent::where('attendance_day_id', $today->id)->orderBy('recorded_at')->get(['event_type', 'recorded_at'])
             : collect();
-        $last = $events->last();
+
+        $state = AttendanceDay::currentStateFor($employee, $now);
+
+        $displayEvents = $todayEvents;
+        if ($todayEvents->isEmpty() && $state['last'] !== null) {
+            $displayEvents = AttendanceEvent::where('attendance_day_id', $state['last']->attendance_day_id)
+                ->orderBy('recorded_at')
+                ->get(['event_type', 'recorded_at']);
+        }
 
         return response()->json([
             'ok' => true,
-            'last_event' => $last?->event_type,
-            'last_event_time' => $last?->recorded_at?->format('H:i'),
-            'allowed_events' => AttendanceEvent::allowedNextEventTypes($last?->event_type),
-            'today_events' => $events->map(fn (AttendanceEvent $event): array => [
+            'last_event' => $state['last']?->event_type,
+            'last_event_time' => $state['last']?->recorded_at?->format('H:i'),
+            'allowed_events' => $state['allowed'],
+            'today_events' => $displayEvents->map(fn (AttendanceEvent $event): array => [
                 'event_type' => $event->event_type,
                 'event_type_label' => AttendanceEvent::getEventTypeLabel($event->event_type),
                 'time' => $event->recorded_at->format('H:i'),

--- a/app/Models/AttendanceMarkFailure.php
+++ b/app/Models/AttendanceMarkFailure.php
@@ -313,17 +313,24 @@ class AttendanceMarkFailure extends Model
         $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
 
         return DB::transaction(function () use ($employee, $eventType, $recordedAt, $date, $approvedById, $notes) {
-            $day = AttendanceDay::firstOrCreate(
-                ['employee_id' => $employee->id, 'date' => $date],
-                ['status' => 'present']
+            // Resuelve a qué jornada asociar el evento — la de hoy, o la de ayer si sigue
+            // abierta y la transición pedida solo tiene sentido ahí (turno nocturno que
+            // cruza medianoche). Ver AttendanceDay::resolveForEvent(). Sin esto, un
+            // checkout de turno nocturno rechazado por AttendanceFaceMarkController
+            // nunca podía aprobarse acá tampoco — volvía a fallar con el mismo motivo.
+            ['day' => $day, 'last' => $last, 'allowed' => $allowed] = AttendanceDay::resolveForEvent(
+                $employee,
+                $recordedAt,
+                $eventType,
+                lockForUpdate: true,
             );
 
-            $last = AttendanceEvent::where('attendance_day_id', $day->id)
-                ->lockForUpdate()
-                ->latest('recorded_at')
-                ->first();
-
-            $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
+            if (! $day) {
+                $day = AttendanceDay::firstOrCreate(
+                    ['employee_id' => $employee->id, 'date' => $date],
+                    ['status' => 'present']
+                );
+            }
 
             if (! in_array($eventType, $allowed, true)) {
                 $lastLabel = $last ? AttendanceEvent::getEventTypeLabel($last->event_type) : 'ninguno';

--- a/tests/Feature/MobileEventSyncServiceTest.php
+++ b/tests/Feature/MobileEventSyncServiceTest.php
@@ -8,8 +8,12 @@ use App\Models\Contract;
 use App\Models\Department;
 use App\Models\Employee;
 use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\ScheduleBreak;
+use App\Models\ScheduleDay;
 use App\Models\User;
 use App\Services\MobileEventSyncService;
+use App\Services\ScheduleAssignmentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 
@@ -50,6 +54,31 @@ function makeMobileSyncEmployee(): Employee
     ]);
 
     return $employee->fresh();
+}
+
+/** Asigna un horario fijo con descanso configurado los 7 días de la semana. */
+function assignMobileSyncBreakSchedule(Employee $employee): void
+{
+    $schedule = Schedule::create(['name' => 'Horario Mobile Sync Test', 'shift_type' => 'diurno', 'description' => null]);
+
+    foreach (range(1, 7) as $dayOfWeek) {
+        $day = ScheduleDay::create([
+            'schedule_id' => $schedule->id,
+            'day_of_week' => $dayOfWeek,
+            'is_active' => true,
+            'start_time' => '07:00',
+            'end_time' => '22:00',
+        ]);
+
+        ScheduleBreak::create([
+            'schedule_day_id' => $day->id,
+            'name' => 'Almuerzo',
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+        ]);
+    }
+
+    ScheduleAssignmentService::assign($employee, $schedule, now()->subYear());
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -163,6 +192,7 @@ it('rechaza como conflict un evento cuya secuencia ya no es válida en el servid
 
 it('aprobar un conflicto mobile reconstruye el evento con source mobile', function () {
     $employee = makeMobileSyncEmployee();
+    assignMobileSyncBreakSchedule($employee);
     $service = app(MobileEventSyncService::class);
 
     // El check_in ya está en el servidor.

--- a/tests/Feature/MobileStatusOvernightAndBreakTest.php
+++ b/tests/Feature/MobileStatusOvernightAndBreakTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use App\Models\AttendanceDay;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\ScheduleBreak;
+use App\Models\ScheduleDay;
+use App\Models\User;
+use App\Services\ScheduleAssignmentService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: MobileStatusController::show() (endpoint online-preferido de
+ * /marcar para el celular) y AttendanceMarkFailure::approve() (aprobación
+ * manual de un fallo desde Filament) se habían quedado con la lógica vieja
+ * al arreglar el turno nocturno y el filtro de "Inicio de descanso" — ambos
+ * son puntos de entrada tan válidos como los ya corregidos.
+ */
+function makeStatusTestEmployee(): Employee
+{
+    static $ci = 8400000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Status {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Status {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Status {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Status {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Status',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+        'face_descriptor' => array_fill(0, 128, 0.1),
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+function assignStatusTestBreakSchedule(Employee $employee): void
+{
+    $schedule = Schedule::create(['name' => 'Horario Status Test', 'shift_type' => 'diurno', 'description' => null]);
+
+    foreach (range(1, 7) as $dayOfWeek) {
+        $day = ScheduleDay::create([
+            'schedule_id' => $schedule->id,
+            'day_of_week' => $dayOfWeek,
+            'is_active' => true,
+            'start_time' => '07:00',
+            'end_time' => '22:00',
+        ]);
+
+        ScheduleBreak::create([
+            'schedule_day_id' => $day->id,
+            'name' => 'Almuerzo',
+            'start_time' => '12:00',
+            'end_time' => '13:00',
+        ]);
+    }
+
+    ScheduleAssignmentService::assign($employee, $schedule, now()->subYear());
+}
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+// ─── MobileStatusController::show() ────────────────────────────────────────
+
+it('status móvil permite marcar salida de un turno nocturno abierto el día anterior', function () {
+    $employee = makeStatusTestEmployee();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-27 17:00:00'));
+    $this->postJson('/marcar', [
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'source' => 'manual',
+        'location' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ])->assertOk();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+
+    $response = $this->getJson('/api/v1/mobile/status');
+
+    $response->assertOk();
+    expect($response->json('last_event'))->toBe('check_in')
+        ->and($response->json('allowed_events'))->toContain('check_out')
+        ->and($response->json('today_events'))->toHaveCount(1)
+        ->and($response->json('today_events.0.event_type'))->toBe('check_in');
+});
+
+it('status móvil no ofrece "Inicio de descanso" sin horario asignado', function () {
+    $employee = makeStatusTestEmployee();
+
+    $this->postJson('/marcar', [
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'source' => 'manual',
+        'location' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ])->assertOk();
+
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $response = $this->getJson('/api/v1/mobile/status');
+
+    $response->assertOk();
+    expect($response->json('allowed_events'))->not->toContain('break_start');
+});
+
+it('status móvil ofrece "Inicio de descanso" con horario que lo contempla', function () {
+    $employee = makeStatusTestEmployee();
+    assignStatusTestBreakSchedule($employee);
+
+    $this->postJson('/marcar', [
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'source' => 'manual',
+        'location' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ])->assertOk();
+
+    Sanctum::actingAs($employee, [Employee::MOBILE_SYNC_ABILITY]);
+    $response = $this->getJson('/api/v1/mobile/status');
+
+    $response->assertOk();
+    expect($response->json('allowed_events'))->toContain('break_start');
+});
+
+// ─── AttendanceMarkFailure::approve() ──────────────────────────────────────
+
+it('approve() reconstruye la salida de un turno nocturno rechazado por cruzar medianoche', function () {
+    $employee = makeStatusTestEmployee();
+
+    Carbon::setTestNow(Carbon::parse('2026-08-27 17:00:00'));
+    $this->postJson('/marcar', [
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'source' => 'manual',
+        'location' => ['lat' => -25.2867, 'lng' => -57.6478],
+    ])->assertOk();
+
+    // Salida rechazada (simula el estado pre-fix: quedó como fallo registrado).
+    Carbon::setTestNow(Carbon::parse('2026-08-28 01:00:00'));
+    $failure = AttendanceMarkFailure::record([
+        'mode' => 'unknown',
+        'failure_type' => 'invalid_event_sequence',
+        'employee_id' => $employee->id,
+        'branch_id' => $employee->branch_id,
+        'attempted_event_type' => 'check_out',
+        'failure_message' => 'Secuencia de evento no permitida.',
+    ]);
+
+    $admin = User::create(['name' => 'Admin', 'email' => 'admin-status@test.com', 'password' => bcrypt('secret')]);
+    $result = $failure->approve($admin->id, 'check_out', Carbon::now());
+
+    expect($result['success'])->toBeTrue();
+
+    $day = AttendanceDay::where('employee_id', $employee->id)->where('date', '2026-08-27')->first();
+    expect($day)->not->toBeNull()
+        ->and($day->events()->pluck('event_type')->toArray())->toBe(['check_in', 'check_out']);
+});


### PR DESCRIPTION
## Summary

Auditando el mismo patrón de bug corregido en #118 (lógica de estado de asistencia duplicada en múltiples puntos de entrada, desincronizada), encontré 2 lugares más que se habían quedado con la lógica vieja:

- **`MobileStatusController::show()`** — endpoint online-preferido de `/marcar` para el celular, hermano exacto de `TerminalEmployeeSyncController::status()` (que sí se había corregido en #118). Tenía ambos bugs: turno nocturno y filtro de descanso. También corregí `today_events` (alimenta "Mis marcaciones"): si hoy todavía no tiene eventos pero la jornada de ayer sigue abierta, ahora muestra esos eventos en vez de una lista vacía.

- **`AttendanceMarkFailure::approve()`** — reconstrucción manual de un fallo desde Filament (`AttendanceMarkFailureResource`). Sin este fix, un checkout de turno nocturno rechazado por `AttendanceFaceMarkController` quedaba imposible de aprobar acá también: volvía a fallar con el mismo motivo, sin más salida que editar la base de datos directamente. Ahora usa `AttendanceDay::resolveForEvent()`, igual que los demás puntos de entrada.

Revisé exhaustivamente todos los usos de `allowedNextEventTypes()` y `AttendanceDay::firstOrCreate()` en PHP y JS — no quedan más instancias sueltas de esta máquina de estados sin pasar por `AttendanceDay::resolveForEvent()`/`currentStateFor()`.

## Test plan

- [x] `MobileStatusOvernightAndBreakTest` — nuevo, 4 tests cubriendo turno nocturno + descanso en `MobileStatusController` y `approve()`
- [x] Ajuste de 1 test existente (`MobileEventSyncServiceTest`) que asumía el comportamiento viejo de "descanso siempre disponible"
- [x] Suite completa: 586/587 passed (el único fallo es un problema preexistente de manifest de Vite en el entorno de test, no relacionado)
- [x] `vendor/bin/pint --dirty` — passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_