### PR TITLE
Terminal: anunciar el registro automático y recordar la última marcación

### DIFF
--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -527,6 +527,18 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
     color: var(--c-muted); text-align: center;
 }
 
+/* Recordatorio de última marcación — pantalla de selección de tipo */
+.type-selection-last-mark {
+    font-size: .8125rem;
+    font-weight: 600;
+    color: var(--c-primary);
+    background: var(--c-primary-bg);
+    border: 1px solid rgba(13,148,136,.25);
+    border-radius: 99px;
+    padding: var(--sp-1) var(--sp-4);
+    text-align: center;
+}
+
 /* Grid 2×2 de tipos */
 .type-grid {
     display: grid;

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -752,7 +752,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         await registerMark(result.employee, allowedEvents[0]);
                     } else if (allowedEvents.length > 1) {
                         // Múltiples eventos válidos — mostrar selección al empleado
-                        showTypeSelectionForEmployee(result.employee, allowedEvents);
+                        showTypeSelectionForEmployee(result.employee, allowedEvents, result.last_event, result.last_event_time);
                     } else {
                         // Sin eventos disponibles — jornada ya completada
                         showDayComplete(result.employee);
@@ -790,7 +790,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     // SELECCIÓN DE TIPO POST-IDENTIFICACIÓN (solo si hay múltiples eventos válidos)
     // ============================================================================
-    function showTypeSelectionForEmployee(employee, allowedEvents) {
+    function showTypeSelectionForEmployee(employee, allowedEvents, lastEvent, lastEventTime) {
         terminalState.employee = employee;
 
         // Mostrar solo los botones de tipos permitidos para este empleado
@@ -814,6 +814,22 @@ document.addEventListener("DOMContentLoaded", () => {
         if (screenTitle)   screenTitle.textContent   = fullName ? `Hola, ${fullName}` : "Seleccione marcación";
         if (screenEyebrow) screenEyebrow.textContent = fullName ? "Empleado verificado ✓" : "Seleccione marcación";
 
+        // Recordatorio de la última marcación conocida — ayuda a elegir, por ejemplo,
+        // entre "Fin descanso" y "Salida" sin que el empleado tenga que recordarlo.
+        const lastMarkEl = document.getElementById("typeSelectionLastMark");
+        if (lastMarkEl) {
+            if (lastEvent) {
+                const lastEventName = eventTypeNames[lastEvent] || lastEvent;
+                lastMarkEl.textContent = lastEventTime
+                    ? `Última marcación: ${lastEventName}, ${lastEventTime}`
+                    : `Última marcación: ${lastEventName}`;
+                lastMarkEl.classList.remove("hidden");
+            } else {
+                lastMarkEl.textContent = "";
+                lastMarkEl.classList.add("hidden");
+            }
+        }
+
         showScreen("typeSelection");
     }
 
@@ -830,7 +846,14 @@ document.addEventListener("DOMContentLoaded", () => {
      * con un error cuando en realidad ya se guardó.
      */
     async function registerMark(employee, eventType) {
-        updateStatus("Registrando marcación...", "loading");
+        // Mensaje con el tipo de evento (no genérico) y tiempo suficiente para leerse
+        // (700ms) antes de pasar a la pantalla de éxito — sin esto, sobre todo en el
+        // registro automático (un único evento válido, sin que el empleado toque nada),
+        // el paso de "identificando" a "listo" era instantáneo y el empleado podía no
+        // darse cuenta de que el sistema ya había decidido y registrado por él.
+        const eventName = eventTypeNames[eventType] || eventType;
+        updateStatus(`Registrando: ${eventName}...`, "loading");
+        await sleep(700);
 
         const { client_event_id: clientEventId, recorded_at: recordedAt } = await enqueueMark(employee.id, eventType);
 

--- a/resources/views/components/attendance/terminal-type-selector.blade.php
+++ b/resources/views/components/attendance/terminal-type-selector.blade.php
@@ -3,6 +3,10 @@
         <p class="screen-eyebrow" id="typeSelectionEyebrow">Empleado verificado</p>
         <h1 class="screen-title" id="typeSelectionTitle">Marcación</h1>
         <p class="screen-subtitle">Seleccione el tipo de marcación</p>
+        {{-- Recordatorio de la última marcación conocida — ayuda a elegir entre opciones
+             parecidas (ej. "Fin descanso" vs. "Salida") sin tener que recordarlo de memoria.
+             Vacío/oculto si no hay una marcación previa hoy. --}}
+        <p class="type-selection-last-mark hidden" id="typeSelectionLastMark"></p>
 
         <div class="type-grid">
             <button


### PR DESCRIPTION
## Summary

Implementa los hallazgos 3 y 4 de la [auditoría UX del terminal de marcación](https://claude.ai/code/artifact/09c59762-fa6d-4385-9998-4c62da648da6), ambos relacionados con la queja de "confusión sobre qué botón tocar". Sigue a #125 (hallazgos 1 y 2), pero es independiente — no depende de ese PR.

**Hallazgo 3:** cuando solo hay un evento de marcación válido, `registerMark()` pasaba de "identificando" a la pantalla de éxito casi instantáneamente, sin ningún aviso legible de qué estaba pasando. Ahora muestra "Registrando: {tipo}..." con 700ms de pausa antes de continuar, para que el empleado vea que el sistema decidió y registró por él (en vez de quedar buscando un botón que no existe).

**Hallazgo 4:** cuando sí hay que elegir entre dos tipos válidos (típicamente "Fin descanso" vs. "Salida"), la pantalla de selección no mostraba ninguna pista de la última marcación del empleado — solo su nombre y "Empleado verificado ✓". Se agrega un recordatorio ("Última marcación: Inicio descanso, 12:03") usando `last_event`/`last_event_time`, datos que ya viajaban en la respuesta de `identifyEmployee()` sin usarse en esta pantalla.

## Test plan

- [x] `php artisan test --compact --filter=Attendance` — 85/85 pasan (cambios son solo JS/CSS/Blade de UI, sin lógica de negocio nueva)
- [x] `vendor/bin/pint --dirty` — sin cambios pendientes
- [ ] Verificación visual manual en un dispositivo/browser real pendiente — no hay entorno con `npm run build`/Vite disponible en este sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_