### PR TITLE
La limpieza diaria de AttendanceMarkFailure ya no borra fallos sin revisar

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\AttendanceMarkFailure;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
@@ -46,10 +47,16 @@ Schedule::command('attendance:check-missing')
 
 /**
  * Limpiar registros de fallos de marcación con más de 30 días
- * Se ejecuta diariamente a las 02:00 para evitar crecimiento indefinido de la tabla
+ * Se ejecuta diariamente a las 02:00 para evitar crecimiento indefinido de la tabla.
+ *
+ * Solo elimina los ya revisados (approved/dismissed) — un fallo 'pending' de más
+ * de 30 días significa que nadie lo revisó todavía; borrarlo pierde para siempre
+ * la evidencia y la posibilidad de reconstruir esa marcación.
  */
 Schedule::call(function () {
-    $deleted = \App\Models\AttendanceMarkFailure::where('occurred_at', '<', now()->subDays(30))->delete();
+    $deleted = AttendanceMarkFailure::where('occurred_at', '<', now()->subDays(30))
+        ->whereIn('resolution_status', ['approved', 'dismissed'])
+        ->delete();
     if ($deleted > 0) {
         Log::info("Limpieza de fallos de marcación: {$deleted} registros eliminados");
     }

--- a/tests/Feature/CleanupMarkFailuresScheduleTest.php
+++ b/tests/Feature/CleanupMarkFailuresScheduleTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Models\AttendanceMarkFailure;
+use Carbon\Carbon;
+use Illuminate\Console\Scheduling\CallbackEvent;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: la limpieza diaria (routes/console.php, 'cleanup-mark-failures')
+ * borraba TODOS los AttendanceMarkFailure de más de 30 días sin importar
+ * resolution_status — un fallo 'pending' que nadie llegó a revisar se perdía
+ * para siempre junto con la posibilidad de reconstruir esa marcación.
+ */
+function makeMarkFailure(string $resolutionStatus, Carbon $occurredAt): AttendanceMarkFailure
+{
+    return AttendanceMarkFailure::create([
+        'mode' => 'unknown',
+        'failure_type' => 'invalid_event_sequence',
+        'failure_message' => 'Secuencia de evento no permitida.',
+        'occurred_at' => $occurredAt,
+        'resolution_status' => $resolutionStatus,
+    ]);
+}
+
+/** Ubica y ejecuta el callback registrado como 'cleanup-mark-failures' en routes/console.php. */
+function runCleanupMarkFailuresSchedule(): void
+{
+    $schedule = app(Schedule::class);
+
+    $event = collect($schedule->events())
+        ->first(fn ($e) => $e instanceof CallbackEvent && $e->description === 'cleanup-mark-failures');
+
+    expect($event)->not->toBeNull('No se encontró el evento programado cleanup-mark-failures — revisar routes/console.php');
+
+    $event->run(app());
+}
+
+it('la limpieza diaria borra fallos revisados de más de 30 días, pero conserva los pending', function () {
+    $old = now()->subDays(31);
+    $recent = now()->subDays(10);
+
+    $oldPending = makeMarkFailure('pending', $old);
+    $oldApproved = makeMarkFailure('approved', $old);
+    $oldDismissed = makeMarkFailure('dismissed', $old);
+    $recentPending = makeMarkFailure('pending', $recent);
+
+    runCleanupMarkFailuresSchedule();
+
+    expect(AttendanceMarkFailure::find($oldPending->id))->not->toBeNull()
+        ->and(AttendanceMarkFailure::find($oldApproved->id))->toBeNull()
+        ->and(AttendanceMarkFailure::find($oldDismissed->id))->toBeNull()
+        ->and(AttendanceMarkFailure::find($recentPending->id))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary

Revisando el proceso de enrolamiento y marcación buscando bugs de la misma familia (lógica de estado/limpieza que se comporta mal en casos límite), encontré que `cleanup-mark-failures` (`routes/console.php`, corre diariamente a las 02:00) eliminaba **todos** los `AttendanceMarkFailure` de más de 30 días sin importar `resolution_status`.

Un fallo que quedó `pending` — es decir, nadie desde `AttendanceMarkFailureResource` llegó a revisarlo — se perdía para siempre después de 30 días, junto con la posibilidad de que un admin lo aprobara y reconstruyera la marcación real que el empleado había intentado hacer.

## Fix

Ahora solo borra los ya revisados (`approved`/`dismissed`) con más de 30 días. Los `pending` se retienen indefinidamente hasta que un admin los resuelva.

## Test plan

- [x] `CleanupMarkFailuresScheduleTest` — nuevo, ejecuta el callback programado directamente (vía `Illuminate\Console\Scheduling\Schedule`) y verifica que conserva los `pending` (viejos y recientes) mientras borra los `approved`/`dismissed` de más de 30 días
- [x] Suite completa: 585/586 passed (el único fallo es un problema preexistente de manifest de Vite en el entorno de test, no relacionado)
- [x] `vendor/bin/pint --dirty` — passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_