### PR TITLE
Terminal: aligerar reconocimiento facial y confirmación de marcación audible

### DIFF
--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -510,6 +510,20 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
 .step-icon { display: none; }
 
 /* ============================================================
+   PANTALLA DE INICIO — "Toque para comenzar"
+   ============================================================ */
+.start-gate-card .terminal-btn { margin-top: var(--sp-2); }
+.start-gate-icon {
+    width: 72px; height: 72px;
+    margin: 0 auto var(--sp-6);
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    background: var(--c-primary-bg);
+    color: var(--c-primary);
+}
+.start-gate-icon svg { width: 32px; height: 32px; }
+
+/* ============================================================
    PANTALLA DE SELECCIÓN DE TIPO
    ============================================================ */
 .screen-eyebrow {

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // ELEMENTOS DEL DOM
     // ============================================================================
     const screens = {
+        startGate:      document.getElementById("startGateScreen"),
         loading:        document.getElementById("loadingScreen"),
         idle:           document.getElementById("idleScreen"),
         typeSelection:  document.getElementById("typeSelectionScreen"),
@@ -569,10 +570,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
         try {
             if (video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0) {
-                const detection = await faceapi
-                    .detectSingleFace(video, tinyOptions)
-                    .withFaceLandmarks()
-                    .withFaceDescriptor();
+                // Detector liviano (mismo usado en presenceCheckLoop) — este loop corre cada
+                // 200ms solo para decidir el color del óvalo y si hay un rostro lo bastante
+                // grande para intentar capturar. No necesita landmarks ni el descriptor de 128
+                // dimensiones (eso lo calcula aparte captureDescriptor() cuando ya hay un rostro
+                // detectado) — encadenar .withFaceLandmarks().withFaceDescriptor() acá corría la
+                // extracción más pesada de face-api.js 5 veces por segundo sin usar el resultado,
+                // el principal cuello de botella de CPU/GPU en tablets de gama baja.
+                const detection = await faceapi.detectSingleFace(video, lightOptions);
 
                 // Limpiar canvas — sin dibujo de bounding box ni landmarks
                 ctx.clearRect(0, 0, overlay.width, overlay.height);
@@ -587,7 +592,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     if (detection) {
                         // Feedback inmediato si la cara está muy chica — evita intentos de captura
                         // que fallarían igual al final del ciclo de 5 muestras
-                        const box = detection.detection.box;
+                        const box = detection.box;
                         const tooSmall = box.width < MIN_FACE_SIZE || box.height < MIN_FACE_SIZE;
                         terminalState.faceDetected = !tooSmall;
                         setTerminalVideoState(tooSmall ? "detecting" : "face-found");
@@ -1284,7 +1289,27 @@ document.addEventListener("DOMContentLoaded", () => {
     // INICIALIZACIÓN
     // ============================================================================
     console.log("Terminal de marcación inicializado");
-    showScreen("loading");
+
+    // checkLegacyTerminalMigration() no depende de un gesto — es solo informativo,
+    // se ejecuta apenas carga la página sin esperar el toque de inicio.
     checkLegacyTerminalMigration();
-    initializeSystem();
+
+    // Pantalla de inicio ("Toque para comenzar"): el resto del sistema (cámara,
+    // reconocimiento, idle con auto-despertar por presencia) recién arranca
+    // después de un toque explícito. Ese primer toque del día es lo que habilita
+    // el beep de confirmación (Web Audio) para todas las marcaciones manos-libres
+    // que vengan después — sin él, el caso más común (empleado se acerca, se
+    // reconoce y se marca solo, sin tocar nada) queda sin ningún sonido de
+    // confirmación porque el navegador nunca autorizó el audio.
+    const btnStartGate = document.getElementById("btnStartGate");
+    if (btnStartGate) {
+        btnStartGate.addEventListener("click", () => {
+            showScreen("loading");
+            initializeSystem();
+        }, { once: true });
+    } else {
+        // Fallback defensivo si el botón no está en el DOM — no debería pasar.
+        showScreen("loading");
+        initializeSystem();
+    }
 });

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -68,6 +68,7 @@
         @endempty
 
         <main id="main-content">
+            <x-attendance.terminal-start-gate />
             <x-attendance.terminal-loading />
             <x-attendance.terminal-idle />
             <x-attendance.terminal-type-selector />

--- a/resources/views/components/attendance/terminal-loading.blade.php
+++ b/resources/views/components/attendance/terminal-loading.blade.php
@@ -1,4 +1,4 @@
-<section id="loadingScreen" class="terminal-screen" role="region" aria-label="Cargando sistema">
+<section id="loadingScreen" class="terminal-screen hidden" role="region" aria-label="Cargando sistema">
     <div class="screen-body">
         <div class="loading-card">
             <div class="loading-spinner">

--- a/resources/views/components/attendance/terminal-start-gate.blade.php
+++ b/resources/views/components/attendance/terminal-start-gate.blade.php
@@ -1,0 +1,16 @@
+<section id="startGateScreen" class="terminal-screen" role="region" aria-label="Activar sonido del terminal">
+    <div class="screen-body">
+        <div class="loading-card start-gate-card">
+            <div class="start-gate-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+                    <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+                    <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+                </svg>
+            </div>
+            <h1 class="loading-title">Toque para comenzar</h1>
+            <p class="loading-subtitle">Un solo toque activa el sonido de confirmación para todas las marcaciones del día.</p>
+            <button type="button" id="btnStartGate" class="terminal-btn terminal-btn-primary">Comenzar</button>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary

Implementa los hallazgos 1 y 2 de la [auditoría UX del terminal de marcación](https://claude.ai/code/artifact/09c59762-fa6d-4385-9998-4c62da648da6), que corresponden a dos de las tres quejas reportadas: reconocimiento lento y "no sé si se registró".

**Hallazgo 1 — reconocimiento lento:** `drawLoop()` (`terminal.js`) corría cada 200ms el pipeline más pesado de face-api.js (`detectSingleFace().withFaceLandmarks().withFaceDescriptor()`) solo para decidir el color del óvalo naranja/verde y si el rostro era lo bastante grande — el descriptor de 128 dimensiones que realmente identifica al empleado se recalcula aparte, en `captureDescriptor()`. Cambiado a `detectSingleFace()` con el detector liviano (`lightOptions`, ya usado en `presenceCheckLoop`), sin landmarks ni descriptor. El pipeline completo queda reservado únicamente al ciclo real de captura.

**Hallazgo 2 — "no sé si se registró":** el beep de confirmación (Web Audio) depende de que el navegador haya recibido un gesto de usuario explícito en algún momento de la sesión. El flujo manos-libres (detección de presencia → auto-identificación → auto-registro cuando el empleado tiene un único evento válido) puede completarse de punta a punta sin que nadie toque la pantalla — dejando el caso más común del día sin ningún sonido de confirmación, solo un flash visual breve. Se agrega una pantalla de inicio ("Toque para comenzar") que gatea el resto del sistema (cámara, reconocimiento, idle) detrás de un único toque por carga de página — suficiente para que el navegador habilite el audio para todas las marcaciones manos-libres que vengan después.

## Test plan

- [x] `php artisan test --compact --filter=Terminal` — 46/47 pasan (la única falla, `TerminalConnectivityTest`, es el `Vite manifest not found` preexistente del sandbox sin `npm run build`, no relacionado)
- [x] `php artisan test --compact --filter=Attendance` — 85/85 pasan
- [x] `vendor/bin/pint --dirty` — sin cambios pendientes
- [ ] Verificación visual manual en un dispositivo/browser real pendiente — no hay entorno con `npm run build`/Vite disponible en este sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_