### PR TITLE
Refactor: compartir feedback sonoro entre mark.js y terminal.js

### DIFF
--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -10,7 +10,7 @@ import {
     dismissConflictEvents,
 } from './mobile-offline/queue.js';
 import { translateEventType, buildDetailedError } from './mark/text-helpers.js';
-import { markUserInteracted, playBeep } from './mark/audio-feedback.js';
+import { markUserInteracted, playBeep } from '../shared/audio-feedback.js';
 import { setOfflineBanner, updateSyncStatus, refreshSyncStatus } from './mark/sync-status-ui.js';
 import { openMyEventsModal, closeMyEventsModal } from './mark/my-events-modal.js';
 import { showSuccessModal } from './mark/success-modal.js';

--- a/resources/js/attendances/mark/gps.js
+++ b/resources/js/attendances/mark/gps.js
@@ -19,7 +19,7 @@
  */
 
 import L from 'leaflet';
-import { markUserInteracted } from './audio-feedback.js';
+import { markUserInteracted } from '../../shared/audio-feedback.js';
 import { showErrorModal } from './error-modal.js';
 
 /** @type {L.Map|null} */

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,4 +1,5 @@
 import { captureFaceSamples } from '../shared/face-capture-core.js';
+import { markUserInteracted, hasUserInteracted, playBeep } from '../shared/audio-feedback.js';
 import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees, countCachedEmployees, clearTerminalState } from './terminal-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './terminal-offline/matcher.js';
 import { heartbeat, syncEmployees, getFaceConfig, TerminalAuthError } from './terminal-offline/sync.js';
@@ -144,7 +145,6 @@ document.addEventListener("DOMContentLoaded", () => {
         idleTimer:              null,
         presenceCheckInterval:  null,
         isIdle:                 false,
-        userHasInteracted:      false,  // vibración solo permitida tras gesto del usuario
         backgroundSyncStarted:  false,  // evita registrar los setInterval de sync más de una vez
         consecutiveFailures:    0,      // intentos de reconocimiento fallidos seguidos — habilita la búsqueda manual por CI
         manualCandidate:        null,   // empleado elegido en la búsqueda manual — acota identifyEmployee() a un único candidato
@@ -785,7 +785,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     terminalState.manualCandidate = null;
                     hideManualSearchLink();
 
-                    if (terminalState.userHasInteracted) navigator.vibrate?.(80);
+                    if (hasUserInteracted()) navigator.vibrate?.(80);
                     stopAutoIdentification();
 
                     await finishCaptureProgress("success");
@@ -1043,47 +1043,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // ============================================================================
-    // AUDIO FEEDBACK (Web Audio API — sin archivos, sin permisos)
-    // ============================================================================
-    let audioCtx = null;
-
-    function getAudioCtx() {
-        if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-        return audioCtx;
-    }
-
-    function playTone(freq, duration, gain = 0.25, delay = 0) {
-        try {
-            const ctx = getAudioCtx();
-            ctx.resume();
-            const osc  = ctx.createOscillator();
-            const env  = ctx.createGain();
-            osc.connect(env);
-            env.connect(ctx.destination);
-            osc.type = "sine";
-            osc.frequency.value = freq;
-            const t = ctx.currentTime + delay;
-            env.gain.setValueAtTime(gain, t);
-            env.gain.exponentialRampToValueAtTime(0.001, t + duration);
-            osc.start(t);
-            osc.stop(t + duration + 0.01);
-        } catch (_) { /* audio no disponible */ }
-    }
-
-    function playBeep(type) {
-        if (!terminalState.userHasInteracted) return;
-        if (type === "success") {
-            // Doble beep ascendente — confirmación positiva
-            playTone(880,  0.08, 0.22, 0.0);
-            playTone(1100, 0.12, 0.22, 0.1);
-        } else if (type === "error") {
-            // Beep grave descendente — advertencia
-            playTone(440, 0.08, 0.22, 0.0);
-            playTone(330, 0.14, 0.22, 0.1);
-        }
-    }
-
-    // ============================================================================
     // PANTALLAS DE RESULTADO
     // ============================================================================
     /**
@@ -1286,7 +1245,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Marcar interacción del usuario para habilitar Vibration API
     const markInteraction = () => {
-        terminalState.userHasInteracted = true;
+        markUserInteracted();
         document.removeEventListener("click",      markInteraction);
         document.removeEventListener("touchstart", markInteraction);
     };

--- a/resources/js/shared/audio-feedback.js
+++ b/resources/js/shared/audio-feedback.js
@@ -1,12 +1,13 @@
 /**
  * =============================================================================
- * MARK.JS — FEEDBACK SONORO (Web Audio API)
+ * FEEDBACK SONORO (Web Audio API) — compartido entre mark.js y terminal.js
  * =============================================================================
  *
- * @fileoverview Beeps de éxito/error para la marcación facial. Extraído de
- * mark.js como parte de su descomposición en módulos más chicos — mismo
- * comportamiento que el código original, incluyendo el guard de interacción
- * del usuario (los navegadores bloquean Web Audio hasta el primer gesto).
+ * @fileoverview Beeps de éxito/error para la marcación facial. Extraído
+ * originalmente de mark.js (mismo comportamiento que ese código original,
+ * incluyendo el guard de interacción del usuario — los navegadores bloquean
+ * Web Audio hasta el primer gesto) y luego reutilizado en terminal.js, que
+ * tenía una copia byte-por-byte idéntica de esta misma lógica.
  */
 
 /** @type {AudioContext|null} */
@@ -21,6 +22,11 @@ let userHasInteracted = false;
 /** Marca que el usuario ya interactuó con la página (habilita el audio). */
 export function markUserInteracted() {
     userHasInteracted = true;
+}
+
+/** @returns {boolean} Si el usuario ya interactuó con la página. */
+export function hasUserInteracted() {
+    return userHasInteracted;
 }
 
 /** @returns {AudioContext} */


### PR DESCRIPTION
## Summary

Primer paso del refactor de `terminal.js` (1540 líneas), y primer caso real de deduplicación entre `mark.js` y `terminal.js` — uno de los tres objetivos originales de esta serie de PRs (ver #150-#157 para la descomposición de `mark.js`).

- `terminal.js` tenía una copia **byte-por-byte idéntica** de `getAudioCtx()`/`playTone()`/`playBeep()` (mismos tonos, mismos parámetros, misma lógica) que ya había sido extraída de `mark.js` en el PR #151.
- Mueve `mark/audio-feedback.js` a `shared/audio-feedback.js` (junto a `face-capture-core.js`, que ya sigue este patrón de módulo compartido entre `mark.js`/`terminal.js`/capture-face) y lo reutiliza en `terminal.js`.
- Se agrega `hasUserInteracted()` al módulo — `terminal.js` leía el flag en un punto además de `playBeep()` (el vibrate de identificación exitosa), algo que `mark.js` no necesitaba.
- Se elimina el campo `terminalState.userHasInteracted` — ese estado ahora vive únicamente en el módulo compartido.
- Vite confirma la dedup también a nivel de bundle: `audio-feedback.js` ahora se empaqueta como chunk compartido entre `mark-*.js` y `terminal-*.js`, y el bundle de `terminal.js` se achica (~33.2kB → ~32.7kB).
- Sin cambios de comportamiento.

## Test plan

- [x] `npm test` — 11/11 tests pasan (sin cambios en esta suite)
- [x] `npm run build` — build de Vite exitoso; `audio-feedback-*.js` aparece como chunk propio compartido
- [x] Revisión manual del diff completo de `terminal.js`: no quedan referencias a `terminalState.userHasInteracted` ni a las funciones locales removidas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_