### PR TITLE
Guía de usuario: verificar capítulo de Reporte de Salarios

### DIFF
--- a/resources/docs/18-reporte-salarios.md
+++ b/resources/docs/18-reporte-salarios.md
@@ -75,4 +75,4 @@ El PDF incluye el encabezado de la empresa, el nombre del período, los filtros 
 2. En el modal seleccionar las **columnas a incluir**
 3. Clic en **Exportar**
 
-El archivo incluye una hoja con la tabla principal. El nombre del archivo lleva la fecha y hora de generación.
+El archivo incluye una hoja con la tabla principal y una **fila de totales** al final (suma de las columnas monetarias seleccionadas: Salario Base, Percepciones, IPS, Descuentos por Deuda, Judiciales, Voluntarias, Deducciones y Neto). El nombre del archivo lleva la fecha y hora de generación.


### PR DESCRIPTION
## Summary
Continúa la verificación módulo por módulo de la guía de usuario. **18-reporte-salarios.md** — verificada contra `SalaryReport`, `SalaryReportExport` y `SalaryReportController`.

Este capítulo ya era en gran parte preciso: los filtros en cascada, las columnas de la tabla y el contenido del PDF (encabezado de empresa, nombre de período, filtros activos, totales al pie) coinciden exactamente con el código. La única corrección fue documentar que el export a Excel agrega una **fila de totales** al final para las columnas monetarias seleccionadas, algo que no estaba mencionado.

## Test plan
- [x] Revisión manual de cada dato contra el código real citado arriba (Page, Export, Controller)
- [x] Solo cambios en Markdown — no aplica test automatizado ni Pint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_