### PR TITLE
Agregar acción de asignar patrón de rotación a empleados

### DIFF
--- a/app/Filament/Resources/RotationPatternResource.php
+++ b/app/Filament/Resources/RotationPatternResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\RotationPatternResource\Pages;
+use App\Filament\Resources\RotationPatternResource\RelationManagers;
 use App\Models\Company;
 use App\Models\RotationPattern;
 use App\Models\ShiftTemplate;
@@ -213,6 +214,16 @@ class RotationPatternResource extends Resource
                     ->successNotificationTitle('Patrón desactivado'),
             ])
             ->defaultSort('name');
+    }
+
+    /**
+     * @return array<class-string>
+     */
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\EmployeesRelationManager::class,
+        ];
     }
 
     /**

--- a/app/Filament/Resources/RotationPatternResource/RelationManagers/EmployeesRelationManager.php
+++ b/app/Filament/Resources/RotationPatternResource/RelationManagers/EmployeesRelationManager.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace App\Filament\Resources\RotationPatternResource\RelationManagers;
+
+use App\Filament\Resources\EmployeeResource;
+use App\Models\Branch;
+use App\Models\Employee;
+use App\Models\RotationPattern;
+use App\Models\ShiftTemplate;
+use App\Services\RotationService;
+use Carbon\Carbon;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Muestra y gestiona los empleados con asignación activa al patrón de
+ * rotación, usando RotationService::assign()/closeActive() — mismo patrón
+ * que ScheduleResource\RelationManagers\EmployeesRelationManager, adaptado
+ * a rotation_assignments (que además requiere start_index).
+ */
+class EmployeesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'currentEmployees';
+
+    protected static ?string $title = 'Empleados Asignados';
+
+    protected static ?string $modelLabel = 'empleado';
+
+    protected static ?string $pluralModelLabel = 'empleados';
+
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Formulario para asignar empleados al patrón, con filtro opcional por
+     * sucursal y selección del día de inicio del ciclo (por nombre de turno,
+     * no por índice crudo).
+     */
+    public function form(Form $form): Form
+    {
+        /** @var RotationPattern $pattern */
+        $pattern = $this->getOwnerRecord();
+
+        return $form
+            ->schema([
+                Select::make('filter_branch')
+                    ->label('Filtrar por Sucursal')
+                    ->options(fn () => Branch::pluck('name', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->native(false)
+                    ->live()
+                    ->afterStateUpdated(fn (callable $set) => $set('employee_ids', []))
+                    ->columnSpanFull(),
+
+                Select::make('employee_ids')
+                    ->label('Empleados')
+                    ->options(function (callable $get) use ($pattern) {
+                        $patternId = $pattern->id;
+                        $today = Carbon::today();
+
+                        $query = Employee::query()->where('status', 'active');
+
+                        $filterBranch = $get('filter_branch');
+                        if ($filterBranch) {
+                            $query->where('branch_id', $filterBranch);
+                        }
+
+                        return $query
+                            ->orderBy('first_name')
+                            ->orderBy('last_name')
+                            ->get()
+                            ->mapWithKeys(function (Employee $employee) use ($patternId, $today) {
+                                $current = $employee->rotationAssignments()
+                                    ->forDate($today)
+                                    ->with('pattern')
+                                    ->first();
+
+                                if ($current?->pattern_id === $patternId) {
+                                    return [];
+                                }
+
+                                $label = "{$employee->full_name} - CI: {$employee->ci}";
+                                if ($current) {
+                                    $label .= " ⚠ (Rotación actual: {$current->pattern?->name})";
+                                }
+
+                                return [$employee->id => $label];
+                            })
+                            ->filter();
+                    })
+                    ->multiple()
+                    ->searchable()
+                    ->required()
+                    ->native(false)
+                    ->helperText('⚠ Los empleados con rotación actual la cambiarán a este patrón')
+                    ->columnSpanFull(),
+
+                Select::make('start_index')
+                    ->label('Empieza en')
+                    ->options(function () use ($pattern) {
+                        $shiftIds = collect($pattern->sequence ?? []);
+                        $shifts = ShiftTemplate::whereIn('id', $shiftIds->unique())->get()->keyBy('id');
+
+                        return $shiftIds
+                            ->values()
+                            ->mapWithKeys(function (int $shiftId, int $index) use ($shifts) {
+                                $shift = $shifts->get($shiftId);
+                                $label = $shift
+                                    ? ($shift->is_day_off ? $shift->name : "{$shift->name} ({$shift->start_time}–{$shift->end_time})")
+                                    : 'Turno';
+
+                                return [$index => 'Día '.($index + 1).": {$label}"];
+                            });
+                    })
+                    ->default(0)
+                    ->native(false)
+                    ->required()
+                    ->helperText('El mismo día de inicio se aplica a todos los empleados seleccionados. Para desfasar a alguien, asignalo aparte.')
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    /**
+     * Tabla de empleados asignados actualmente al patrón, con acciones para asignar y remover.
+     */
+    public function table(Table $table): Table
+    {
+        /** @var RotationPattern $pattern */
+        $pattern = $this->getOwnerRecord();
+
+        return $table
+            ->recordTitleAttribute('first_name')
+            ->recordUrl(fn (Employee $record) => EmployeeResource::getUrl('view', ['record' => $record]))
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->addSelect([
+                    'employees.*',
+                    'rotation_assignments.valid_from as assignment_start_date',
+                    'rotation_assignments.start_index as assignment_start_index',
+                    'users.name as assignment_created_by',
+                ])
+                ->leftJoin('users', 'users.id', '=', 'rotation_assignments.created_by_id')
+                ->with(['activeContract.position.department', 'branch']))
+            ->columns([
+                ImageColumn::make('photo')
+                    ->label('Foto')
+                    ->circular()
+                    ->defaultImageUrl(fn ($record) => $record->avatar_url),
+
+                TextColumn::make('full_name')
+                    ->label('Nombre completo')
+                    ->getStateUsing(fn (Employee $record) => $record->first_name.' '.$record->last_name)
+                    ->description(fn (Employee $record) => 'CI: '.$record->ci)
+                    ->searchable(query: fn (Builder $query, string $search) => $query
+                        ->where('first_name', 'like', "%{$search}%")
+                        ->orWhere('last_name', 'like', "%{$search}%")
+                        ->orWhere('ci', 'like', "%{$search}%")
+                    )
+                    ->sortable()
+                    ->weight('medium'),
+
+                TextColumn::make('activeContract.position.name')
+                    ->label('Cargo')
+                    ->icon('heroicon-o-briefcase')
+                    ->default('-')
+                    ->badge()
+                    ->color('info'),
+
+                TextColumn::make('branch.name')
+                    ->label('Sucursal')
+                    ->icon('heroicon-o-building-storefront')
+                    ->default('-')
+                    ->badge()
+                    ->color('success'),
+
+                TextColumn::make('assignment_start_date')
+                    ->label('Vigente desde')
+                    ->description(fn ($record) => Carbon::parse($record->assignment_start_date)->diffForHumans())
+                    ->date('d/m/Y')
+                    ->sortable()
+                    ->alignCenter(),
+
+                TextColumn::make('assignment_start_index')
+                    ->label('Día de inicio')
+                    ->getStateUsing(function ($record) use ($pattern) {
+                        $index = (int) $record->assignment_start_index;
+                        $shiftId = $pattern->sequence[$index] ?? null;
+                        $shift = $shiftId ? ShiftTemplate::find($shiftId) : null;
+
+                        return 'Día '.($index + 1).($shift ? ": {$shift->name}" : '');
+                    })
+                    ->badge()
+                    ->color('gray'),
+
+                TextColumn::make('assignment_created_by')
+                    ->label('Asignado por')
+                    ->icon('heroicon-o-user')
+                    ->placeholder('—')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('branch_id')
+                    ->label('Sucursal')
+                    ->relationship('branch', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->native(false),
+            ])
+            ->headerActions([
+                Action::make('assign')
+                    ->label('Asignar')
+                    ->icon('heroicon-o-user-plus')
+                    ->color('primary')
+                    ->modalHeading('Asignar Empleados al Patrón')
+                    ->modalSubmitActionLabel('Asignar')
+                    ->modalWidth('2xl')
+                    ->form(fn () => $this->form($this->makeForm())->getComponents())
+                    ->action(function (array $data) use ($pattern) {
+                        $employees = Employee::whereIn('id', $data['employee_ids'])->get();
+                        $assigned = 0;
+                        $errors = [];
+
+                        foreach ($employees as $employee) {
+                            try {
+                                RotationService::assign(
+                                    employee: $employee,
+                                    pattern: $pattern,
+                                    validFrom: Carbon::today(),
+                                    startIndex: (int) $data['start_index'],
+                                );
+                                $assigned++;
+                            } catch (\Exception) {
+                                $errors[] = $employee->full_name;
+                            }
+                        }
+
+                        if ($assigned > 0) {
+                            Notification::make()
+                                ->success()
+                                ->title('Empleados asignados')
+                                ->body("Se asignó \"{$pattern->name}\" a {$assigned} empleado(s) a partir de hoy.")
+                                ->send();
+                        }
+
+                        if (! empty($errors)) {
+                            Notification::make()
+                                ->warning()
+                                ->title('Algunos empleados no pudieron asignarse')
+                                ->body('Revisar solapamientos en: '.implode(', ', $errors))
+                                ->persistent()
+                                ->send();
+                        }
+                    }),
+            ])
+            ->actions([
+                Action::make('remove')
+                    ->label('Remover')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalHeading('Remover Empleado del Patrón')
+                    ->modalDescription(fn ($record) => "¿Está seguro de que desea remover a {$record->full_name} de este patrón de rotación?")
+                    ->modalSubmitActionLabel('Sí, remover')
+                    ->action(function (Employee $record) {
+                        RotationService::closeActive($record, Carbon::today());
+
+                        Notification::make()
+                            ->success()
+                            ->title('Empleado removido')
+                            ->body("Se cerró la asignación de {$record->full_name} con fecha de hoy.")
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([
+                BulkAction::make('remove')
+                    ->label('Remover seleccionados')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalHeading('Remover Empleados del Patrón')
+                    ->modalDescription('¿Está seguro de que desea remover los empleados seleccionados de este patrón de rotación?')
+                    ->modalSubmitActionLabel('Sí, remover')
+                    ->action(function ($records) {
+                        $count = $records->count();
+
+                        foreach ($records as $record) {
+                            RotationService::closeActive($record, Carbon::today());
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title('Empleados removidos')
+                            ->body("Se cerró la asignación de {$count} empleado(s) con fecha de hoy.")
+                            ->send();
+                    }),
+            ])
+            ->defaultSort('assignment_start_date', 'desc')
+            ->emptyStateHeading('No hay empleados asignados')
+            ->emptyStateDescription('Comience asignando empleados a este patrón.')
+            ->emptyStateIcon('heroicon-o-user-group');
+    }
+}

--- a/app/Models/RotationPattern.php
+++ b/app/Models/RotationPattern.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 /** Patrón de rotación: ciclo ordenado de turnos definido como secuencia JSON de IDs. */
 class RotationPattern extends Model
@@ -18,7 +20,7 @@ class RotationPattern extends Model
     ];
 
     protected $casts = [
-        'sequence'  => 'array',
+        'sequence' => 'array',
         'is_active' => 'boolean',
     ];
 
@@ -35,6 +37,30 @@ class RotationPattern extends Model
     }
 
     /**
+     * Empleados con asignación de rotación activa a este patrón hoy —
+     * misma lógica que Schedule::currentEmployees(), adaptada a
+     * rotation_assignments/pattern_id.
+     */
+    public function currentEmployees(): HasManyThrough
+    {
+        $today = Carbon::today()->toDateString();
+
+        return $this->hasManyThrough(
+            Employee::class,
+            RotationAssignment::class,
+            'pattern_id',   // FK en rotation_assignments
+            'id',           // FK en employees
+            'id',           // PK en rotation_patterns
+            'employee_id',  // PK local en rotation_assignments
+        )
+            ->where('rotation_assignments.valid_from', '<=', $today)
+            ->where(fn ($q) => $q
+                ->whereNull('rotation_assignments.valid_until')
+                ->orWhere('rotation_assignments.valid_until', '>=', $today)
+            );
+    }
+
+    /**
      * Largo del ciclo en días (derivado del array sequence).
      */
     public function getCycleLengthAttribute(): int
@@ -46,7 +72,6 @@ class RotationPattern extends Model
      * Retorna el ShiftTemplate ID para la posición dada del ciclo.
      *
      * @param  int  $position  Posición 0-based dentro del ciclo.
-     * @return int|null
      */
     public function shiftIdAtPosition(int $position): ?int
     {

--- a/tests/Feature/RotationPatternEmployeesRelationManagerTest.php
+++ b/tests/Feature/RotationPatternEmployeesRelationManagerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use App\Filament\Resources\RotationPatternResource\Pages\EditRotationPattern;
+use App\Filament\Resources\RotationPatternResource\RelationManagers\EmployeesRelationManager;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\RotationAssignment;
+use App\Models\RotationPattern;
+use App\Models\ShiftTemplate;
+use App\Models\User;
+use App\Services\RotationService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: RotationService::assign()/closeActive() no tenían ningún
+ * caller en la UI — no existía forma de asignar un patrón de rotación a un
+ * empleado desde el panel. Este test cubre el nuevo RelationManager que
+ * expone esa acción en RotationPatternResource.
+ */
+function makeRotationRmCompany(): Company
+{
+    static $n = 8700000;
+    $n++;
+
+    return Company::create(['name' => "Empresa RotationRM {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+}
+
+function makeRotationRmEmployee(Company $company): Employee
+{
+    static $ci = 8700000;
+    $n = $ci++;
+
+    $branch = Branch::create(['name' => "Sucursal RotationRM {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto RotationRM {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo RotationRM {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Rotation',
+        'last_name' => "RM {$n}",
+        'ci' => (string) $n,
+        'birth_date' => '1990-01-01',
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+function makeRotationRmPattern(Company $company): RotationPattern
+{
+    $shift = ShiftTemplate::create([
+        'company_id' => $company->id,
+        'name' => 'Turno Mañana',
+        'shift_type' => 'diurno',
+        'is_day_off' => false,
+        'start_time' => '07:00',
+        'end_time' => '15:00',
+        'break_minutes' => 30,
+        'is_active' => true,
+    ]);
+
+    return RotationPattern::create([
+        'company_id' => $company->id,
+        'name' => 'Patrón RM Test',
+        'sequence' => [$shift->id],
+        'is_active' => true,
+    ]);
+}
+
+it('asigna el patrón de rotación a los empleados seleccionados desde el RelationManager', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = makeRotationRmCompany();
+    $employee = makeRotationRmEmployee($company);
+    $pattern = makeRotationRmPattern($company);
+
+    Livewire::test(EmployeesRelationManager::class, [
+        'ownerRecord' => $pattern,
+        'pageClass' => EditRotationPattern::class,
+    ])
+        ->callTableAction('assign', data: ['employee_ids' => [$employee->id], 'start_index' => 0])
+        ->assertHasNoTableActionErrors();
+
+    $assignment = RotationAssignment::where('employee_id', $employee->id)
+        ->where('pattern_id', $pattern->id)
+        ->whereNull('valid_until')
+        ->first();
+
+    expect($assignment)->not->toBeNull();
+    expect($assignment->start_index)->toBe(0);
+    expect($assignment->valid_from->toDateString())->toBe(Carbon::today()->toDateString());
+});
+
+it('remueve la asignación activa de un empleado desde el RelationManager', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = makeRotationRmCompany();
+    $employee = makeRotationRmEmployee($company);
+    $pattern = makeRotationRmPattern($company);
+
+    RotationService::assign($employee, $pattern, Carbon::today()->subMonth());
+
+    Livewire::test(EmployeesRelationManager::class, [
+        'ownerRecord' => $pattern,
+        'pageClass' => EditRotationPattern::class,
+    ])
+        ->assertCanSeeTableRecords([$employee])
+        ->callTableAction('remove', $employee)
+        ->assertHasNoTableActionErrors();
+
+    $assignment = RotationAssignment::where('employee_id', $employee->id)
+        ->where('pattern_id', $pattern->id)
+        ->first();
+
+    expect($assignment->valid_until?->toDateString())->toBe(Carbon::today()->toDateString());
+});
+
+it('el RelationManager solo lista empleados con asignación activa vigente hoy', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = makeRotationRmCompany();
+    $activeEmployee = makeRotationRmEmployee($company);
+    $closedEmployee = makeRotationRmEmployee($company);
+    $pattern = makeRotationRmPattern($company);
+
+    RotationService::assign($activeEmployee, $pattern, Carbon::today()->subMonth());
+    RotationService::assign($closedEmployee, $pattern, Carbon::today()->subMonths(3), validUntil: Carbon::today()->subMonth());
+
+    Livewire::test(EmployeesRelationManager::class, [
+        'ownerRecord' => $pattern,
+        'pageClass' => EditRotationPattern::class,
+    ])
+        ->assertCanSeeTableRecords([$activeEmployee])
+        ->assertCanNotSeeTableRecords([$closedEmployee])
+        ->assertCountTableRecords(1);
+});


### PR DESCRIPTION
## Summary
- `RotationService::assign()`/`closeActive()` estaban completamente implementados pero no tenían ningún caller en la UI — no existía forma de asignar un patrón de rotación a un empleado desde el panel Filament (descubierto al auditar la guía de usuario en busca del capítulo de Rotaciones).
- Se agrega `RotationPatternResource\RelationManagers\EmployeesRelationManager`, siguiendo el mismo patrón que `ScheduleResource\RelationManagers\EmployeesRelationManager`: selección múltiple de empleados (con aviso si ya tienen rotación activa), selector de día de inicio del ciclo (por nombre de turno, ej. "Día 1: Turno Mañana"), y acción de remover asignación activa (individual y en bulk).
- Se agrega `RotationPattern::currentEmployees(): HasManyThrough`, mismo mecanismo que `Schedule::currentEmployees()`, requerido por el RelationManager.

## Test plan
- [x] Nuevos tests Pest (`tests/Feature/RotationPatternEmployeesRelationManagerTest.php`): asignar patrón desde el RelationManager, remover asignación activa, y que la tabla solo liste empleados con asignación vigente hoy.
- [x] `php artisan test --compact --filter=Rotation` — 8 passed.
- [x] `vendor/bin/pint --dirty` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_