### PR TITLE
Revocar tokens Sanctum al desactivar un terminal

### DIFF
--- a/app/Http/Middleware/EnsureTerminalIsActive.php
+++ b/app/Http/Middleware/EnsureTerminalIsActive.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Terminal;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Bloquea el acceso a la API de sincronización del terminal cuando su
+ * registro está `inactive`. Defensa en profundidad: `TerminalObserver` ya
+ * revoca los tokens Sanctum al desactivar un terminal desde el panel, pero
+ * este chequeo cubre cualquier caso no contemplado por esa vía (ej. un
+ * token que sobreviva a un flujo de reactivación futuro).
+ */
+class EnsureTerminalIsActive
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $terminal = $request->user();
+
+        if ($terminal instanceof Terminal && $terminal->isInactive()) {
+            abort(403, 'Este terminal fue desactivado.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Observers/TerminalObserver.php
+++ b/app/Observers/TerminalObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Terminal;
+
+/**
+ * Revoca los tokens Sanctum del terminal al desactivarlo.
+ *
+ * Sin esto, "desactivar" un terminal desde el panel solo ocultaba la
+ * pantalla pública del kiosco (`AttendanceFaceMarkController::terminalByCode()`)
+ * — el token Sanctum ya emitido seguía siendo válido para sincronizar
+ * empleados, recibir heartbeats y marcar asistencia vía la API, porque
+ * ninguna de esas rutas validaba el `status` del terminal.
+ */
+class TerminalObserver
+{
+    public function updated(Terminal $terminal): void
+    {
+        if (! $terminal->isDirty('status')) {
+            return;
+        }
+
+        if ($terminal->status === 'inactive') {
+            $terminal->tokens()->delete();
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,11 +7,13 @@ use App\Models\AttendanceEvent;
 use App\Models\Company;
 use App\Models\Contract;
 use App\Models\Employee;
+use App\Models\Terminal;
 use App\Observers\AttendanceDayObserver;
 use App\Observers\AttendanceEventObserver;
 use App\Observers\CompanyObserver;
 use App\Observers\ContractObserver;
 use App\Observers\EmployeeObserver;
+use App\Observers\TerminalObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -34,5 +36,6 @@ class AppServiceProvider extends ServiceProvider
         Company::observe(CompanyObserver::class);
         Contract::observe(ContractObserver::class);
         Employee::observe(EmployeeObserver::class);
+        Terminal::observe(TerminalObserver::class);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\MobileLinkController;
+use App\Http\Middleware\EnsureTerminalIsActive;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -22,6 +23,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'abilities' => CheckAbilities::class,
             'ability' => CheckForAnyAbility::class,
+            'terminal.active' => EnsureTerminalIsActive::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Route;
 
 // Terminal compartido por sucursal — bearer token emitido al provisionarlo
 // (ver TerminalSetupController). Ability requerida: 'terminal:sync'.
-Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum'])->group(function () {
+Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum', 'terminal.active'])->group(function () {
     Route::get('/employees/sync', [TerminalEmployeeSyncController::class, 'index'])
         ->middleware('ability:terminal:sync')
         ->name('employees.sync');

--- a/tests/Feature/TerminalDeactivationTest.php
+++ b/tests/Feature/TerminalDeactivationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Terminal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDeactivationTerminal(): Terminal
+{
+    static $n = 7500000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa Deact {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Deact {$n}", 'company_id' => $company->id]);
+
+    return Terminal::create(['name' => 'Terminal Test', 'branch_id' => $branch->id]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('desactivar un terminal revoca todos sus tokens Sanctum', function () {
+    $terminal = makeDeactivationTerminal();
+    $terminal->createToken('kiosk:test', [Terminal::SYNC_ABILITY]);
+
+    expect($terminal->tokens()->count())->toBe(1);
+
+    $terminal->update(['status' => 'inactive']);
+
+    expect($terminal->fresh()->tokens()->count())->toBe(0);
+});
+
+it('reactivar un terminal no revoca tokens (solo desactivar lo hace)', function () {
+    $terminal = makeDeactivationTerminal();
+    $terminal->update(['status' => 'inactive']);
+    $terminal->createToken('kiosk:test', [Terminal::SYNC_ABILITY]);
+
+    $terminal->update(['status' => 'active']);
+
+    expect($terminal->fresh()->tokens()->count())->toBe(1);
+});
+
+it('actualizar un campo que no sea status no revoca tokens', function () {
+    $terminal = makeDeactivationTerminal();
+    $terminal->createToken('kiosk:test', [Terminal::SYNC_ABILITY]);
+
+    $terminal->update(['last_seen_at' => now()]);
+
+    expect($terminal->fresh()->tokens()->count())->toBe(1);
+});
+
+it('un terminal desactivado no puede sincronizar vía la API aunque conserve un token', function () {
+    $terminal = makeDeactivationTerminal();
+    $terminal->update(['status' => 'inactive']);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/heartbeat');
+
+    $response->assertForbidden();
+});
+
+it('un terminal desactivado no puede sincronizar empleados vía la API', function () {
+    $terminal = makeDeactivationTerminal();
+    $terminal->update(['status' => 'inactive']);
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->getJson('/api/v1/terminal/employees/sync');
+
+    $response->assertForbidden();
+});
+
+it('un terminal activo sigue pudiendo sincronizar normalmente', function () {
+    $terminal = makeDeactivationTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/heartbeat');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+});


### PR DESCRIPTION
## Summary
Hallazgo de seguridad detectado en producción (demo): **"desactivar" un `Terminal` desde el panel no revocaba su acceso real a la API.**

`AttendanceFaceMarkController::terminalByCode()` ya bloqueaba la pantalla pública del kiosco cuando `Terminal::isInactive()`, pero ninguna ruta de `/api/v1/terminal/*` (`TerminalEmployeeSyncController`, `TerminalHeartbeatController`, `TerminalEventSyncController`) validaba el `status` del terminal — solo exigían `auth:sanctum` + `ability:terminal:sync`. Un token Sanctum ya emitido para un terminal marcado como "Inactivo" en el panel seguía siendo válido para sincronizar empleados, recibir heartbeats y marcar asistencia sin ninguna restricción adicional.

## Cambios
- **`TerminalObserver`** (nuevo, registrado en `AppServiceProvider`): al detectar `status → inactive`, revoca todos los tokens Sanctum del terminal (`$terminal->tokens()->delete()`). Reactivar (`status → active`) **no** restaura tokens a propósito — requiere re-provisionar con un nuevo enlace de setup de un solo uso.
- **`EnsureTerminalIsActive`** (middleware nuevo, alias `terminal.active`, aplicado al grupo `/api/v1/terminal`): defensa en profundidad — rechaza con 403 cualquier request autenticada como un `Terminal` `inactive`, por si algún caso futuro deja un token vivo sin pasar por la revocación del observer.
- Tests (`TerminalDeactivationTest`): revocación al desactivar, no-revocación al reactivar ni al tocar otros campos del terminal, y que la API rechace un terminal desactivado aunque conserve un token válido.

## Test plan
- [x] `php artisan test --compact tests/Feature/TerminalDeactivationTest.php` — 6 passed
- [x] `php artisan test --compact tests/Feature/TerminalConnectivityTest.php` — sin regresiones (el único fallo es preexistente, por falta de build de Vite en el entorno de prueba, no relacionado a este cambio)
- [x] `vendor/bin/pint --dirty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_