### PR TITLE
Refactor: extraer feedback visual de mark.js

### DIFF
--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -22,6 +22,16 @@ import {
     resetLocationUi,
     initGps,
 } from './mark/gps.js';
+import {
+    updateClock,
+    setVideoState,
+    setStatusBar,
+    getCaptureDotCount,
+    showCaptureProgress,
+    updateCaptureProgress,
+    hideCaptureProgress,
+    finishCaptureProgress,
+} from './mark/ui-feedback.js';
 
 /**
  * =============================================================================
@@ -85,10 +95,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const eventTypeEl = document.getElementById("eventType");
 
     // New UI elements added in the redesign
-    const videoWrap       = document.getElementById("videoWrap");
-    const statusDot       = document.getElementById("statusDot");
-    const statusText      = document.getElementById("statusText");
-    const headerClock     = document.getElementById("headerClock");
     const eventBtns       = document.querySelectorAll(".event-btn");
 
     // Step sections — wizard de un solo screen
@@ -103,9 +109,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const step2LastEventEl  = document.getElementById("step2LastEvent");
     const step2BtnBack      = document.getElementById("step2BtnBack");
 
-const statusBar           = document.getElementById("statusBar");
-    const captureProgress     = document.getElementById("captureProgress");
-    const captureDots         = captureProgress ? Array.from(captureProgress.querySelectorAll(".capture-dot")) : [];
     const splashOverlay       = document.getElementById("splashOverlay");
     const markHint            = document.getElementById("markHint");
     const btnSyncNow          = document.getElementById("btnSyncNow");
@@ -434,93 +437,8 @@ const statusBar           = document.getElementById("statusBar");
     // --------------------------------------------------------------------------
     // RELOJ EN TIEMPO REAL
     // --------------------------------------------------------------------------
-    function updateClock() {
-        if (headerClock) {
-            const now = new Date();
-            const day   = String(now.getDate()).padStart(2, "0");
-            const month = String(now.getMonth() + 1).padStart(2, "0");
-            const year  = now.getFullYear();
-            const dateStr = `${day}/${month}/${year}`;
-            const timeStr = now.toLocaleTimeString("es-BO", {
-                hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
-            });
-            headerClock.innerHTML =
-                `<span class="clock-date">${dateStr}</span><span class="clock-time">${timeStr}</span>`;
-        }
-    }
     updateClock();
     setInterval(updateClock, 1000);
-
-    // --------------------------------------------------------------------------
-    // ESTADO VISUAL DEL VIDEO
-    // --------------------------------------------------------------------------
-    function setVideoState(stateClass) {
-        if (!videoWrap) return;
-        videoWrap.classList.remove(
-            "video-wrap--detecting", "video-wrap--face-found",
-            "video-wrap--success", "video-wrap--error"
-        );
-        if (stateClass) videoWrap.classList.add(`video-wrap--${stateClass}`);
-    }
-
-    function setStatusBar(text, dotClass) {
-        if (statusText) {
-            statusText.classList.remove("status-text--new");
-            void statusText.offsetWidth; // reiniciar animación
-            statusText.textContent = text;
-            statusText.classList.add("status-text--new");
-        }
-        if (statusBar) {
-            statusBar.classList.remove("status-bar--detecting", "status-bar--found", "status-bar--error");
-            if (dotClass) statusBar.classList.add(`status-bar--${dotClass}`);
-        }
-        if (statusDot) {
-            statusDot.classList.remove(
-                "status-dot--active", "status-dot--found",
-                "status-dot--success", "status-dot--error"
-            );
-            const cssMap = { detecting: "active", found: "found", success: "success", error: "error" };
-            const cssClass = cssMap[dotClass] ?? dotClass;
-            if (cssClass) statusDot.classList.add(`status-dot--${cssClass}`);
-        }
-    }
-
-    // --------------------------------------------------------------------------
-    // PROGRESO DE CAPTURA FACIAL
-    // --------------------------------------------------------------------------
-    function showCaptureProgress() {
-        if (!captureProgress) return;
-        captureDots.forEach(dot => dot.classList.remove("capture-dot--filled"));
-        captureProgress.classList.remove("hidden");
-    }
-
-    function updateCaptureProgress(count) {
-        captureDots.forEach((dot, i) => {
-            dot.classList.toggle("capture-dot--filled", i < count);
-        });
-    }
-
-    function hideCaptureProgress() {
-        if (!captureProgress) return;
-        captureProgress.classList.add("hidden");
-        captureDots.forEach(dot => dot.classList.remove("capture-dot--filled", "capture-dot--success", "capture-dot--error"));
-    }
-
-    /**
-     * Finaliza la animación de captura mostrando todos los dots en el color del resultado
-     * (éxito = verde, error = rojo) durante 400ms antes de ocultarlos.
-     * @param {"success"|"error"} outcome
-     */
-    async function finishCaptureProgress(outcome) {
-        if (!captureProgress) return;
-        captureDots.forEach(dot => {
-            dot.classList.remove("capture-dot--filled", "capture-dot--success", "capture-dot--error");
-            dot.classList.add(`capture-dot--${outcome}`);
-        });
-        captureProgress.classList.remove("hidden");
-        await sleep(400);
-        hideCaptureProgress();
-    }
 
     // ==========================================================================
     // FUNCIONES DE VERIFICACIÓN
@@ -1248,7 +1166,7 @@ const statusBar           = document.getElementById("statusBar");
         autoIdDotInterval = setInterval(() => {
             dotsFilled++;
             updateCaptureProgress(dotsFilled);
-            if (dotsFilled >= captureDots.length) {
+            if (dotsFilled >= getCaptureDotCount()) {
                 clearInterval(autoIdDotInterval);
                 autoIdDotInterval = null;
                 runIdentification(true);

--- a/resources/js/attendances/mark/ui-feedback.js
+++ b/resources/js/attendances/mark/ui-feedback.js
@@ -1,0 +1,132 @@
+/**
+ * =============================================================================
+ * MARK.JS — FEEDBACK VISUAL (reloj, estado del video/status bar, dots de captura)
+ * =============================================================================
+ *
+ * @fileoverview Funciones de UI puramente visuales sin estado compartido con
+ * el resto de mark.js — reloj del header, clases de estado del video/barra de
+ * estado, y los dots de progreso de captura facial. Extraído de mark.js como
+ * parte de su descomposición en módulos más chicos — mismo comportamiento
+ * que el código original.
+ */
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Actualiza el reloj del header con la fecha y hora actual. Se llama una vez y luego cada 1s. */
+export function updateClock() {
+    const headerClock = document.getElementById("headerClock");
+    if (headerClock) {
+        const now = new Date();
+        const day   = String(now.getDate()).padStart(2, "0");
+        const month = String(now.getMonth() + 1).padStart(2, "0");
+        const year  = now.getFullYear();
+        const dateStr = `${day}/${month}/${year}`;
+        const timeStr = now.toLocaleTimeString("es-BO", {
+            hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+        });
+        headerClock.innerHTML =
+            `<span class="clock-date">${dateStr}</span><span class="clock-time">${timeStr}</span>`;
+    }
+}
+
+/** @param {string|null} stateClass - "detecting"|"face-found"|"success"|"error"|null */
+export function setVideoState(stateClass) {
+    const videoWrap = document.getElementById("videoWrap");
+    if (!videoWrap) return;
+    videoWrap.classList.remove(
+        "video-wrap--detecting", "video-wrap--face-found",
+        "video-wrap--success", "video-wrap--error"
+    );
+    if (stateClass) videoWrap.classList.add(`video-wrap--${stateClass}`);
+}
+
+/**
+ * @param {string} text
+ * @param {string|null} dotClass - "detecting"|"found"|"error"|null
+ */
+export function setStatusBar(text, dotClass) {
+    const statusText = document.getElementById("statusText");
+    const statusBar = document.getElementById("statusBar");
+    const statusDot = document.getElementById("statusDot");
+
+    if (statusText) {
+        statusText.classList.remove("status-text--new");
+        void statusText.offsetWidth; // reiniciar animación
+        statusText.textContent = text;
+        statusText.classList.add("status-text--new");
+    }
+    if (statusBar) {
+        statusBar.classList.remove("status-bar--detecting", "status-bar--found", "status-bar--error");
+        if (dotClass) statusBar.classList.add(`status-bar--${dotClass}`);
+    }
+    if (statusDot) {
+        statusDot.classList.remove(
+            "status-dot--active", "status-dot--found",
+            "status-dot--success", "status-dot--error"
+        );
+        const cssMap = { detecting: "active", found: "found", success: "success", error: "error" };
+        const cssClass = cssMap[dotClass] ?? dotClass;
+        if (cssClass) statusDot.classList.add(`status-dot--${cssClass}`);
+    }
+}
+
+// Memoizados en el primer uso (no al cargar el módulo — evita depender del
+// timing exacto de evaluación de módulos vs. parseo del DOM). Los dots son
+// estáticos en el DOM, no se recrean, así que una sola consulta alcanza.
+let captureProgress;
+let captureDots;
+
+function getCaptureDots() {
+    if (captureDots === undefined) {
+        captureProgress = document.getElementById("captureProgress");
+        captureDots = captureProgress ? Array.from(captureProgress.querySelectorAll(".capture-dot")) : [];
+    }
+    return { captureProgress, captureDots };
+}
+
+/** @returns {number} Cantidad total de dots de progreso de captura. */
+export function getCaptureDotCount() {
+    const { captureDots } = getCaptureDots();
+    return captureDots.length;
+}
+
+/** Muestra los dots de progreso de captura, todos vacíos. */
+export function showCaptureProgress() {
+    const { captureProgress, captureDots } = getCaptureDots();
+    if (!captureProgress) return;
+    captureDots.forEach(dot => dot.classList.remove("capture-dot--filled"));
+    captureProgress.classList.remove("hidden");
+}
+
+/** @param {number} count - Cantidad de dots a llenar */
+export function updateCaptureProgress(count) {
+    const { captureDots } = getCaptureDots();
+    captureDots.forEach((dot, i) => {
+        dot.classList.toggle("capture-dot--filled", i < count);
+    });
+}
+
+/** Oculta los dots de progreso de captura y limpia sus clases de resultado. */
+export function hideCaptureProgress() {
+    const { captureProgress, captureDots } = getCaptureDots();
+    if (!captureProgress) return;
+    captureProgress.classList.add("hidden");
+    captureDots.forEach(dot => dot.classList.remove("capture-dot--filled", "capture-dot--success", "capture-dot--error"));
+}
+
+/**
+ * Finaliza la animación de captura mostrando todos los dots en el color del resultado
+ * (éxito = verde, error = rojo) durante 400ms antes de ocultarlos.
+ * @param {"success"|"error"} outcome
+ */
+export async function finishCaptureProgress(outcome) {
+    const { captureProgress, captureDots } = getCaptureDots();
+    if (!captureProgress) return;
+    captureDots.forEach(dot => {
+        dot.classList.remove("capture-dot--filled", "capture-dot--success", "capture-dot--error");
+        dot.classList.add(`capture-dot--${outcome}`);
+    });
+    captureProgress.classList.remove("hidden");
+    await sleep(400);
+    hideCaptureProgress();
+}


### PR DESCRIPTION
## Summary

Octavo paso de la descomposición incremental de `resources/js/attendances/mark.js` (ver PR #150-#156 para los anteriores).

- Extrae `updateClock()`, `setVideoState()`, `setStatusBar()` y los dots de progreso de captura facial (`showCaptureProgress()`, `updateCaptureProgress()`, `hideCaptureProgress()`, `finishCaptureProgress()`) a `resources/js/attendances/mark/ui-feedback.js`.
- Todas son funciones puramente visuales sin estado compartido con el resto de `mark.js` — no necesitaron callbacks ni cambios en ninguno de sus ~20 call sites.
- El módulo memoiza su propia consulta de `captureProgress`/`captureDots` en el **primer uso**, no al cargar el módulo — evita depender del timing exacto de evaluación de módulos ES vs. parseo del DOM (a diferencia de otras funciones ya extraídas, que resuelven sus elementos en cada llamada).
- Se agrega `getCaptureDotCount()` para el único punto de `mark.js` (`startAutoIdentifyDwell()`) que leía `captureDots.length` directamente — ahora usa el getter del módulo.
- Sin cambios de comportamiento.

## Test plan

- [x] `npm test` — 11/11 tests pasan (sin cambios en esta suite)
- [x] `npm run build` — build de Vite exitoso, sin errores
- [x] Revisión manual del diff completo de `mark.js`: no quedan referencias a las funciones locales removidas ni a los `const` de DOM (`videoWrap`, `statusText`, `statusDot`, `headerClock`, `statusBar`, `captureProgress`, `captureDots`) eliminados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_