### PR TITLE
Envolver notify() en try/catch en enrolamiento facial y bloqueo de vinculación

### DIFF
--- a/app/Http/Controllers/FaceEnrollmentController.php
+++ b/app/Http/Controllers/FaceEnrollmentController.php
@@ -112,7 +112,18 @@ class FaceEnrollmentController extends Controller
                 'employee_id' => $enrollment->employee_id,
             ]);
 
-            User::all()->each(fn (User $user) => $user->notify(new FaceEnrollmentPendingApprovalNotification($enrollment)));
+            // La captura ya quedó persistida arriba — un fallo al notificar (ej. mailer
+            // mal configurado) no debe convertirse en un 500 que le diga al empleado que
+            // falló cuando en realidad su rostro ya se guardó correctamente (mismo gotcha
+            // corregido en Terminal::claimSanctumToken() / Employee::claimMobileToken()).
+            try {
+                User::all()->each(fn (User $user) => $user->notify(new FaceEnrollmentPendingApprovalNotification($enrollment)));
+            } catch (\Throwable $e) {
+                Log::warning("No se pudo notificar la captura facial pendiente de aprobación (enrollment #{$enrollment->id}): {$e->getMessage()}", [
+                    'enrollment_id' => $enrollment->id,
+                    'employee_id' => $enrollment->employee_id,
+                ]);
+            }
 
             // Retornar una respuesta JSON indicando éxito
             return response()->json([

--- a/app/Http/Controllers/MobileLinkController.php
+++ b/app/Http/Controllers/MobileLinkController.php
@@ -143,6 +143,13 @@ class MobileLinkController extends Controller
 
         Cache::put($notifiedKey, true, now()->endOfDay());
 
-        User::all()->each(fn (User $user) => $user->notify(new MobileLinkThrottledNotification($ip, $lastCiAttempted)));
+        // Un fallo al notificar (ej. mailer mal configurado) no debe convertirse en un 500
+        // genérico para un empleado que ya está siendo bloqueado por el rate limiter — debe
+        // seguir viendo el mensaje 429 "límite alcanzado", no un error interno sin relación.
+        try {
+            User::all()->each(fn (User $user) => $user->notify(new MobileLinkThrottledNotification($ip, $lastCiAttempted)));
+        } catch (\Throwable $e) {
+            Log::warning("No se pudo notificar el límite diario de vinculación alcanzado (IP {$ip}): {$e->getMessage()}");
+        }
     }
 }

--- a/tests/Feature/NotifyMailFailureResilienceTest.php
+++ b/tests/Feature/NotifyMailFailureResilienceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Http\Controllers\MobileLinkController;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\FaceEnrollment;
+use App\Models\Position;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: mismo gotcha que Terminal::claimSanctumToken() /
+ * Employee::claimMobileToken() — un fallo del mailer no debe convertir una
+ * operación ya persistida en un error de cliente. Ver
+ * FaceEnrollmentController::store() y MobileLinkController::notifyAdminsOfDailyLimitOnce().
+ */
+function makeNotifyFailureEmployee(): Employee
+{
+    static $ci = 8500000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Notify {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Notify {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Notify {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Notify {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Notify',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+it('la captura facial por auto-registro se guarda aunque falle el envío de la notificación por email', function () {
+    config(['mail.default' => 'resend', 'services.resend.key' => null]);
+    User::create(['name' => 'Admin', 'email' => 'admin-facemail@test.com', 'password' => bcrypt('secret')]);
+
+    $employee = makeNotifyFailureEmployee();
+    $enrollment = FaceEnrollment::createForEmployee($employee, User::factory()->create()->id, 24);
+
+    $response = $this->postJson("/registro-facial/{$enrollment->token}", [
+        'face_descriptor' => array_fill(0, 128, 0.1),
+        'samples_count' => 5,
+        'face_score' => 0.9,
+    ]);
+
+    $response->assertOk()->assertJson(['success' => true]);
+    expect($enrollment->fresh()->status)->toBe('pending_approval')
+        ->and($enrollment->fresh()->face_descriptor)->not->toBeNull();
+});
+
+it('el bloqueo por límite diario de vinculación responde 429 aunque falle el envío de la notificación por email', function () {
+    config(['mail.default' => 'resend', 'services.resend.key' => null]);
+    User::create(['name' => 'Admin', 'email' => 'admin-linkmail@test.com', 'password' => bcrypt('secret')]);
+
+    $request = Request::create('/vincular-dispositivo', 'POST', ['ci' => '9999999']);
+    $request->server->set('REMOTE_ADDR', '203.0.113.55');
+
+    $exception = new ThrottleRequestsException('Too Many Attempts.', null, [
+        'Retry-After' => 60,
+        'X-RateLimit-Limit' => 15,
+        'X-RateLimit-Remaining' => 0,
+    ]);
+
+    $response = MobileLinkController::throttledResponse($exception, $request);
+
+    expect($response->getStatusCode())->toBe(429)
+        ->and($response->getData(true)['ok'])->toBeFalse()
+        ->and($response->getData(true)['message'])->toContain('límite');
+});


### PR DESCRIPTION
## Summary

Revisando el proceso de enrolamiento facial y marcación de asistencia buscando bugs de la misma clase que los ya corregidos en el flujo de terminales (un fallo del mailer no debe convertir una operación ya persistida en un error para el usuario final — ver `Terminal::claimSanctumToken()` / `Employee::claimMobileToken()`), encontré 2 lugares más sin ese resguardo:

- **`FaceEnrollmentController::store()`** — la captura facial del auto-registro ya quedaba guardada (`status: pending_approval`) antes de notificar a los admins. Si el mailer fallaba, el catch genérico del método devolvía "Error al procesar el registro facial. Intente nuevamente." aunque el rostro sí se había guardado correctamente — el empleado no tenía forma de saber que ya no hacía falta reintentar (y reintentar mostraba "ya se envió una solicitud", confuso).

- **`MobileLinkController::notifyAdminsOfDailyLimitOnce()`** — si el mailer fallaba acá, un empleado ya bloqueado por el rate limiter diario recibía un 500 genérico en vez del 429 "Alcanzó el límite de intentos... Contacte a RRHH" esperado.

## Hallazgo sin tocar (para que el equipo decida)

`AttendanceFaceMarkController::identify()`/`store()` (rutas `POST /marcar`, `/marcar/identificar`) no tienen ningún caller actual en el frontend — `docs/marcacion-offline.md` confirma explícitamente que tanto `mark.js` como `terminal.js` migraron al matching facial 100% client-side + `enqueueMark()`/`flushQueue()` vía Sanctum. No lo toqué (no hace daño que exista sin usarse), pero lo señalo por si el equipo quiere limpiarlo en otra tanda.

## Test plan

- [x] `NotifyMailFailureResilienceTest` — nuevo, 2 tests simulando fallo de mailer (`mail.default=resend` sin key) en ambos flujos
- [x] Suite completa: 588/589 passed (el único fallo es un problema preexistente de manifest de Vite en el entorno de test, no relacionado)
- [x] `vendor/bin/pint --dirty` — passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_