### PR TITLE
Guía de usuario: verificar capítulo de Lotes de Pagos Bancarios

### DIFF
--- a/resources/docs/17-lotes-pagos-bancarios.md
+++ b/resources/docs/17-lotes-pagos-bancarios.md
@@ -1,6 +1,15 @@
 # Lotes de Pagos Bancarios
 
-El módulo de Lotes agrupa adelantos de salario en un único archivo TXT en formato Itaú para enviar al banco y registrar el resultado de la acreditación. Evita procesar cada adelanto por separado y mantiene trazabilidad completa del ciclo bancario.
+El módulo de Lotes agrupa pagos por transferencia bancaria en un único archivo TXT en formato Itaú para enviar al banco, y registra el resultado de la acreditación. Evita procesar cada pago por separado y mantiene trazabilidad completa del ciclo bancario.
+
+Un lote puede agrupar **cuatro tipos** de pago distintos — cada uno se crea desde su propio módulo, no desde un formulario único:
+
+| Tipo | Se crea desde |
+|------|----------------|
+| **Adelantos de salario** | **Nóminas → Pagos Bancarios**, botón **Crear lote de pago** |
+| **Planilla de salarios** | Vista de un período de nómina cerrado, acción **Enviar al Banco** |
+| **Préstamos** | Listado de Préstamos, header action **Crear Lote Bancario** |
+| **Aguinaldo** | Vista de un período de aguinaldo, acción **Enviar al Banco** |
 
 ---
 
@@ -10,7 +19,7 @@ Para poder generar y descargar el archivo TXT, deben estar configurados:
 
 - La **empresa** con una cuenta bancaria principal activa
 - La cuenta bancaria con el **ID de Empresa** configurado
-- Los empleados incluidos con **cuentas bancarias primarias activas**
+- Los empleados incluidos con **cuentas bancarias primarias activas** — si falta alguna, el sistema advierte cuáles empleados no la tienen (no bloquea la creación del lote, pero esos registros quedan fuera del TXT)
 
 ---
 
@@ -19,31 +28,42 @@ Para poder generar y descargar el archivo TXT, deben estar configurados:
 | Estado | Descripción |
 |--------|-------------|
 | **Pendiente** | Creado, aún no confirmado con el banco |
-| **Confirmado** | Todos los adelantos fueron aceptados por el banco |
-| **Parcialmente Confirmado** | El banco aceptó algunos y rechazó otros |
-| **Cancelado** | Cancelado manualmente o porque todos los ítems fueron rechazados |
+| **Confirmado** | Todos los ítems fueron aceptados por el banco |
+| **Parcialmente confirmado** | El banco aceptó algunos y rechazó otros |
+| **Cancelado** | Cancelado manualmente, o porque todos los ítems fueron rechazados |
 
 ---
 
-## Crear un lote
+## Crear un lote de Adelantos
 
-1. Ir a **Nóminas → Lotes Bancarios**
-2. Clic en **Nuevo Lote**
+1. Ir a **Nóminas → Pagos Bancarios**
+2. Clic en **Crear lote de pago**
 3. Seleccionar la **empresa** — el sistema carga automáticamente los adelantos disponibles (estado Aprobado, método de pago Transferencia, sin lote asignado)
 4. Seleccionar los adelantos a incluir en este lote
 5. Definir la **fecha de acreditación** (por defecto: hoy)
 6. Agregar **notas** si aplica
 7. Guardar
 
+## Crear un lote de Planilla, Préstamos o Aguinaldo
+
+Estos tres tipos **no** se crean desde el listado de Pagos Bancarios — se generan desde su propio módulo, y el sistema incluye automáticamente **todos** los registros elegibles de la empresa (no hay selección individual):
+
+- **Planilla**: en la vista del período de nómina, acción **Enviar al Banco** → elegir empresa (si hay más de una con recibos elegibles) → el lote incluye todos los recibos **Aprobados**, por **Transferencia**, sin lote asignado, de ese período
+- **Préstamos**: en el listado de Préstamos, header action **Crear Lote Bancario** → mismo criterio, sobre préstamos **Aprobados** por Transferencia
+- **Aguinaldo**: en la vista del período de aguinaldo, acción **Enviar al Banco** → mismo criterio, sobre aguinaldos **Pendientes** por Transferencia
+
+En los tres casos, antes de crear el lote el modal muestra un aviso con los empleados que no tienen cuenta bancaria activa registrada (no bloquea la creación). Al confirmar, el sistema redirige directamente al detalle del lote recién creado.
+
 ---
 
 ## Descargar el archivo TXT para el banco
 
-1. Abrir el lote desde **Nóminas → Lotes Bancarios**
+1. Abrir el lote (estado **Pendiente**)
 2. Clic en **Descargar TXT**
-3. El archivo generado está en formato Itaú — enviarlo al banco por el canal habitual
+3. El modal muestra un resumen (cantidad de ítems y monto total) antes de generar el archivo
+4. El archivo generado está en formato Itaú — enviarlo al banco por el canal habitual
 
-> Si algún empleado no tiene cuenta bancaria configurada, sus adelantos no se incluyen en el TXT y el sistema lo notifica.
+> Si la empresa no tiene cuenta bancaria principal activa, o le falta el **ID de Empresa**, el sistema bloquea la descarga y avisa qué falta configurar.
 
 ---
 
@@ -54,55 +74,77 @@ Una vez que el banco procesa el archivo y devuelve el resultado:
 1. Abrir el lote (debe estar en estado **Pendiente**)
 2. Clic en **Confirmar Lote**
 3. En el modal:
-   - Adjuntar el **comprobante bancario** (PDF, JPG, PNG o WEBP, máx. 10 MB)
-   - Si el banco rechazó algún adelanto, marcarlo como rechazado en la lista
-   - Ingresar el motivo de rechazo si aplica
+   - Adjuntar el **comprobante bancario** (PDF, JPG, PNG o WEBP, máx. 10 MB) — obligatorio
+   - Marcar en la lista los ítems que el banco **rechazó** (si los hay)
 4. Confirmar
 
-El sistema actualiza automáticamente:
-- Adelantos aceptados → estado **Entregado (Acreditado)**
-- Adelantos rechazados → vuelven a estado **Aprobado** con el motivo de rechazo registrado
-- El lote pasa a **Confirmado**, **Parcialmente Confirmado** o **Cancelado** según el resultado
+Los ítems no marcados como rechazados pasan automáticamente según el tipo de lote:
+
+| Tipo | Ítems aceptados pasan a | Ítems rechazados vuelven a |
+|------|--------------------------|------------------------------|
+| Adelantos | Entregado (Acreditado) | Aprobado, con motivo de rechazo registrado |
+| Planilla | Desembolsado | Aprobado, con motivo de rechazo registrado |
+| Préstamos | Desembolsado | Aprobado |
+| Aguinaldo | Pagado | Pendiente |
+
+El lote pasa a **Confirmado**, **Parcialmente confirmado** o **Cancelado** (si se rechazaron todos) según el resultado.
+
+---
+
+## Editar un lote
+
+Mientras el lote esté **Pendiente**, la acción **Editar** permite modificar la **fecha de acreditación** y las **notas** — no los ítems incluidos.
 
 ---
 
 ## Cancelar un lote
 
-Solo disponible desde estado **Pendiente**:
+Solo disponible desde estado **Pendiente**, acción **Cancelar Lote** (con confirmación).
 
-1. Abrir el lote
-2. Clic en **Cancelar Lote**
-3. Confirmar
-
-Al cancelar, todos los adelantos del lote vuelven a estado **Aprobado** y quedan disponibles para incluirse en un nuevo lote.
+Al cancelar, todos los ítems del lote quedan libres para incluirse en un lote nuevo: los adelantos y recibos de nómina vuelven a **Aprobado**, los préstamos vuelven a **Aprobado**, los aguinaldos vuelven a **Pendiente**.
 
 ---
 
 ## Acciones disponibles según estado
 
+Estas acciones están en el encabezado de la vista de detalle del lote (no en el listado — la tabla solo tiene la acción **Ver**):
+
 | Estado | Acciones disponibles |
 |--------|---------------------|
-| **Pendiente** | Editar, Descargar TXT, Confirmar Lote, Cancelar |
-| **Confirmado** | Ver comprobante bancario (solo lectura) |
-| **Parcialmente Confirmado** | Ver comprobante bancario (solo lectura) |
-| **Cancelado** | Solo lectura |
+| **Pendiente** | Editar, Descargar TXT, Confirmar Lote, Cancelar Lote |
+| **Confirmado / Parcialmente confirmado / Cancelado** | Solo lectura — sin acciones de mutación |
+
+En lotes de tipo Planilla o Aguinaldo también aparece un acceso directo (**Ver Planilla** / **Ver Período de Aguinaldo**) al período de origen.
+
+---
+
+## Detalle del lote
+
+La vista de detalle muestra, además de los datos generales (empresa, tipo, fecha de acreditación, estado, cantidad de ítems y monto total):
+- El **archivo TXT** generado y el **comprobante bancario** adjuntado (si existen), con enlace de descarga
+- Pestañas con el listado de los ítems incluidos (adelantos, recibos, préstamos o aguinaldos según el tipo)
+- Pestaña de **Auditoría** con el historial de cambios de estado
 
 ---
 
 ## Tabs del listado
 
+El listado (**Nóminas → Pagos Bancarios**) filtra por **tipo de lote**, no por estado:
+
 | Tab | Descripción |
 |-----|-------------|
-| **Todos** | Todos los lotes |
-| **Pendientes** | Esperando confirmación bancaria |
-| **Confirmados** | Acreditación exitosa |
-| **Parcialmente Confirmados** | Con algunos ítems rechazados |
-| **Cancelados** | Cancelados o rechazados totalmente |
+| **Todos** | Todos los lotes, de cualquier tipo |
+| **Adelantos** | Lotes de adelantos de salario |
+| **Planilla** | Lotes de recibos de nómina |
+| **Préstamos** | Lotes de préstamos |
+| **Aguinaldo** | Lotes de aguinaldo |
+
+Para filtrar por estado (Pendiente, Confirmado, etc.) usar el filtro **Estado** de la tabla, junto con el filtro **Empresa**.
 
 ---
 
-## Relación con los adelantos
+## Relación con los módulos de origen
 
-Los adelantos incluidos en un lote muestran el lote al que pertenecen en su vista de detalle. Al cancelar o rechazar un lote, el adelanto queda libre para asignarse a un nuevo lote.
+Los adelantos, recibos, préstamos y aguinaldos incluidos en un lote muestran a qué lote pertenecen desde su propia vista de detalle. Al cancelar o rechazar un lote, el registro queda libre para asignarse a un nuevo lote.
 
-Para ver y gestionar los adelantos individualmente ir a **Nóminas → Adelantos** (ver capítulo **Adelantos**).
+Para gestionar cada tipo individualmente ver los capítulos **Adelantos**, **Nóminas**, **Préstamos** y **Aguinaldo**.


### PR DESCRIPTION
## Summary
Continúa la verificación módulo por módulo de la guía de usuario. **17-lotes-pagos-bancarios.md** — reescritura verificada contra `DisbursementBatch`, `DisbursementBatchResource`, `ViewDisbursementBatch`, `ListDisbursementBatches` y los entry points en `ViewPayrollPeriod`, `ListLoans` y `ViewAguinaldoPeriod`.

Correcciones principales:
- El capítulo anterior documentaba **solo** el tipo Adelantos — el módulo en realidad soporta **cuatro** tipos de lote (Adelantos, Planilla, Préstamos, Aguinaldo), cada uno con su propio punto de entrada: **"Crear lote de pago"** (Adelantos, desde este mismo listado) vs. **"Enviar al Banco"** (Planilla/Aguinaldo, desde el período) vs. **"Crear Lote Bancario"** (Préstamos, desde su listado). Para estos últimos tres la selección no es manual: el sistema incluye automáticamente todos los registros elegibles de la empresa.
- El label de navegación es **"Pagos Bancarios"**, no "Lotes Bancarios".
- Las pestañas del listado filtran por **tipo de lote** (Todos, Adelantos, Planilla, Préstamos, Aguinaldo) — el capítulo anterior decía que filtraban por estado, que en realidad es un filtro aparte.
- Las acciones (Editar, Descargar TXT, Confirmar Lote, Cancelar) están en el **encabezado de la vista de detalle**, no como acciones de fila en la tabla (la tabla solo tiene "Ver").
- "Editar" solo permite cambiar fecha de acreditación y notas, no los ítems incluidos — no estaba documentado qué cubre exactamente.
- El resultado de "Confirmar Lote" varía según el tipo (a qué estado pasan los aceptados/rechazados en cada uno) — el capítulo anterior solo cubría el caso de adelantos.
- Faltaban los accesos directos "Ver Planilla"/"Ver Período de Aguinaldo" y las pestañas de ítems/auditoría en el detalle del lote.

## Test plan
- [x] Revisión manual de cada dato contra el código real citado arriba (Model, Resource, Pages, entry points en otros módulos)
- [x] Solo cambios en Markdown — no aplica test automatizado ni Pint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_