### PR TITLE
attendance:check-missing ahora contempla empleados con rotación

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2010,6 +2010,7 @@ Acompañar siempre con `formatAuditFieldsForPresentation()` en el modelo para mo
 - Advance salary cap validation (mensual only) is in `Advance::approve()` — compares sum of all active advances against gross monthly salary
 - Mobile mode is for remote employees using their own device, **not** a shared kiosk
 - Terminal/kiosk mode is a shared device per branch
+- `attendance:check-missing` (deuda técnica conocida): corre cada 15 min entre 06:00-20:00 y solo evalúa la fecha de "hoy" contra "ahora" — nunca mira retroactivamente. Un empleado cuyo turno (horario fijo o rotación) arranca de noche (ej. 22:00) y falta esa noche **nunca** genera una ausencia automática: para cuando el comando vuelve a correr al día siguiente (06:00), ya está evaluando el horario/turno de ese nuevo día, no retrocede a revisar el turno de la noche anterior que nunca se marcó. Arreglarlo requiere que el comando también mire hacia atrás (el día previo), no solo "hoy" — pendiente, alcance mayor al soporte de rotación ya agregado (`AttendanceCalculator::resolveShiftDataFor()`).
 
 ===
 

--- a/app/Console/Commands/CheckMissingAttendance.php
+++ b/app/Console/Commands/CheckMissingAttendance.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\AttendanceDay;
 use App\Models\Employee;
 use App\Services\AttendanceCalculator;
+use App\Settings\GeneralSettings;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
@@ -42,10 +43,13 @@ class CheckMissingAttendance extends Command
         }
 
         // Obtener el umbral de tiempo para considerar ausencia
-        $thresholdMinutes = app(\App\Settings\GeneralSettings::class)->absence_threshold_minutes;
+        $thresholdMinutes = app(GeneralSettings::class)->absence_threshold_minutes;
         $this->info("⏱️  Umbral configurado: {$thresholdMinutes} minutos después de la hora de entrada");
 
-        // Obtener empleados activos con horario vigente (asignación nueva o campo legacy)
+        // Obtener empleados activos con horario u turno vigente para esta fecha — horario
+        // fijo (asignación nueva o campo legacy) o rotación (patrón asignado u override
+        // puntual). Antes de este fix, un empleado con rotación nunca generaba ausencia
+        // automática por más que faltara a marcar: la consulta no lo incluía.
         $employees = Employee::where('status', 'active')
             ->where(fn ($q) => $q
                 ->whereHas('scheduleAssignments', fn ($q) => $q->forDate($date))
@@ -53,6 +57,8 @@ class CheckMissingAttendance extends Command
                     ->where('day_of_week', $date->dayOfWeekIso)
                     ->where('is_active', true)
                 )
+                ->orWhereHas('rotationAssignments', fn ($q) => $q->forDate($date))
+                ->orWhereHas('shiftOverrides', fn ($q) => $q->where('override_date', $date->toDateString()))
             )
             ->with([
                 'scheduleAssignments.schedule.days',
@@ -116,24 +122,13 @@ class CheckMissingAttendance extends Command
             return 'skipped';
         }
 
-        // Obtener el horario del empleado para el día de la semana actual
-        $dayOfWeek = $date->dayOfWeekIso; // 1=Lunes, 7=Domingo
-        $scheduleDay = $employee->getScheduleForDate($date)?->days->where('day_of_week', $dayOfWeek)->first();
+        // Resuelve el turno/horario esperado para esta fecha — misma jerarquía que usa
+        // el cálculo de horas trabajadas (rotación > horario fijo), para no duplicar la
+        // lógica de resolución una tercera vez. check_in viene null si es franco
+        // (rotación o día inactivo del horario fijo) o si no hay horario/turno vigente.
+        $shiftData = AttendanceCalculator::resolveShiftDataFor($employee, $date);
+        $expectedCheckIn = $shiftData['check_in'];
 
-        // Verificar si es día libre o no tiene horario
-        if (! $scheduleDay) {
-            return 'skipped';
-        }
-
-        // Verificar si es día libre
-        if (! $scheduleDay->is_active) {
-            return 'skipped';
-        }
-
-        // Obtener hora de entrada esperada
-        $expectedCheckIn = $scheduleDay->start_time;
-
-        // Si no hay hora de entrada esperada, omitir
         if (! $expectedCheckIn) {
             return 'skipped';
         }
@@ -157,8 +152,8 @@ class CheckMissingAttendance extends Command
                     'status' => 'absent',
                     'is_calculated' => false,
                     'expected_check_in' => $expectedCheckIn,
-                    'expected_check_out' => $scheduleDay->end_time,
-                    'expected_break_minutes' => $scheduleDay->total_break_minutes,
+                    'expected_check_out' => $shiftData['check_out'],
+                    'expected_break_minutes' => $shiftData['break_minutes'],
                 ]);
 
                 // Aplicar cálculo para verificar vacaciones/permisos/feriados

--- a/tests/Feature/CheckMissingAttendanceRotationTest.php
+++ b/tests/Feature/CheckMissingAttendanceRotationTest.php
@@ -1,0 +1,240 @@
+<?php
+
+use App\Models\AttendanceDay;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\RotationPattern;
+use App\Models\Schedule;
+use App\Models\ScheduleDay;
+use App\Models\ShiftTemplate;
+use App\Services\RotationService;
+use App\Services\ScheduleAssignmentService;
+use App\Settings\GeneralSettings;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: attendance:check-missing solo consultaba empleados con horario
+ * fijo (scheduleAssignments / schedule.days) — un empleado con rotación
+ * asignada (RotationAssignment / ShiftOverride) nunca generaba una ausencia
+ * automática por más que faltara a marcar, sin importar el turno.
+ */
+function makeCheckMissingCompany(): Company
+{
+    static $n = 8600000;
+    $n++;
+
+    return Company::create(['name' => "Empresa CheckMissing {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+}
+
+function makeCheckMissingEmployee(Company $company): Employee
+{
+    static $ci = 8600000;
+    $n = $ci++;
+
+    $branch = Branch::create(['name' => "Sucursal CheckMissing {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto CheckMissing {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo CheckMissing {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'CheckMissing',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+beforeEach(function () {
+    app(GeneralSettings::class)->absence_threshold_minutes = 15;
+    app(GeneralSettings::class)->save();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('crea ausencia para un empleado con horario fijo que no marcó pasado el umbral (regresión)', function () {
+    $company = makeCheckMissingCompany();
+    $employee = makeCheckMissingEmployee($company);
+
+    $schedule = Schedule::create(['name' => 'Horario Fijo CheckMissing', 'shift_type' => 'diurno', 'description' => null]);
+    $today = Carbon::parse('2026-08-24'); // lunes
+    ScheduleDay::create([
+        'schedule_id' => $schedule->id,
+        'day_of_week' => $today->dayOfWeekIso,
+        'is_active' => true,
+        'start_time' => '08:00',
+        'end_time' => '17:00',
+    ]);
+    ScheduleAssignmentService::assign($employee, $schedule, $today->copy()->subYear());
+
+    Carbon::setTestNow($today->copy()->setTime(8, 30));
+
+    Artisan::call('attendance:check-missing', ['--date' => $today->toDateString()]);
+
+    $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today->toDateString())->first();
+    expect($day)->not->toBeNull()
+        ->and($day->status)->toBe('absent')
+        ->and($day->expected_check_in)->toBe('08:00:00');
+});
+
+it('crea ausencia para un empleado con rotación asignada que no marcó pasado el umbral', function () {
+    $company = makeCheckMissingCompany();
+    $employee = makeCheckMissingEmployee($company);
+
+    $shift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Turno Mañana',
+        'shift_type' => 'diurno',
+        'is_day_off' => false,
+        'start_time' => '07:00',
+        'end_time' => '15:00',
+        'break_minutes' => 30,
+        'is_active' => true,
+    ]);
+    $pattern = RotationPattern::create([
+        'company_id' => $company->id,
+        'name' => 'Patrón Fijo Mañana',
+        'sequence' => [$shift->id],
+        'is_active' => true,
+    ]);
+
+    $today = Carbon::parse('2026-08-24');
+    RotationService::assign($employee, $pattern, $today->copy()->subMonth());
+
+    Carbon::setTestNow($today->copy()->setTime(7, 30));
+
+    Artisan::call('attendance:check-missing', ['--date' => $today->toDateString()]);
+
+    $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today->toDateString())->first();
+    expect($day)->not->toBeNull()
+        ->and($day->status)->toBe('absent')
+        ->and($day->expected_check_in)->toBe('07:00:00')
+        ->and($day->expected_check_out)->toBe('15:00:00');
+});
+
+it('no crea ausencia para un empleado con rotación en día de franco', function () {
+    $company = makeCheckMissingCompany();
+    $employee = makeCheckMissingEmployee($company);
+
+    $workShift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Turno Mañana',
+        'shift_type' => 'diurno',
+        'is_day_off' => false,
+        'start_time' => '07:00',
+        'end_time' => '15:00',
+        'break_minutes' => 30,
+        'is_active' => true,
+    ]);
+    $dayOffShift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Franco',
+        'shift_type' => 'diurno',
+        'is_day_off' => true,
+        'is_active' => true,
+    ]);
+    $pattern = RotationPattern::create([
+        'company_id' => $company->id,
+        'name' => 'Patrón 1x1',
+        'sequence' => [$workShift->id, $dayOffShift->id],
+        'is_active' => true,
+    ]);
+
+    $today = Carbon::parse('2026-08-24');
+    // valid_from 10 días antes (diff par) + start_index=1 → offset (10+1)%2=1 → franco.
+    RotationService::assign($employee, $pattern, $today->copy()->subDays(10), startIndex: 1);
+
+    Carbon::setTestNow($today->copy()->setTime(23, 0));
+
+    Artisan::call('attendance:check-missing', ['--date' => $today->toDateString()]);
+
+    expect(AttendanceDay::where('employee_id', $employee->id)->where('date', $today->toDateString())->exists())->toBeFalse();
+});
+
+it('no crea ausencia para un empleado con rotación si todavía no pasó el umbral de tolerancia', function () {
+    $company = makeCheckMissingCompany();
+    $employee = makeCheckMissingEmployee($company);
+
+    $shift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Turno Tarde',
+        'shift_type' => 'diurno',
+        'is_day_off' => false,
+        'start_time' => '14:00',
+        'end_time' => '22:00',
+        'break_minutes' => 30,
+        'is_active' => true,
+    ]);
+    $pattern = RotationPattern::create([
+        'company_id' => $company->id,
+        'name' => 'Patrón Tarde',
+        'sequence' => [$shift->id],
+        'is_active' => true,
+    ]);
+
+    $today = Carbon::parse('2026-08-24');
+    RotationService::assign($employee, $pattern, $today->copy()->subMonth());
+
+    // Todavía no llegó ni la hora de entrada (14:00).
+    Carbon::setTestNow($today->copy()->setTime(10, 0));
+
+    Artisan::call('attendance:check-missing', ['--date' => $today->toDateString()]);
+
+    expect(AttendanceDay::where('employee_id', $employee->id)->where('date', $today->toDateString())->exists())->toBeFalse();
+});
+
+it('no duplica la ausencia si ya existe un AttendanceDay para la fecha', function () {
+    $company = makeCheckMissingCompany();
+    $employee = makeCheckMissingEmployee($company);
+
+    $shift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Turno Mañana',
+        'shift_type' => 'diurno',
+        'is_day_off' => false,
+        'start_time' => '07:00',
+        'end_time' => '15:00',
+        'break_minutes' => 30,
+        'is_active' => true,
+    ]);
+    $pattern = RotationPattern::create([
+        'company_id' => $company->id,
+        'name' => 'Patrón Fijo',
+        'sequence' => [$shift->id],
+        'is_active' => true,
+    ]);
+
+    $today = Carbon::parse('2026-08-24');
+    RotationService::assign($employee, $pattern, $today->copy()->subMonth());
+
+    AttendanceDay::create(['employee_id' => $employee->id, 'date' => $today->toDateString(), 'status' => 'present']);
+
+    Carbon::setTestNow($today->copy()->setTime(23, 0));
+
+    Artisan::call('attendance:check-missing', ['--date' => $today->toDateString()]);
+
+    expect(AttendanceDay::where('employee_id', $employee->id)->where('date', $today->toDateString())->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Revisando el proceso de asistencia buscando bugs de la misma familia (empleados que quedan fuera de una consulta y por lo tanto nunca generan el efecto esperado), encontré que `attendance:check-missing` solo consultaba empleados con **horario fijo** (`scheduleAssignments`/`schedule.days`) — un empleado con **rotación** asignada (`RotationAssignment`/`ShiftOverride`) nunca generaba una ausencia automática por más que faltara a marcar, sin importar el turno. Confirmado que hay clientes con rotación activa en producción.

## Fix

- La consulta de empleados ahora también incluye `rotationAssignments` y `shiftOverrides` vigentes para la fecha.
- `processEmployee()` usa `AttendanceCalculator::resolveShiftDataFor()` (misma jerarquía rotación > horario fijo que ya usa el cálculo de horas trabajadas) en vez de resolver el horario fijo a mano — evita triplicar la misma lógica de resolución en un tercer lugar.

## Deuda técnica documentada, fuera de alcance de este PR

Encontré un segundo gap relacionado, de mayor alcance: el comando corre cada 15 min entre 06:00-20:00 y solo evalúa "hoy" contra "ahora" — nunca mira retroactivamente. Un empleado cuyo turno arranca de noche (ej. 22:00) y falta esa noche nunca genera una ausencia automática, porque para cuando el comando vuelve a correr al día siguiente ya está evaluando el horario de ese nuevo día. Arreglarlo requiere rediseñar la ventana/lógica del comando para también mirar el día anterior — documentado en `CLAUDE.md` (sección "Important Notes") como deuda técnica conocida, a discutir en otra tanda.

## Test plan

- [x] `CheckMissingAttendanceRotationTest` — nuevo, 5 tests: regresión de horario fijo, ausencia con rotación, franco de rotación (sin ausencia), umbral de tolerancia (sin ausencia), no duplica si ya existe registro
- [x] Suite completa: 593/594 passed (el único fallo es un problema preexistente de manifest de Vite en el entorno de test, no relacionado)
- [x] `vendor/bin/pint --dirty` — passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_