### PR TITLE
Refactor: extraer UI de estado de sincronización de mark.js

### DIFF
--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -8,11 +8,11 @@ import {
     enqueueMark,
     flushQueue,
     countPendingEvents,
-    countConflictEvents,
     dismissConflictEvents,
 } from './mobile-offline/queue.js';
 import { translateEventType, buildDetailedError } from './mark/text-helpers.js';
 import { markUserInteracted, playBeep } from './mark/audio-feedback.js';
+import { setOfflineBanner, updateSyncStatus, refreshSyncStatus } from './mark/sync-status-ui.js';
 
 /**
  * =============================================================================
@@ -106,10 +106,8 @@ const statusBar           = document.getElementById("statusBar");
     const gpsBannerText       = document.getElementById("gpsBannerText");
     const gpsBannerRetry      = document.getElementById("gpsBannerRetry");
     const markHint            = document.getElementById("markHint");
-    const syncStatusText      = document.getElementById("syncStatusText");
     const btnSyncNow          = document.getElementById("btnSyncNow");
     const btnUnlinkDevice     = document.getElementById("btnUnlinkDevice");
-    const conflictBanner      = document.getElementById("conflictBanner");
     const btnDismissConflict  = document.getElementById("btnDismissConflict");
     const btnMyEvents         = document.getElementById("btnMyEvents");
     const btnCameraPause      = document.getElementById("btnCameraPause");
@@ -342,51 +340,6 @@ const statusBar           = document.getElementById("statusBar");
     const logError = (message, errorObj) => {
         errorObj !== undefined ? console.error("[Error]", message, errorObj) : console.error("[Error]", message);
     };
-
-    // --------------------------------------------------------------------------
-    // BANNER OFFLINE
-    // --------------------------------------------------------------------------
-    function setOfflineBanner(isOffline) {
-        const banner = document.getElementById("offlineBanner");
-        if (!banner) return;
-        banner.classList.toggle("is-visible", isOffline);
-        banner.setAttribute("aria-hidden", String(!isOffline));
-        // Re-evaluar botón de marcación al cambiar estado de conexión
-        checkEnableMark();
-    }
-
-    // --------------------------------------------------------------------------
-    // ESTADO DE SINCRONIZACIÓN OFFLINE — paridad con refreshIdleSyncStatus()
-    // de terminal.js: mismo texto/prioridad (conflictos > pendientes >
-    // sincronizado), pero acá además hay un aviso separado (conflictBanner)
-    // porque un conflicto en el dispositivo es del propio empleado, no de un
-    // tercero — amerita más que una línea de texto discreta.
-    // --------------------------------------------------------------------------
-    function updateSyncStatus(text) {
-        if (syncStatusText) syncStatusText.textContent = text;
-    }
-
-    /**
-     * Refleja en la fila de estado la cola de eventos offline real (no solo
-     * el último resultado puntual) — se llama después de cada intento de
-     * sincronización (marcación, sync de fondo, botón manual, carga inicial).
-     */
-    async function refreshSyncStatus() {
-        const [pending, conflicts] = await Promise.all([countPendingEvents(), countConflictEvents()]);
-
-        if (conflicts > 0) {
-            updateSyncStatus(`${conflicts} marcación(es) requieren revisión`);
-        } else if (pending > 0) {
-            updateSyncStatus(`${pending} marcación(es) pendiente(s) de sincronizar`);
-        } else {
-            updateSyncStatus(navigator.onLine ? "Sincronizado" : "Sin conexión — usando datos locales");
-        }
-
-        if (conflictBanner) {
-            conflictBanner.classList.toggle("is-visible", conflicts > 0);
-            conflictBanner.setAttribute("aria-hidden", String(conflicts === 0));
-        }
-    }
 
     // Botón "Entendido" del aviso de conflicto — el empleado no puede resolverlo
     // (ya lo revisa RRHH en Filament), solo confirma que lo vio. Limpia la copia
@@ -2481,9 +2434,9 @@ const statusBar           = document.getElementById("statusBar");
     });
 
     // Evento: Detección de conexión online/offline
-    setOfflineBanner(!navigator.onLine);
-    window.addEventListener("offline", () => setOfflineBanner(true));
-    window.addEventListener("online",  () => setOfflineBanner(false));
+    setOfflineBanner(!navigator.onLine, checkEnableMark);
+    window.addEventListener("offline", () => setOfflineBanner(true, checkEnableMark));
+    window.addEventListener("online",  () => setOfflineBanner(false, checkEnableMark));
 
     // Evento: Botón "Reintentar" del modal de error
     const retryErrorBtn = document.getElementById("retryErrorModal");

--- a/resources/js/attendances/mark/sync-status-ui.js
+++ b/resources/js/attendances/mark/sync-status-ui.js
@@ -1,0 +1,58 @@
+/**
+ * =============================================================================
+ * MARK.JS — UI DE ESTADO DE SINCRONIZACIÓN OFFLINE
+ * =============================================================================
+ *
+ * @fileoverview Banner de "sin conexión", fila de estado de sincronización y
+ * aviso de conflictos — extraído de mark.js como parte de su descomposición
+ * en módulos más chicos. Mismo comportamiento que el código original: paridad
+ * con `refreshIdleSyncStatus()` de terminal.js (mismo texto/prioridad —
+ * conflictos > pendientes > sincronizado), pero acá además hay un aviso
+ * separado (conflictBanner) porque un conflicto en el dispositivo es del
+ * propio empleado, no de un tercero — amerita más que una línea de texto discreta.
+ */
+
+import { countPendingEvents, countConflictEvents } from '../mobile-offline/queue.js';
+
+/**
+ * Muestra u oculta el banner de "sin conexión".
+ * @param {boolean} isOffline
+ * @param {() => void} [onChange] - Callback tras el cambio (ej. re-evaluar el botón de marcación).
+ */
+export function setOfflineBanner(isOffline, onChange) {
+    const banner = document.getElementById("offlineBanner");
+    if (!banner) return;
+    banner.classList.toggle("is-visible", isOffline);
+    banner.setAttribute("aria-hidden", String(!isOffline));
+    onChange?.();
+}
+
+/** @param {string} text */
+export function updateSyncStatus(text) {
+    const syncStatusText = document.getElementById("syncStatusText");
+    if (syncStatusText) syncStatusText.textContent = text;
+}
+
+/**
+ * Refleja en la fila de estado la cola de eventos offline real (no solo
+ * el último resultado puntual) — se llama después de cada intento de
+ * sincronización (marcación, sync de fondo, botón manual, carga inicial).
+ * @returns {Promise<void>}
+ */
+export async function refreshSyncStatus() {
+    const [pending, conflicts] = await Promise.all([countPendingEvents(), countConflictEvents()]);
+
+    if (conflicts > 0) {
+        updateSyncStatus(`${conflicts} marcación(es) requieren revisión`);
+    } else if (pending > 0) {
+        updateSyncStatus(`${pending} marcación(es) pendiente(s) de sincronizar`);
+    } else {
+        updateSyncStatus(navigator.onLine ? "Sincronizado" : "Sin conexión — usando datos locales");
+    }
+
+    const conflictBanner = document.getElementById("conflictBanner");
+    if (conflictBanner) {
+        conflictBanner.classList.toggle("is-visible", conflicts > 0);
+        conflictBanner.setAttribute("aria-hidden", String(conflicts === 0));
+    }
+}


### PR DESCRIPTION
## Summary

Tercer paso de la descomposición incremental de `resources/js/attendances/mark.js` (ver PR #150 y #151 para los anteriores).

- Extrae `setOfflineBanner()`, `updateSyncStatus()` y `refreshSyncStatus()` a `resources/js/attendances/mark/sync-status-ui.js`.
- El módulo hace sus propios `document.getElementById()` (mismo patrón que ya usan las funciones de modales en `mark.js`) en vez de depender de los `const` capturados una sola vez al inicio del archivo — se eliminan `syncStatusText` y `conflictBanner` de `mark.js` porque ya no los usa nada más.
- `setOfflineBanner()` recibe `checkEnableMark` como callback explícito en vez de leerlo del closure de `mark.js` — se llama exactamente en los mismos 3 puntos donde antes se invocaba internamente.
- `countConflictEvents` se elimina del import de `mark.js` (solo lo usaba `refreshSyncStatus`, que ya vive en el nuevo módulo); `countPendingEvents` se mantiene porque `mark.js` lo sigue usando directamente en el handler de "Desvincular dispositivo".
- Sin cambios de comportamiento.

## Test plan

- [x] `npm test` — 11/11 tests pasan (sin cambios en esta suite)
- [x] `npm run build` — build de Vite exitoso, sin errores
- [x] Revisión manual: no quedan referencias a las definiciones locales removidas ni a los `const` de DOM eliminados en `mark.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_