### PR TITLE
Terminal: mostrar sucursal/empresa, dispositivo y conectividad en el header

### DIFF
--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -204,15 +204,24 @@ body {
     border-bottom-color: transparent;
     box-shadow: none;
 }
+/* En idle solo se atenúan la etiqueta "Modo Terminal" y el reloj chico del header (ya
+   duplicado por el reloj grande de la pantalla de reposo) — sucursal/empresa, logo y la
+   fila de meta (dispositivo, conectividad, últ. sync) quedan visibles siempre: es
+   justamente en reposo, sin nadie todavía frente a la cámara, cuando más tiempo pasan
+   en pantalla. */
 .terminal-header--idle .terminal-mode-badge,
-.terminal-header--idle .header-logo,
-.terminal-header--idle .terminal-location-badge,
 .terminal-header--idle .terminal-clock {
     opacity: 0;
     visibility: hidden;
     transition: opacity 400ms ease, visibility 400ms ease;
 }
 .terminal-header-brand { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
+.terminal-header-titles {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
 .terminal-mode-badge {
     background: var(--c-primary-bg);
     color: var(--c-primary);
@@ -224,22 +233,48 @@ body {
     border-radius: var(--r);
     border: 1px solid rgba(13,148,136,.25);
     flex-shrink: 0;
+    align-self: flex-start;
+    margin-bottom: 2px;
 }
-/* Sucursal — empresa del terminal, visible también durante la identificación
-   activa (a diferencia del bloque idle-only en la pantalla de reposo). */
+/* Sucursal — empresa del terminal: título prominente del header, visible en todas las
+   pantallas (idle incluida). */
 .terminal-location-badge {
-    font-size: .8125rem;
-    font-weight: 500;
-    color: var(--c-muted);
+    font-size: 1.0625rem;
+    font-weight: 700;
+    color: var(--c-text);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
 }
+/* Fila secundaria bajo sucursal/empresa: dispositivo, conectividad, última sincronización. */
+.terminal-header-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    flex-wrap: wrap;
+}
+.terminal-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: .75rem;
+    font-weight: 500;
+    color: var(--c-muted);
+    white-space: nowrap;
+}
+.connectivity-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--c-success);
+    flex-shrink: 0;
+    transition: background var(--tr);
+}
+.connectivity-dot.is-offline { background: var(--c-danger); }
 /* Logo de la empresa junto al badge de sucursal — PNG con transparencia, se ve
    bien en ambos temas. object-fit: contain preserva la proporción original. */
 .header-logo {
-    height: 24px;
+    height: 32px;
     max-width: 120px;
     width: auto;
     object-fit: contain;
@@ -1048,6 +1083,7 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
    ============================================================ */
 @media (max-width: 640px) {
     .terminal-header      { padding: var(--sp-3) var(--sp-4); }
+    .terminal-location-badge { font-size: .9375rem; }
     .screen-body          { padding: var(--sp-4) var(--sp-3); gap: var(--sp-4); }
     .type-grid            { gap: var(--sp-3); }
     .terminal-type-btn    { padding: var(--sp-4); min-height: 90px; }
@@ -1072,6 +1108,9 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
     .terminal-header     { padding: var(--sp-2) var(--sp-4); }
     .clock-time          { font-size: 1.25rem; }
     .clock-date          { font-size: .7rem; }
+    /* Poco alto para la fila de meta (dispositivo/conectividad/sync) — se prioriza
+       sucursal/empresa, que sigue visible. */
+    .terminal-header-meta { display: none; }
     .screen-body         { padding: var(--sp-3) var(--sp-4); gap: var(--sp-3); }
     .terminal-type-btn   { min-height: 70px; padding: var(--sp-3) var(--sp-4); }
     .loading-card        { padding: var(--sp-5); }

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -114,6 +114,18 @@ document.addEventListener("DOMContentLoaded", () => {
         headerLogo.classList.remove("hidden");
     }
 
+    // Marca/modelo del dispositivo físico (device_brand/device_model en Terminal) — ambos
+    // son opcionales y siempre editables desde Filament, así que se omite el elemento por
+    // completo si el admin nunca los cargó, en vez de mostrar un texto vacío o "null null".
+    const headerDevice = document.getElementById("terminalHeaderDevice");
+    if (terminalData && headerDevice) {
+        const deviceLabel = [terminalData.device_brand, terminalData.device_model].filter(Boolean).join(" ");
+        if (deviceLabel) {
+            headerDevice.textContent = deviceLabel;
+            headerDevice.classList.remove("hidden");
+        }
+    }
+
     // ============================================================================
     // ESTADO GLOBAL
     // ============================================================================
@@ -1239,12 +1251,23 @@ document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     // CONECTIVIDAD
     // ============================================================================
-    const offlineBanner = document.getElementById("offlineBanner");
+    const offlineBanner    = document.getElementById("offlineBanner");
+    const connectivityDot  = document.getElementById("connectivityDot");
+    const connectivityLabel = document.getElementById("connectivityLabel");
 
+    /**
+     * A diferencia del banner (que solo aparece mientras el navegador está sin red),
+     * el indicador del header queda siempre visible — refleja `navigator.onLine`, no la
+     * conectividad real con el servidor (eso lo indica por separado "Últ. sync", más
+     * abajo: un dispositivo puede tener wifi pero sin salida a internet real).
+     */
     function setOffline(isOffline) {
-        if (!offlineBanner) return;
-        offlineBanner.classList.toggle("is-visible", isOffline);
-        offlineBanner.setAttribute("aria-hidden", String(!isOffline));
+        if (offlineBanner) {
+            offlineBanner.classList.toggle("is-visible", isOffline);
+            offlineBanner.setAttribute("aria-hidden", String(!isOffline));
+        }
+        if (connectivityDot)   connectivityDot.classList.toggle("is-offline", isOffline);
+        if (connectivityLabel) connectivityLabel.textContent = isOffline ? "Sin conexión" : "En línea";
     }
 
     // Estado inicial (por si la página carga sin red)
@@ -1284,6 +1307,31 @@ document.addEventListener("DOMContentLoaded", () => {
         } else {
             updateIdleSyncStatus(navigator.onLine ? "Sincronizado" : "Sin conexión — usando datos locales");
         }
+        await refreshLastSyncLabel();
+    }
+
+    const terminalHeaderLastSync = document.getElementById("terminalHeaderLastSync");
+
+    /**
+     * Última vez que un heartbeat exitoso confirmó contacto real con el servidor
+     * (`last_heartbeat_at` en terminal_meta, escrito por heartbeat() en sync.js) — a
+     * diferencia del indicador "En línea"/"Sin conexión" (que solo refleja
+     * `navigator.onLine`), esto sirve para detectar un terminal con wifi pero sin
+     * conectividad real al backend. Se lee de IndexedDB en cada llamada, así que
+     * sobrevive a recargas de página sin depender del estado de esta sesión.
+     */
+    async function refreshLastSyncLabel() {
+        if (!terminalHeaderLastSync) return;
+        const lastHeartbeatAt = await getMeta("last_heartbeat_at");
+        if (!lastHeartbeatAt) {
+            terminalHeaderLastSync.classList.add("hidden");
+            return;
+        }
+        const time = new Date(lastHeartbeatAt).toLocaleTimeString("es-BO", {
+            hour: "2-digit", minute: "2-digit", hour12: false,
+        });
+        terminalHeaderLastSync.textContent = `Últ. sync: ${time}`;
+        terminalHeaderLastSync.classList.remove("hidden");
     }
 
     /**
@@ -1362,6 +1410,9 @@ document.addEventListener("DOMContentLoaded", () => {
         } catch (error) {
             console.warn("Sincronización inicial falló (se reintentará en segundo plano):", error.message);
             updateIdleSyncStatus(navigator.onLine ? "Error al sincronizar" : "Sin conexión — usando datos locales");
+            // Mostrar igual el último sync exitoso conocido (de una sesión anterior, ya
+            // persistido en IndexedDB) aunque el de ahora haya fallado.
+            await refreshLastSyncLabel();
         }
 
         startBackgroundSync();

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -19,9 +19,19 @@
     <div class="terminal-container">
         <header class="terminal-header">
             <div class="terminal-header-brand">
-                <span class="terminal-mode-badge">Modo Terminal</span>
                 <img id="terminalHeaderLogo" class="header-logo hidden" alt="">
-                <span id="terminalHeaderLocation" class="terminal-location-badge"></span>
+                <div class="terminal-header-titles">
+                    <span class="terminal-mode-badge">Modo Terminal</span>
+                    <span id="terminalHeaderLocation" class="terminal-location-badge"></span>
+                    <div class="terminal-header-meta" id="terminalHeaderMeta">
+                        <span id="terminalHeaderDevice" class="terminal-meta-item hidden"></span>
+                        <span class="terminal-meta-item terminal-connectivity" id="terminalConnectivity">
+                            <span class="connectivity-dot" id="connectivityDot" aria-hidden="true"></span>
+                            <span id="connectivityLabel">En línea</span>
+                        </span>
+                        <span id="terminalHeaderLastSync" class="terminal-meta-item hidden"></span>
+                    </div>
+                </div>
                 <button type="button" id="btnThemeToggle" class="theme-toggle" aria-label="Cambiar tema claro/oscuro">
                     <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
@@ -89,6 +99,8 @@
             branch_name: @json($terminal->branch?->name),
             company_name: @json($terminal->branch?->company?->name),
             company_logo: @json($terminal->branch?->company?->logo_thumbnail),
+            device_brand: @json($terminal->device_brand),
+            device_model: @json($terminal->device_model),
         };
     </script>
     @endisset


### PR DESCRIPTION
## Summary

A pedido del usuario: el header del terminal (`/terminal/{code}`) ahora muestra de forma prominente y persistente — en todas las pantallas, idle incluida — la sucursal — empresa del terminal, más una fila secundaria con:

- **Marca/modelo del dispositivo físico** (`device_brand`/`device_model` de `Terminal`, ya editables desde Filament) — se omite el elemento por completo si el admin nunca los cargó, en vez de mostrar texto vacío.
- **Indicador de conectividad permanente** (punto verde/rojo + "En línea" / "Sin conexión"), a diferencia del banner existente (`#offlineBanner`) que solo aparece mientras el navegador está sin red — este queda siempre visible.
- **Última sincronización exitosa** (hora), leída de `last_heartbeat_at` (ya persistido en IndexedDB por `heartbeat()` en `sync.js`) — sobrevive a recargas de página, no depende de esta sesión.

**Cambio de comportamiento en idle:** antes, la pantalla de reposo ocultaba todo el header (`opacity: 0`). Ahora solo se atenúan la etiqueta "Modo Terminal" y el reloj chico (duplicado por el reloj grande central de idle) — sucursal/empresa, logo y la fila de meta quedan visibles siempre, que es justamente cuando más tiempo pasan en pantalla sin que nadie se haya acercado todavía.

## Test plan

- [x] `php artisan test --compact --filter=Attendance` — 85/85 pasan (cambios son solo JS/CSS/Blade de UI, sin lógica de negocio nueva)
- [x] `vendor/bin/pint --dirty` — sin cambios pendientes
- [x] `node --check` sobre `terminal.js` — sin errores de sintaxis
- [ ] Verificación visual manual en un dispositivo/browser real pendiente — no hay entorno con `npm run build`/Vite disponible en este sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_