### PR TITLE
Refactor: extraer buildDetailedError de terminal.js con tests

### DIFF
--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -20,6 +20,7 @@ import {
     refreshIdleSyncStatus,
     refreshLastSyncLabel,
 } from './terminal/sync-status-ui.js';
+import { buildDetailedError } from './terminal/text-helpers.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
@@ -300,32 +301,6 @@ document.addEventListener("DOMContentLoaded", () => {
         setTerminalVideoState("detecting");
     }
 
-
-    // ============================================================================
-    // MENSAJES DE ERROR DETALLADOS
-    // ============================================================================
-    function buildDetailedError(rawMessage) {
-        if (!rawMessage) return "No se pudo completar la marcación. Por favor, intente nuevamente.";
-        const msg = rawMessage.toLowerCase();
-        if (msg.includes("no identificado") || msg.includes("not found") || msg.includes("no match")) {
-            return "No se pudo reconocer su rostro. Asegúrese de estar frente a la cámara con buena iluminación, sin lentes de sol ni gorras, y mantenga el rostro quieto.";
-        }
-        if (msg.includes("descriptor") || msg.includes("muestra") || msg.includes("sample")) {
-            return "No se detectó un rostro válido. Acerque el rostro a la cámara (30-60 cm) y asegúrese de tener buena iluminación frontal.";
-        }
-        if (msg.includes("conexión") || msg.includes("network") || msg.includes("fetch")) {
-            return !navigator.onLine
-                ? "Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar."
-                : "Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.";
-        }
-        if (msg.includes("csrf") || msg.includes("419")) {
-            return "La sesión expiró. Por favor, recargue la página para continuar.";
-        }
-        if (msg.includes("event") || msg.includes("evento") || msg.includes("allowed")) {
-            return "No hay tipos de marcación disponibles para este empleado en este momento. Consulte con el departamento de RRHH.";
-        }
-        return rawMessage;
-    }
 
     // ============================================================================
     // PANTALLA DE CARGA

--- a/resources/js/attendances/terminal/text-helpers.js
+++ b/resources/js/attendances/terminal/text-helpers.js
@@ -1,0 +1,46 @@
+/**
+ * =============================================================================
+ * TERMINAL.JS — HELPERS DE TEXTO (mensajes de error detallados)
+ * =============================================================================
+ *
+ * @fileoverview Traduce mensajes de error crudos del servidor/cliente en
+ * mensajes accionables para quien opera el terminal. Extraído de terminal.js
+ * como parte de su descomposición en módulos más chicos — mismo
+ * comportamiento que el código original.
+ *
+ * No es el mismo módulo que mark/text-helpers.js: el terminal no tiene el
+ * caso de "perfil todavía no sincronizado" (el terminal cachea *todos* los
+ * empleados de la sucursal, no un único descriptor propio como el celular),
+ * ni distingue rostro ambiguo de rostro no identificado; en cambio sí
+ * distingue sesión expirada (CSRF/419) y, a falta de un mensaje reconocido,
+ * devuelve el mensaje crudo tal cual en vez de un genérico.
+ */
+
+/**
+ * Transforma un mensaje de error crudo del servidor en un mensaje amigable
+ * con sugerencias concretas para quien opera el terminal.
+ * @param {string|null} rawMessage
+ * @returns {string}
+ */
+export function buildDetailedError(rawMessage) {
+    if (!rawMessage) return "No se pudo completar la marcación. Por favor, intente nuevamente.";
+    const msg = rawMessage.toLowerCase();
+    if (msg.includes("no identificado") || msg.includes("not found") || msg.includes("no match")) {
+        return "No se pudo reconocer su rostro. Asegúrese de estar frente a la cámara con buena iluminación, sin lentes de sol ni gorras, y mantenga el rostro quieto.";
+    }
+    if (msg.includes("descriptor") || msg.includes("muestra") || msg.includes("sample")) {
+        return "No se detectó un rostro válido. Acerque el rostro a la cámara (30-60 cm) y asegúrese de tener buena iluminación frontal.";
+    }
+    if (msg.includes("conexión") || msg.includes("network") || msg.includes("fetch")) {
+        return !navigator.onLine
+            ? "Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar."
+            : "Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.";
+    }
+    if (msg.includes("csrf") || msg.includes("419")) {
+        return "La sesión expiró. Por favor, recargue la página para continuar.";
+    }
+    if (msg.includes("event") || msg.includes("evento") || msg.includes("allowed")) {
+        return "No hay tipos de marcación disponibles para este empleado en este momento. Consulte con el departamento de RRHH.";
+    }
+    return rawMessage;
+}

--- a/resources/js/attendances/terminal/text-helpers.test.js
+++ b/resources/js/attendances/terminal/text-helpers.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildDetailedError } from './text-helpers.js';
+
+describe('buildDetailedError', () => {
+    it('devuelve el mensaje genérico cuando no hay mensaje crudo', () => {
+        expect(buildDetailedError(null)).toBe('No se pudo completar la marcación. Por favor, intente nuevamente.');
+    });
+
+    it('detecta rostro no identificado', () => {
+        expect(buildDetailedError('No identificado'))
+            .toContain('No se pudo reconocer su rostro');
+    });
+
+    it('detecta fallas de captura de descriptor', () => {
+        expect(buildDetailedError('No se pudo capturar suficientes muestras del rostro.'))
+            .toContain('No se detectó un rostro válido');
+    });
+
+    it('distingue sin red vs error de servidor en fallas de conexión', () => {
+        vi.stubGlobal('navigator', { onLine: false });
+        expect(buildDetailedError('Network error')).toBe('Sin conexión a internet. Verifique la red del dispositivo y vuelva a intentar.');
+
+        vi.stubGlobal('navigator', { onLine: true });
+        expect(buildDetailedError('Network error')).toBe('Error de conexión al servidor. Verifique que el dispositivo tenga acceso a la red y vuelva a intentar.');
+
+        vi.unstubAllGlobals();
+    });
+
+    it('detecta sesión expirada (CSRF/419)', () => {
+        expect(buildDetailedError('419 CSRF token mismatch'))
+            .toBe('La sesión expiró. Por favor, recargue la página para continuar.');
+    });
+
+    it('detecta falta de eventos permitidos', () => {
+        expect(buildDetailedError('No allowed events for this employee'))
+            .toContain('No hay tipos de marcación disponibles');
+    });
+
+    it('devuelve el mensaje crudo tal cual para errores no reconocidos (a diferencia de mark.js)', () => {
+        expect(buildDetailedError('algo totalmente inesperado')).toBe('algo totalmente inesperado');
+    });
+});


### PR DESCRIPTION
## Summary

Cuarto paso de la descomposición de `terminal.js` (1540 líneas) — ver PR #158-#160 para los anteriores.

- Extrae `buildDetailedError()` a `resources/js/attendances/terminal/text-helpers.js`.
- **No es el mismo módulo** que `mark/text-helpers.js`: ya se había confirmado en una sesión anterior que ambas versiones difieren en varias ramas — el terminal no tiene el caso de "perfil todavía no sincronizado" (cachea todos los empleados de la sucursal, no un único descriptor propio como el celular) ni distingue rostro ambiguo de no identificado, pero sí distingue sesión expirada (CSRF/419), y su fallback devuelve el mensaje crudo tal cual en vez de un genérico.
- Se agregan 7 tests con Vitest, mismo patrón que `mark/text-helpers.test.js`, cubriendo cada rama — incluida la diferencia de fallback respecto a la versión de `mark.js`.
- Único call site (`registerMark()`) sin cambios.
- Sin cambios de comportamiento.

## Test plan

- [x] `npm test` — 18/18 tests pasan (11 existentes + 7 nuevos)
- [x] `npm run build` — build de Vite exitoso, sin errores
- [x] Revisión manual: no queda la definición local en `terminal.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_