### PR TITLE
Diferenciar mensajes de reconocimiento facial cuando falta sincronizar

### DIFF
--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -359,6 +359,14 @@ const statusBar           = document.getElementById("statusBar");
     function buildDetailedError(rawMessage) {
         if (!rawMessage) return "No se pudo completar la marcación. Por favor, intente nuevamente.";
         const msg = rawMessage.toLowerCase();
+        // Chequeo primero — sin esto, el mensaje específico lanzado cuando el propio
+        // perfil todavía no sincronizó (ver identifyEmployee(), "ownEmployee" null)
+        // no matcheaba ninguna de las ramas de abajo y caía al genérico "error
+        // inesperado", escondiendo que el problema real es de sincronización, no de
+        // reconocimiento facial.
+        if (msg.includes("sincronizó tu perfil") || msg.includes("conectate a internet")) {
+            return "Tu perfil todavía no se sincronizó con este dispositivo. Conectate a internet y volvé a intentar en unos segundos.";
+        }
         if (msg.includes("ambiguo") || msg.includes("ambiguous") || msg.includes("múltiple") || msg.includes("multiple face")) {
             return "Se detectaron múltiples rostros o el rostro no es claro. Asegúrese de estar solo frente a la cámara y reposicione su cara.";
         }
@@ -2265,18 +2273,33 @@ const statusBar           = document.getElementById("statusBar");
                     if (employee?.company_name) {
                         document.title = `${employee.company_name} — Marcación Facial`;
                     }
+
+                    // Sin descriptor propio cacheado, cualquier intento de marcar va a
+                    // fallar sin importar cuántas veces lo intente el empleado — mostrarlo
+                    // acá (en vez de esperar a que falle un intento real) deja claro que el
+                    // problema es de sincronización, no de la cámara/rostro. Se resuelve
+                    // ANTES de tocar getOwnStatus() (no en paralelo) para que ese resultado
+                    // no pise este aviso con "Todavía no marcaste hoy" — getOwnStatus() no
+                    // depende de own_employee, así que sin este orden ganaría la carrera.
+                    if (!employee) {
+                        if (splashStatusEl) {
+                            splashStatusEl.textContent = "⚠ Tu perfil todavía no se sincronizó. Conectate a internet.";
+                            splashStatusEl.classList.remove("hidden");
+                        }
+                        return;
+                    }
+
+                    getOwnStatus()
+                        .then((status) => {
+                            if (!splashStatusEl) return;
+                            splashStatusEl.textContent = status.last_event
+                                ? `Hoy: ${translateEventType(status.last_event)}${status.last_event_time ? ` · ${status.last_event_time}` : ""}`
+                                : "Todavía no marcaste hoy";
+                            splashStatusEl.classList.remove("hidden");
+                        })
+                        .catch(() => {}); // sin red y sin nada cacheado todavía — se deja oculto, no vale la pena mostrar un error acá
                 })
                 .catch(() => {}); // sin caché todavía — se queda con el saludo genérico
-
-            getOwnStatus()
-                .then((status) => {
-                    if (!splashStatusEl) return;
-                    splashStatusEl.textContent = status.last_event
-                        ? `Hoy: ${translateEventType(status.last_event)}${status.last_event_time ? ` · ${status.last_event_time}` : ""}`
-                        : "Todavía no marcaste hoy";
-                    splashStatusEl.classList.remove("hidden");
-                })
-                .catch(() => {}); // sin red y sin nada cacheado todavía — se deja oculto, no vale la pena mostrar un error acá
         };
         refreshOwnEmployeeUi();
 

--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -149,6 +149,11 @@ export async function getCachedEmployees() {
     return db.getAll('employees_cache');
 }
 
+/** @returns {Promise<number>} Cantidad de empleados cacheados — 0 indica que el terminal nunca sincronizó (o quedó sin candidatos). */
+export async function countCachedEmployees() {
+    return (await getCachedEmployees()).length;
+}
+
 /** @param {number} employeeId @returns {Promise<object|undefined>} */
 export async function getCachedEmployee(employeeId) {
     const db = await getDb();

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,5 +1,5 @@
 import { captureFaceSamples } from '../shared/face-capture-core.js';
-import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees, clearTerminalState } from './terminal-offline/db.js';
+import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees, countCachedEmployees, clearTerminalState } from './terminal-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './terminal-offline/matcher.js';
 import { heartbeat, syncEmployees, getFaceConfig, TerminalAuthError } from './terminal-offline/sync.js';
 import { getEmployeeStatus, enqueueMark, flushQueue, countPendingEvents, countConflictEvents } from './terminal-offline/queue.js';
@@ -815,8 +815,16 @@ document.addEventListener("DOMContentLoaded", () => {
                     terminalState.inNotRecognizedCooldown = true;
                     setTerminalVideoState("detecting");
                     setIdStatusDot("detecting");
-                    updateStatus("Rostro no reconocido. Mantenga el rostro quieto frente a la cámara.");
-                    console.log("No se pudo identificar");
+                    // `result.reason` distingue "no hay nadie cacheado" (problema del terminal,
+                    // no del empleado) de un intento normal que no matcheó — antes se pisaban
+                    // ambos casos con el mismo texto genérico, escondiendo la falla real de sync.
+                    const idleStatusMessages = {
+                        no_candidates: "Terminal sin empleados sincronizados. Contacte al administrador.",
+                        ambiguous: "Rostro ambiguo. Reposicione su cara e intente de nuevo.",
+                        no_match: "Rostro no reconocido. Mantenga el rostro quieto frente a la cámara.",
+                    };
+                    updateStatus(idleStatusMessages[result.reason] || result.message || "Rostro no reconocido. Mantenga el rostro quieto frente a la cámara.");
+                    console.log("No se pudo identificar", result.reason);
 
                     // Tras varios intentos fallidos seguidos, ofrecer la búsqueda manual por CI
                     // en vez de dejar al empleado atrapado repitiendo el mismo intento sin salida.
@@ -1299,6 +1307,17 @@ document.addEventListener("DOMContentLoaded", () => {
      * refleje la cola real en IndexedDB, no solo el último resultado puntual.
      */
     async function refreshIdleSyncStatus() {
+        // Prioridad más alta: sin empleados cacheados el terminal no puede identificar
+        // a NADIE — más grave que marcaciones pendientes/en conflicto, que sí sabe
+        // resolver localmente. Antes esto solo se notaba al fallar un intento real de
+        // reconocimiento, con un mensaje genérico que no distinguía la causa.
+        const employeeCount = await countCachedEmployees();
+        if (employeeCount === 0) {
+            updateIdleSyncStatus("⚠ Sin empleados sincronizados — verifique la conexión o contacte al administrador");
+            await refreshLastSyncLabel();
+            return;
+        }
+
         const [pending, conflicts] = await Promise.all([countPendingEvents(), countConflictEvents()]);
         if (conflicts > 0) {
             updateIdleSyncStatus(`${conflicts} marcación(es) requieren revisión`);


### PR DESCRIPTION
## Summary
Hallazgo detectado en producción (demo): tanto en el terminal compartido como en el dispositivo personal, un fallo de identificación por **falta de datos sincronizados** (0 empleados cacheados en el terminal, o el propio perfil sin sincronizar en el celular) mostraba el mismo mensaje genérico de "rostro no reconocido" que un intento normal fallido — escondiendo que el problema real era de sincronización, no de la cámara/iluminación/rostro.

## Cambios

**Terminal** (`terminal.js` + `terminal-offline/db.js`):
- Nueva `countCachedEmployees()` en `db.js`.
- La rama de fallo de `identifyEmployee()` ahora usa `result.reason` para elegir el mensaje correcto (`no_candidates`/`ambiguous`/`no_match`) en vez de un texto hardcodeado único.
- `refreshIdleSyncStatus()` (pantalla de reposo) ahora chequea la cantidad de empleados cacheados con **prioridad** sobre el estado de la cola de eventos — con 0 empleados sincronizados, ningún reconocimiento puede tener éxito, así que se avisa de entrada en vez de esperar a que el empleado intente marcar y falle.

**Mobile** (`mark.js`):
- `buildDetailedError()` reconocía todas las variantes de error del backend/matcher salvo la de "tu perfil todavía no se sincronizó" (el caso real de este hallazgo) — caía al genérico "error inesperado". Agregado el chequeo correspondiente.
- `refreshOwnEmployeeUi()` ahora muestra el mismo aviso en el splash **antes** de que el empleado intente marcar. Reestructurado para que la consulta a `getOwnStatus()` (que no depende de `own_employee`) no corra en paralelo y pise ese aviso con "Todavía no marcaste hoy".

## Test plan
- [x] `node --check` sobre los 3 archivos JS tocados — sin errores de sintaxis
- [x] `npm run build` — compila limpio (85 módulos transformados, sin warnings nuevos)
- [x] `php artisan test --compact tests/Feature/TerminalConnectivityTest.php` — 12 passed, sin regresiones
- [x] Sin test runner de JS configurado en el proyecto (solo Pest para backend) — no aplica test automatizado de la lógica de UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY

---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_