### PR TITLE
Refactor: extraer helpers de texto de mark.js y agregar Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^1.2.0",
                 "tailwindcss": "^4.0.0",
-                "vite": "^6.2.4"
+                "vite": "^6.2.4",
+                "vitest": "^3.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1152,6 +1153,24 @@
                 "vite": "^5.2.0 || ^6"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1172,6 +1191,131 @@
             "peerDependencies": {
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+            "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.7",
+                "@vitest/utils": "3.2.7",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+            "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.7",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+            "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+            "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.7",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+            "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.7",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+            "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+            "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.7",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vue/compiler-core": {
@@ -1313,6 +1457,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1333,6 +1487,16 @@
                 "proxy-from-env": "^2.1.0"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1345,6 +1509,23 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1375,6 +1556,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
             }
         },
         "node_modules/chownr": {
@@ -1485,6 +1676,16 @@
                 }
             }
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1573,6 +1774,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1658,11 +1866,24 @@
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "license": "MIT"
         },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/fdir": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-            "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -1894,6 +2115,13 @@
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
+        },
+        "node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/laravel-vite-plugin": {
             "version": "1.2.0",
@@ -2157,6 +2385,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/loupe": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2245,6 +2480,23 @@
             },
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
             }
         },
         "node_modules/picocolors": {
@@ -2380,6 +2632,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2388,6 +2647,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -2415,6 +2688,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/supports-color": {
@@ -2467,20 +2753,64 @@
                 "node": ">=18"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-            "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+            "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tree-kill": {
@@ -2574,6 +2904,29 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/vite-plugin-full-reload": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
@@ -2598,6 +2951,79 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+            "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.7",
+                "@vitest/mocker": "3.2.7",
+                "@vitest/pretty-format": "^3.2.7",
+                "@vitest/runner": "3.2.7",
+                "@vitest/snapshot": "3.2.7",
+                "@vitest/spy": "3.2.7",
+                "@vitest/utils": "3.2.7",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.7",
+                "@vitest/ui": "3.2.7",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vue": {
             "version": "3.5.32",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
@@ -2617,6 +3043,23 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "test": "vitest run"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -11,7 +12,8 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.2.4"
+        "vite": "^6.2.4",
+        "vitest": "^3.0.0"
     },
     "dependencies": {
         "@vitejs/plugin-vue": "^6.0.5",

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -11,6 +11,7 @@ import {
     countConflictEvents,
     dismissConflictEvents,
 } from './mobile-offline/queue.js';
+import { translateEventType, buildDetailedError } from './mark/text-helpers.js';
 
 /**
  * =============================================================================
@@ -346,46 +347,6 @@ const statusBar           = document.getElementById("statusBar");
     const logError = (message, errorObj) => {
         errorObj !== undefined ? console.error("[Error]", message, errorObj) : console.error("[Error]", message);
     };
-
-    // --------------------------------------------------------------------------
-    // MENSAJES DE ERROR DETALLADOS
-    // --------------------------------------------------------------------------
-    /**
-     * Transforma un mensaje de error crudo del servidor en un mensaje amigable
-     * con sugerencias concretas para el usuario.
-     * @param {string|null} rawMessage
-     * @returns {string}
-     */
-    function buildDetailedError(rawMessage) {
-        if (!rawMessage) return "No se pudo completar la marcación. Por favor, intente nuevamente.";
-        const msg = rawMessage.toLowerCase();
-        // Chequeo primero — sin esto, el mensaje específico lanzado cuando el propio
-        // perfil todavía no sincronizó (ver identifyEmployee(), "ownEmployee" null)
-        // no matcheaba ninguna de las ramas de abajo y caía al genérico "error
-        // inesperado", escondiendo que el problema real es de sincronización, no de
-        // reconocimiento facial.
-        if (msg.includes("sincronizó tu perfil") || msg.includes("conectate a internet")) {
-            return "Tu perfil todavía no se sincronizó con este dispositivo. Conectate a internet y volvé a intentar en unos segundos.";
-        }
-        if (msg.includes("ambiguo") || msg.includes("ambiguous") || msg.includes("múltiple") || msg.includes("multiple face")) {
-            return "Se detectaron múltiples rostros o el rostro no es claro. Asegúrese de estar solo frente a la cámara y reposicione su cara.";
-        }
-        if (msg.includes("no identificado") || msg.includes("not found") || msg.includes("no match")) {
-            return "No se pudo reconocer su rostro. Asegúrese de estar frente a la cámara con buena iluminación, sin lentes de sol ni gorras, y mantenga el rostro quieto.";
-        }
-        if (msg.includes("descriptor") || msg.includes("muestra") || msg.includes("sample")) {
-            return "No se detectó un rostro válido. Acerque el rostro a la cámara (30–60 cm) y asegúrese de tener buena iluminación frontal.";
-        }
-        if (msg.includes("conexión") || msg.includes("network") || msg.includes("fetch")) {
-            return !navigator.onLine
-                ? "Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar."
-                : "Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.";
-        }
-        if (msg.includes("event") || msg.includes("evento") || msg.includes("allowed")) {
-            return "No hay tipos de marcación disponibles para este empleado en este momento. Consulte con el departamento de RRHH.";
-        }
-        return "Ocurrió un error inesperado. Por favor, intente nuevamente.";
-    }
 
     // --------------------------------------------------------------------------
     // AUDIO FEEDBACK (Web Audio API)
@@ -1493,22 +1454,6 @@ const statusBar           = document.getElementById("statusBar");
         } catch (error) {
             logError("Error en checkEnableMark:", error);
         }
-    }
-
-    /**
-     * Traduce los tipos de eventos de inglés a español
-     * @param {string|null} eventType - Tipo de evento en inglés
-     * @returns {string} Tipo de evento en español
-     */
-    function translateEventType(eventType) {
-        const translations = {
-            check_in: "Entrada",
-            break_start: "Inicio de descanso",
-            break_end: "Fin de descanso",
-            check_out: "Salida",
-        };
-
-        return translations[eventType] || eventType || "—";
     }
 
     /**

--- a/resources/js/attendances/mark/text-helpers.js
+++ b/resources/js/attendances/mark/text-helpers.js
@@ -1,0 +1,64 @@
+/**
+ * =============================================================================
+ * MARK.JS — HELPERS DE TEXTO (funciones puras, extraídas para poder testearlas)
+ * =============================================================================
+ *
+ * @fileoverview Funciones sin dependencias del DOM usadas por mark.js para
+ * traducir tipos de evento y traducir errores crudos del servidor/cliente en
+ * mensajes accionables para el empleado. Primer paso de la descomposición de
+ * mark.js en módulos más chicos — sin cambios de comportamiento respecto al
+ * código original.
+ */
+
+/**
+ * Traduce los tipos de eventos de inglés a español.
+ * @param {string|null} eventType - Tipo de evento en inglés
+ * @returns {string} Tipo de evento en español
+ */
+export function translateEventType(eventType) {
+    const translations = {
+        check_in: "Entrada",
+        break_start: "Inicio de descanso",
+        break_end: "Fin de descanso",
+        check_out: "Salida",
+    };
+
+    return translations[eventType] || eventType || "—";
+}
+
+/**
+ * Transforma un mensaje de error crudo del servidor en un mensaje amigable
+ * con sugerencias concretas para el usuario.
+ * @param {string|null} rawMessage
+ * @returns {string}
+ */
+export function buildDetailedError(rawMessage) {
+    if (!rawMessage) return "No se pudo completar la marcación. Por favor, intente nuevamente.";
+    const msg = rawMessage.toLowerCase();
+    // Chequeo primero — sin esto, el mensaje específico lanzado cuando el propio
+    // perfil todavía no sincronizó (ver identifyEmployee(), "ownEmployee" null)
+    // no matcheaba ninguna de las ramas de abajo y caía al genérico "error
+    // inesperado", escondiendo que el problema real es de sincronización, no de
+    // reconocimiento facial.
+    if (msg.includes("sincronizó tu perfil") || msg.includes("conectate a internet")) {
+        return "Tu perfil todavía no se sincronizó con este dispositivo. Conectate a internet y volvé a intentar en unos segundos.";
+    }
+    if (msg.includes("ambiguo") || msg.includes("ambiguous") || msg.includes("múltiple") || msg.includes("multiple face")) {
+        return "Se detectaron múltiples rostros o el rostro no es claro. Asegúrese de estar solo frente a la cámara y reposicione su cara.";
+    }
+    if (msg.includes("no identificado") || msg.includes("not found") || msg.includes("no match")) {
+        return "No se pudo reconocer su rostro. Asegúrese de estar frente a la cámara con buena iluminación, sin lentes de sol ni gorras, y mantenga el rostro quieto.";
+    }
+    if (msg.includes("descriptor") || msg.includes("muestra") || msg.includes("sample")) {
+        return "No se detectó un rostro válido. Acerque el rostro a la cámara (30–60 cm) y asegúrese de tener buena iluminación frontal.";
+    }
+    if (msg.includes("conexión") || msg.includes("network") || msg.includes("fetch")) {
+        return !navigator.onLine
+            ? "Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar."
+            : "Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.";
+    }
+    if (msg.includes("event") || msg.includes("evento") || msg.includes("allowed")) {
+        return "No hay tipos de marcación disponibles para este empleado en este momento. Consulte con el departamento de RRHH.";
+    }
+    return "Ocurrió un error inesperado. Por favor, intente nuevamente.";
+}

--- a/resources/js/attendances/mark/text-helpers.test.js
+++ b/resources/js/attendances/mark/text-helpers.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { translateEventType, buildDetailedError } from './text-helpers.js';
+
+describe('translateEventType', () => {
+    it('traduce cada tipo de evento conocido', () => {
+        expect(translateEventType('check_in')).toBe('Entrada');
+        expect(translateEventType('break_start')).toBe('Inicio de descanso');
+        expect(translateEventType('break_end')).toBe('Fin de descanso');
+        expect(translateEventType('check_out')).toBe('Salida');
+    });
+
+    it('devuelve el valor recibido cuando el tipo no es reconocido', () => {
+        expect(translateEventType('unknown_type')).toBe('unknown_type');
+    });
+
+    it('devuelve un guion largo cuando el valor es null/undefined', () => {
+        expect(translateEventType(null)).toBe('—');
+        expect(translateEventType(undefined)).toBe('—');
+    });
+});
+
+describe('buildDetailedError', () => {
+    it('devuelve el mensaje genérico cuando no hay mensaje crudo', () => {
+        expect(buildDetailedError(null)).toBe('No se pudo completar la marcación. Por favor, intente nuevamente.');
+    });
+
+    it('prioriza el aviso de perfil no sincronizado sobre cualquier otra rama', () => {
+        expect(buildDetailedError('Todavía no se sincronizó tu perfil — conectate a internet al menos una vez.'))
+            .toBe('Tu perfil todavía no se sincronizó con este dispositivo. Conectate a internet y volvé a intentar en unos segundos.');
+    });
+
+    it('detecta rostro ambiguo', () => {
+        expect(buildDetailedError('Rostro ambiguo. Por favor, reposicione su cara e intente de nuevo.'))
+            .toContain('múltiples rostros');
+    });
+
+    it('detecta rostro no identificado', () => {
+        expect(buildDetailedError('No identificado'))
+            .toContain('No se pudo reconocer su rostro');
+    });
+
+    it('detecta fallas de captura de descriptor', () => {
+        expect(buildDetailedError('No se pudo capturar suficientes muestras del rostro.'))
+            .toContain('No se detectó un rostro válido');
+    });
+
+    it('distingue sin red vs error de servidor en fallas de conexión', () => {
+        vi.stubGlobal('navigator', { onLine: false });
+        expect(buildDetailedError('Network error')).toBe('Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar.');
+
+        vi.stubGlobal('navigator', { onLine: true });
+        expect(buildDetailedError('Network error')).toBe('Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.');
+
+        vi.unstubAllGlobals();
+    });
+
+    it('detecta falta de eventos permitidos', () => {
+        expect(buildDetailedError('No allowed events for this employee'))
+            .toContain('No hay tipos de marcación disponibles');
+    });
+
+    it('cae al mensaje genérico para errores no reconocidos', () => {
+        expect(buildDetailedError('algo totalmente inesperado')).toBe('Ocurrió un error inesperado. Por favor, intente nuevamente.');
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['resources/js/**/*.test.js'],
+    },
+});


### PR DESCRIPTION
## Summary

Primer paso de una descomposición incremental de `resources/js/attendances/mark.js` (2700+ líneas) en módulos más chicos, empezando por las piezas más fáciles de aislar y testear.

- Extrae `translateEventType()` y `buildDetailedError()` — ambas funciones puras sin dependencias del DOM — a `resources/js/attendances/mark/text-helpers.js`.
- `mark.js` ahora las importa en vez de definirlas localmente. Sin cambios de comportamiento.
- Agrega **Vitest** al proyecto (no existía runner de JS hasta ahora) con `vitest.config.js` mínimo y el script `npm test`.
- Cubre ambas funciones con 11 tests unitarios en `text-helpers.test.js`.

Este es el primero de varios PRs chicos para descomponer `mark.js`, y luego `terminal.js` y `shared/FaceCaptureApp.js` (los tres archivos JS más grandes del proyecto). Cada extracción siguiente se enfoca en piezas de responsabilidad única (UI de sincronización, cámara/detección facial, GPS, modales) sin tocar el comportamiento — eso queda para una fase posterior, deliberadamente separada.

## Test plan

- [x] `npm test` — 11/11 tests pasan
- [x] `npm run build` — build de Vite exitoso, sin errores
- [x] Revisión manual: no quedan referencias a las definiciones locales removidas en `mark.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_