### PR TITLE
Terminal: fallback de búsqueda manual por CI cuando el reconocimiento falla seguido

### DIFF
--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -702,6 +702,76 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
 /* Botón cancelar — OCULTO */
 .terminal-btn.terminal-btn-secondary { display: none !important; }
 
+/* Link "¿No te reconoce? Buscar por CI" — aparece tras varios intentos fallidos */
+.manual-search-link {
+    background: none; border: none; cursor: pointer;
+    font-size: .8125rem; font-weight: 600;
+    color: var(--c-muted);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    padding: var(--sp-2);
+    align-self: center;
+}
+.manual-search-link:hover { color: var(--c-primary); }
+
+/* ============================================================
+   OVERLAY DE BÚSQUEDA MANUAL POR CI
+   ============================================================ */
+.manual-search-overlay {
+    position: fixed; inset: 0; z-index: 50;
+    display: flex; align-items: center; justify-content: center;
+    padding: var(--sp-4);
+    background: rgba(15,23,42,.55);
+    backdrop-filter: blur(2px);
+}
+.manual-search-card {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-3xl);
+    box-shadow: var(--sh-xl);
+    padding: var(--sp-8);
+    width: min(100%, 460px);
+    max-height: 85vh;
+    display: flex; flex-direction: column; gap: var(--sp-4);
+}
+.manual-search-title { font-size: 1.25rem; font-weight: 700; color: var(--c-text); }
+.manual-search-subtitle { font-size: .8125rem; color: var(--c-muted); margin-top: calc(-1 * var(--sp-2)); }
+.manual-search-input {
+    width: 100%;
+    font-size: 1.125rem;
+    padding: var(--sp-3) var(--sp-4);
+    border: 1px solid var(--c-border-s);
+    border-radius: var(--r-lg);
+    background: var(--c-bg);
+    color: var(--c-text);
+}
+.manual-search-input:focus { outline: 2px solid var(--c-primary); outline-offset: 1px; }
+
+.manual-search-results {
+    display: flex; flex-direction: column; gap: var(--sp-2);
+    overflow-y: auto;
+    max-height: 40vh;
+}
+.manual-search-result {
+    display: flex; align-items: center; gap: var(--sp-3);
+    padding: var(--sp-3);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-lg);
+    background: var(--c-bg);
+    cursor: pointer;
+    text-align: left;
+    font: inherit; color: inherit;
+}
+.manual-search-result:hover { border-color: var(--c-primary); background: var(--c-primary-bg); }
+.manual-search-result img {
+    width: 40px; height: 40px; border-radius: 50%; object-fit: cover; flex-shrink: 0;
+    background: var(--c-border);
+}
+.manual-search-result-name { font-weight: 600; color: var(--c-text); font-size: .9375rem; }
+.manual-search-result-ci { font-size: .8125rem; color: var(--c-muted); }
+
+.manual-search-empty { font-size: .875rem; color: var(--c-muted); text-align: center; padding: var(--sp-4) 0; }
+
 
 /* SVG dentro del icono de tipo */
 .type-icon svg { width: 22px; height: 22px; flex-shrink: 0; }

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -52,6 +52,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const btnReload      = document.getElementById("btnReload");
     const btnThemeToggle = document.getElementById("btnThemeToggle");
 
+    // Búsqueda manual por CI (fallback cuando el reconocimiento facial falla seguido)
+    const btnManualSearch       = document.getElementById("btnManualSearch");
+    const manualSearchOverlay   = document.getElementById("manualSearchOverlay");
+    const manualSearchInput     = document.getElementById("manualSearchInput");
+    const manualSearchResults   = document.getElementById("manualSearchResults");
+    const manualSearchEmpty     = document.getElementById("manualSearchEmpty");
+    const btnManualSearchCancel = document.getElementById("btnManualSearchCancel");
+
     // Day complete screen elements
     const dayCompleteEmployeePhoto  = document.getElementById("dayCompleteEmployeePhoto");
     const dayCompleteEmployeeName   = document.getElementById("dayCompleteEmployeeName");
@@ -125,6 +133,8 @@ document.addEventListener("DOMContentLoaded", () => {
         isIdle:                 false,
         userHasInteracted:      false,  // vibración solo permitida tras gesto del usuario
         backgroundSyncStarted:  false,  // evita registrar los setInterval de sync más de una vez
+        consecutiveFailures:    0,      // intentos de reconocimiento fallidos seguidos — habilita la búsqueda manual por CI
+        manualCandidate:        null,   // empleado elegido en la búsqueda manual — acota identifyEmployee() a un único candidato
     };
 
     const tinyOptions  = new faceapi.TinyFaceDetectorOptions({ inputSize: 416, scoreThreshold: 0.6 });
@@ -132,6 +142,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     /** Tamaño mínimo de rostro en píxeles para aceptar una detección (drawLoop y captureDescriptor) */
     const MIN_FACE_SIZE = 100;
+
+    /** Intentos de reconocimiento fallidos seguidos antes de ofrecer la búsqueda manual por CI. */
+    const CONSECUTIVE_FAILURES_FOR_MANUAL_SEARCH = 2;
 
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -343,6 +356,13 @@ document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     function startIdentificationFlow() {
         resetIdleTimer();
+        // Cada vez que arranca un ciclo de identificación nuevo (nuevo empleado frente a
+        // la cámara) se vuelve al reconocimiento contra todos los candidatos — el estado
+        // de la búsqueda manual del empleado anterior no debe seguir acotando el match.
+        terminalState.consecutiveFailures = 0;
+        terminalState.manualCandidate = null;
+        hideManualSearchLink();
+        closeManualSearch();
         showScreen("identification");
         startAutoIdentification();
         setTerminalVideoState("detecting");
@@ -655,7 +675,15 @@ document.addEventListener("DOMContentLoaded", () => {
                 return { ok: false, message: "Terminal sincronizando por primera vez, espere un momento." };
             }
 
-            const candidates = await getCachedEmployees();
+            // Si el empleado se identificó por la búsqueda manual de CI, acotar el match a
+            // ese único candidato — con un solo candidato, matchDescriptor() ya omite el
+            // chequeo de "gap" contra un segundo mejor (no aplica con N=1), pero el rostro
+            // capturado igual tiene que superar el umbral de distancia normal contra ESE
+            // descriptor: la búsqueda manual ayuda a encontrarse en la lista, no reemplaza
+            // la verificación facial.
+            const candidates = terminalState.manualCandidate
+                ? [terminalState.manualCandidate]
+                : await getCachedEmployees();
             const { employee, distance, reason } = matchDescriptor(descriptor, candidates, threshold, minGap);
 
             if (!employee) {
@@ -736,6 +764,10 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
 
                 if (result.ok && result.employee) {
+                    terminalState.consecutiveFailures = 0;
+                    terminalState.manualCandidate = null;
+                    hideManualSearchLink();
+
                     if (terminalState.userHasInteracted) navigator.vibrate?.(80);
                     stopAutoIdentification();
 
@@ -768,6 +800,13 @@ document.addEventListener("DOMContentLoaded", () => {
                     setIdStatusDot("detecting");
                     updateStatus("Rostro no reconocido. Mantenga el rostro quieto frente a la cámara.");
                     console.log("No se pudo identificar");
+
+                    // Tras varios intentos fallidos seguidos, ofrecer la búsqueda manual por CI
+                    // en vez de dejar al empleado atrapado repitiendo el mismo intento sin salida.
+                    terminalState.consecutiveFailures++;
+                    if (terminalState.consecutiveFailures >= CONSECUTIVE_FAILURES_FOR_MANUAL_SEARCH) {
+                        showManualSearchLink();
+                    }
                 }
             } catch (error) {
                 await finishCaptureProgress("error");
@@ -785,6 +824,99 @@ document.addEventListener("DOMContentLoaded", () => {
             terminalState.identifyInterval = null;
         }
         stopCamera();
+    }
+
+    // ============================================================================
+    // BÚSQUEDA MANUAL POR CI — fallback cuando el reconocimiento facial falla seguido
+    // ============================================================================
+    /**
+     * NO reemplaza la verificación facial: elegir un candidato acá solo acota
+     * identifyEmployee() a esa única persona (ver terminalState.manualCandidate) — la
+     * cámara sigue activa y el empleado igual tiene que superar el umbral de distancia
+     * normal contra ese descriptor específico antes de que se registre cualquier marcación.
+     */
+    const MAX_MANUAL_SEARCH_RESULTS = 8;
+
+    function showManualSearchLink() {
+        if (btnManualSearch) btnManualSearch.classList.remove("hidden");
+    }
+
+    function hideManualSearchLink() {
+        if (btnManualSearch) btnManualSearch.classList.add("hidden");
+    }
+
+    function openManualSearch() {
+        if (!manualSearchOverlay) return;
+        manualSearchOverlay.classList.remove("hidden");
+        if (manualSearchInput) {
+            manualSearchInput.value = "";
+            manualSearchInput.focus();
+        }
+        renderManualSearchResults("");
+    }
+
+    function closeManualSearch() {
+        if (manualSearchOverlay) manualSearchOverlay.classList.add("hidden");
+    }
+
+    async function renderManualSearchResults(query) {
+        if (!manualSearchResults) return;
+        manualSearchResults.innerHTML = "";
+
+        const digits = (query || "").trim();
+        if (digits.length < 2) {
+            if (manualSearchEmpty) manualSearchEmpty.classList.add("hidden");
+            return;
+        }
+
+        const candidates = await getCachedEmployees();
+        const matches = candidates
+            .filter((employee) => employee.ci && String(employee.ci).includes(digits))
+            .slice(0, MAX_MANUAL_SEARCH_RESULTS);
+
+        if (manualSearchEmpty) manualSearchEmpty.classList.toggle("hidden", matches.length > 0);
+
+        matches.forEach((employee) => {
+            const fullName = `${employee.first_name || ""} ${employee.last_name || ""}`.trim() || "Empleado";
+            const item = document.createElement("button");
+            item.type = "button";
+            item.className = "manual-search-result";
+            item.setAttribute("role", "option");
+            item.innerHTML = `
+                <img src="${employee.photo_thumbnail || "/images/default-avatar.png"}" alt="" aria-hidden="true">
+                <span>
+                    <span class="manual-search-result-name">${fullName}</span><br>
+                    <span class="manual-search-result-ci">CI: ${employee.ci}</span>
+                </span>
+            `;
+            item.addEventListener("click", () => selectManualCandidate(employee));
+            manualSearchResults.appendChild(item);
+        });
+    }
+
+    function selectManualCandidate(employee) {
+        terminalState.manualCandidate = employee;
+        terminalState.consecutiveFailures = 0;
+        hideManualSearchLink();
+        closeManualSearch();
+        updateStatus(`Mirá la cámara para confirmar que sos ${employee.first_name || "vos"}...`);
+    }
+
+    if (btnManualSearch) {
+        btnManualSearch.addEventListener("click", openManualSearch);
+    }
+    if (btnManualSearchCancel) {
+        btnManualSearchCancel.addEventListener("click", closeManualSearch);
+    }
+    if (manualSearchOverlay) {
+        manualSearchOverlay.addEventListener("click", (event) => {
+            if (event.target === manualSearchOverlay) closeManualSearch();
+        });
+    }
+    if (manualSearchInput) {
+        manualSearchInput.addEventListener("input", (event) => {
+            renderManualSearchResults(event.target.value);
+        });
     }
 
     // ============================================================================

--- a/resources/views/components/attendance/terminal-video-section.blade.php
+++ b/resources/views/components/attendance/terminal-video-section.blade.php
@@ -26,6 +26,16 @@
                 <span class="id-status-text">Posicione su rostro dentro del óvalo...</span>
             </div>
 
+            {{--
+                Aparece después de varios intentos fallidos seguidos (ver
+                CONSECUTIVE_FAILURES_FOR_MANUAL_SEARCH en terminal.js) — no reemplaza el
+                reconocimiento facial, abre una búsqueda por CI que igual pide confirmar
+                con la cámara contra ese único candidato antes de registrar la marcación.
+            --}}
+            <button type="button" id="btnManualSearch" class="manual-search-link hidden">
+                ¿No te reconoce? Buscar por CI
+            </button>
+
             {{-- Cancel button kept in DOM for JS compatibility, hidden via CSS --}}
             <button
                 type="button"
@@ -37,3 +47,29 @@
         </div>
     </div>
 </section>
+
+{{--
+    Overlay de búsqueda manual por CI — fallback cuando el reconocimiento facial
+    falla repetidamente (mala foto de enrolamiento, ángulo, luz). Elegir un
+    candidato acá NO registra la marcación por sí solo: solo acota la
+    identificación facial a esa persona (ver terminalState.manualCandidate en
+    terminal.js) y vuelve a pedir la cámara para confirmar que es esa persona —
+    el rostro sigue siendo el control real, esto solo evita comparar contra
+    todos los empleados de la sucursal a la vez.
+--}}
+<div id="manualSearchOverlay" class="manual-search-overlay hidden" role="dialog" aria-modal="true" aria-label="Buscar por CI">
+    <div class="manual-search-card">
+        <h2 class="manual-search-title">Buscar por CI</h2>
+        <p class="manual-search-subtitle">Vas a tener que confirmar con la cámara igual — esto solo te ayuda a encontrarte en la lista.</p>
+        <input
+            type="text"
+            inputmode="numeric"
+            id="manualSearchInput"
+            class="manual-search-input"
+            placeholder="Ingresá tu número de CI"
+            autocomplete="off">
+        <div id="manualSearchResults" class="manual-search-results" role="listbox" aria-label="Resultados de búsqueda"></div>
+        <p id="manualSearchEmpty" class="manual-search-empty hidden">No se encontraron empleados con ese CI.</p>
+        <button type="button" id="btnManualSearchCancel" class="terminal-btn terminal-btn-ghost">Cancelar</button>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Implementa el hallazgo 5 (complementario) de la [auditoría UX del terminal de marcación](https://claude.ai/code/artifact/09c59762-fa6d-4385-9998-4c62da648da6). Independiente de #125 y #126.

Cuando el reconocimiento facial falla 2 veces seguidas (mala foto de enrolamiento, ángulo, iluminación), aparece un link "¿No te reconoce? Buscar por CI" que abre una búsqueda sobre los empleados ya cacheados en el terminal (`employees_cache`, IndexedDB — funciona offline, sin red).

**Decisión de diseño (confirmada con el usuario antes de implementar):** esto NO reemplaza la verificación biométrica. Elegir un candidato en la búsqueda solo acota `identifyEmployee()` a esa única persona (`terminalState.manualCandidate`) — la cámara sigue activa y el empleado tiene que superar el mismo umbral de distancia facial de siempre contra ESE descriptor específico antes de que se registre cualquier marcación. Con un solo candidato, `matchDescriptor()` (sin tocarlo) ya omite el chequeo de "gap" contra un segundo mejor porque no aplica con N=1 — la búsqueda manual ayuda a encontrarse en la lista, el rostro sigue siendo el control real.

El estado de la búsqueda (candidato elegido, contador de intentos fallidos) se resetea en cada ciclo de identificación nuevo, así que un empleado nunca hereda el candidato acotado por la persona anterior en el terminal.

## Test plan

- [x] `php artisan test --compact --filter=Attendance` — 85/85 pasan (cambios son solo JS/CSS/Blade de UI, sin lógica de negocio nueva)
- [x] `vendor/bin/pint --dirty` — sin cambios pendientes
- [x] `node --check` sobre `terminal.js` — sin errores de sintaxis
- [ ] Verificación visual manual en un dispositivo/browser real pendiente — no hay entorno con `npm run build`/Vite disponible en este sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_