### PR TITLE
Guía de usuario: verificar capítulo de Reporte de Contratos

### DIFF
--- a/resources/docs/19-reporte-contratos.md
+++ b/resources/docs/19-reporte-contratos.md
@@ -36,7 +36,7 @@ Todos los contratos activos, ordenados desde el más antiguo. La columna **Antig
 
 | Color | Rango |
 |-------|-------|
-| Rojo | Menos de 1 año |
+| Gris | Menos de 1 año |
 | Naranja | 1 a 5 años |
 | Azul | 5 a 10 años |
 | Verde | 10 años o más |
@@ -60,12 +60,24 @@ Contratos terminados, ordenados por fecha de rescisión más reciente. Muestra l
 
 ## Filtros disponibles
 
+Los filtros cambian según el tab activo — no todos los tabs muestran los mismos:
+
 | Filtro | Aplica a |
 |--------|---------|
 | **Empresa** (si hay >1 activa) | Todos los tabs |
 | **Sucursal** | Todos los tabs |
+| **Tipo de contrato** | Todos salvo "Sin Contrato" |
+| **Tipo de salario** (Mensual / Jornal) | Todos salvo "Sin Contrato" |
+| **Departamento** | Todos salvo "Sin Contrato" (en cascada con Empresa) |
+| **Cargo** | Todos salvo "Sin Contrato" (en cascada con Departamento) |
 | **Vencer en** (30 / 60 / 90 días) | Solo "Por Vencer" y "Período de Prueba" |
 | **Rescindidos en los últimos** (3 / 6 / 12 meses) | Solo "Rescindidos" |
+| **Período de inicio** (rango de fechas) | "Por Vencer", "Todos Activos", "Por Antigüedad", "Rescindidos" |
+| **Período de vencimiento** (rango de fechas) | Solo "Por Vencer" |
+| **Período de rescisión** (rango de fechas) | Solo "Rescindidos" |
+| **Registrado en el sistema** (rango de fechas) | Solo "Sin Contrato" |
+
+> Los filtros Empresa → Sucursal y Departamento → Cargo son en cascada: cambiar el filtro padre limpia el hijo.
 
 ---
 
@@ -75,6 +87,7 @@ Disponible en todos los tabs desde el encabezado:
 
 1. Clic en **Exportar PDF** o **Exportar Excel**
 2. Seleccionar las **columnas a incluir** — las opciones son dinámicas según el tab activo
-3. Confirmar
+3. En PDF, la **orientación** (Vertical/Horizontal) se ajusta automáticamente según la cantidad de columnas elegidas (Vertical hasta 6 columnas, Horizontal para más) — se puede cambiar manualmente
+4. Confirmar
 
-Las columnas disponibles cambian según el tab (por ejemplo, "Días Restantes" solo aparece en "Por Vencer" y "Período de Prueba").
+Las columnas disponibles cambian según el tab (por ejemplo, "Días Restantes" solo aparece en "Por Vencer" y "Período de Prueba"). Si solo hay una empresa activa, la columna/opción "Empresa" no se ofrece.


### PR DESCRIPTION
## Summary
Continúa la verificación módulo por módulo de la guía de usuario. **19-reporte-contratos.md** — verificada contra `ContractReport`, `ContractReportExport` y el blade de la página.

Correcciones principales:
- El color de la columna Antigüedad para "menos de 1 año" es **gris**, no rojo como decía el capítulo (el código no usa rojo en este tab en absoluto).
- Faltaban seis filtros: **Tipo de contrato**, **Tipo de salario**, **Departamento** y **Cargo** (disponibles en todos los tabs salvo "Sin Contrato", con cascada Empresa→Sucursal y Departamento→Cargo), y los rangos de fecha **"Período de inicio"**, **"Período de vencimiento"**, **"Período de rescisión"** y **"Registrado en el sistema"** (cada uno visible solo en los tabs donde aplica).
- Faltaba mencionar que la orientación del PDF se ajusta automáticamente según la cantidad de columnas elegidas (mismo patrón que otros reportes ya verificados), y que la columna/filtro Empresa desaparece si solo hay una empresa activa.

## Test plan
- [x] Revisión manual de cada dato contra el código real citado arriba (Page, Export, blade)
- [x] Solo cambios en Markdown — no aplica test automatizado ni Pint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_