### PR TITLE
Guía de usuario: verificar capítulo de Amonestaciones

### DIFF
--- a/resources/docs/13-amonestaciones.md
+++ b/resources/docs/13-amonestaciones.md
@@ -31,25 +31,26 @@ El módulo de Amonestaciones permite registrar formalmente las sanciones discipl
    - **Tipo** (Verbal, Escrita o Grave)
    - **Motivo** (categoría predefinida)
    - **Descripción del hecho** (detalle libre)
-   - **Observaciones** (opcional)
 4. Guardar
 
-> La fecha de emisión y el emisor se registran automáticamente con la fecha actual y el usuario logueado.
+> La fecha de emisión y el emisor se registran automáticamente con la fecha actual y el usuario logueado. Este formulario **no** tiene un campo de observaciones adicionales — para eso, cargar la amonestación desde el perfil del empleado (ver abajo).
 
 ### Desde el perfil del empleado
 
 1. Abrir el perfil del empleado
 2. Ir a la pestaña **Amonestaciones**
 3. Clic en **Nueva Amonestación**
-4. Completar el formulario y guardar
+4. Completar el formulario — acá sí hay un campo adicional **Observaciones adicionales** (opcional) — y guardar
 
-## Editar una amonestación
+## Editar o eliminar una amonestación
 
 Desde la vista de detalle, clic en **Editar**. En el formulario de edición están disponibles adicionalmente:
 
-- **Fecha de emisión** — si se necesita corregir la fecha
+- **Fecha de emisión** — si se necesita corregir la fecha (no permite fechas futuras)
 - **Emitida por** — si se necesita cambiar el emisor
 - **Documento Firmado** — para adjuntar el PDF escaneado con la firma del empleado
+
+Una amonestación no tiene ciclo de vida ni estados — es un registro documental permanente. Si se cargó por error, se puede **Eliminar** desde el encabezado de la pantalla de edición (acción irreversible, sin confirmación adicional más allá del modal estándar).
 
 ## Documento PDF
 
@@ -82,4 +83,7 @@ El listado permite filtrar por:
 
 ## Exportar a Excel
 
-Desde el encabezado del listado, el botón **Exportar Excel** descarga un archivo con todas las amonestaciones registradas, incluyendo: Empleado, CI, Tipo, Motivo, Descripción, Fecha de emisión, Emitida por, Observaciones, Creado y Editado.
+Hay dos formas de exportar:
+
+- **Exportar Excel** (encabezado del listado) — descarga **todas** las amonestaciones registradas, incluyendo: Empleado, CI, Tipo, Motivo, Descripción, Fecha de emisión, Emitida por, Observaciones, Creado y Editado.
+- **Exportar a Excel** (acción masiva sobre la tabla) — exporta solo las amonestaciones seleccionadas con el checkbox.


### PR DESCRIPTION
## Summary
Continúa la verificación módulo por módulo de la guía de usuario. **13-amonestaciones.md** — reescritura verificada contra `WarningResource`, sus Pages (`EditWarning`, `ViewWarning`, `ListWarnings`), `WarningsRelationManager` y el modelo `Warning`.

Correcciones:
- El formulario general (Empleados → Amonestaciones → Nueva Amonestación) **no** tiene campo de "Observaciones" — ese campo ("Observaciones adicionales") solo existe en el formulario del RelationManager, al cargar la amonestación desde el perfil del empleado. Es una inconsistencia real entre ambos puntos de entrada, reflejada tal cual en la documentación.
- Faltaba mencionar la acción **Eliminar** (disponible desde la edición).
- Se aclara que existen dos exportaciones distintas con nombres parecidos: **"Exportar Excel"** (todas, botón de encabezado) y **"Exportar a Excel"** (solo seleccionadas, acción masiva).

## Test plan
- [x] Revisión manual de cada dato contra el código real citado arriba (Resource, Pages, RelationManager, Model)
- [x] Solo cambios en Markdown — no aplica test automatizado ni Pint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_