### PR TITLE
Refactor: extraer búsqueda manual por CI de terminal.js

### DIFF
--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -21,6 +21,12 @@ import {
     refreshLastSyncLabel,
 } from './terminal/sync-status-ui.js';
 import { buildDetailedError } from './terminal/text-helpers.js';
+import {
+    showManualSearchLink,
+    hideManualSearchLink,
+    closeManualSearch,
+    initManualSearch,
+} from './terminal/manual-search.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
@@ -59,14 +65,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const btnRetry       = document.getElementById("btnRetry");
     const btnReload      = document.getElementById("btnReload");
     const btnThemeToggle = document.getElementById("btnThemeToggle");
-
-    // Búsqueda manual por CI (fallback cuando el reconocimiento facial falla seguido)
-    const btnManualSearch       = document.getElementById("btnManualSearch");
-    const manualSearchOverlay   = document.getElementById("manualSearchOverlay");
-    const manualSearchInput     = document.getElementById("manualSearchInput");
-    const manualSearchResults   = document.getElementById("manualSearchResults");
-    const manualSearchEmpty     = document.getElementById("manualSearchEmpty");
-    const btnManualSearchCancel = document.getElementById("btnManualSearchCancel");
 
     // Day complete screen elements
     const dayCompleteEmployeePhoto  = document.getElementById("dayCompleteEmployeePhoto");
@@ -748,95 +746,13 @@ document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     // BÚSQUEDA MANUAL POR CI — fallback cuando el reconocimiento facial falla seguido
     // ============================================================================
-    /**
-     * NO reemplaza la verificación facial: elegir un candidato acá solo acota
-     * identifyEmployee() a esa única persona (ver terminalState.manualCandidate) — la
-     * cámara sigue activa y el empleado igual tiene que superar el umbral de distancia
-     * normal contra ese descriptor específico antes de que se registre cualquier marcación.
-     */
-    const MAX_MANUAL_SEARCH_RESULTS = 8;
-
-    function showManualSearchLink() {
-        if (btnManualSearch) btnManualSearch.classList.remove("hidden");
-    }
-
-    function hideManualSearchLink() {
-        if (btnManualSearch) btnManualSearch.classList.add("hidden");
-    }
-
-    function openManualSearch() {
-        if (!manualSearchOverlay) return;
-        manualSearchOverlay.classList.remove("hidden");
-        if (manualSearchInput) {
-            manualSearchInput.value = "";
-            manualSearchInput.focus();
-        }
-        renderManualSearchResults("");
-    }
-
-    function closeManualSearch() {
-        if (manualSearchOverlay) manualSearchOverlay.classList.add("hidden");
-    }
-
-    async function renderManualSearchResults(query) {
-        if (!manualSearchResults) return;
-        manualSearchResults.innerHTML = "";
-
-        const digits = (query || "").trim();
-        if (digits.length < 2) {
-            if (manualSearchEmpty) manualSearchEmpty.classList.add("hidden");
-            return;
-        }
-
-        const candidates = await getCachedEmployees();
-        const matches = candidates
-            .filter((employee) => employee.ci && String(employee.ci).includes(digits))
-            .slice(0, MAX_MANUAL_SEARCH_RESULTS);
-
-        if (manualSearchEmpty) manualSearchEmpty.classList.toggle("hidden", matches.length > 0);
-
-        matches.forEach((employee) => {
-            const fullName = `${employee.first_name || ""} ${employee.last_name || ""}`.trim() || "Empleado";
-            const item = document.createElement("button");
-            item.type = "button";
-            item.className = "manual-search-result";
-            item.setAttribute("role", "option");
-            item.innerHTML = `
-                <img src="${employee.photo_thumbnail || "/images/default-avatar.png"}" alt="" aria-hidden="true">
-                <span>
-                    <span class="manual-search-result-name">${fullName}</span><br>
-                    <span class="manual-search-result-ci">CI: ${employee.ci}</span>
-                </span>
-            `;
-            item.addEventListener("click", () => selectManualCandidate(employee));
-            manualSearchResults.appendChild(item);
-        });
-    }
-
-    function selectManualCandidate(employee) {
-        terminalState.manualCandidate = employee;
-        terminalState.consecutiveFailures = 0;
-        hideManualSearchLink();
-        closeManualSearch();
-        updateStatus(`Mirá la cámara para confirmar que sos ${employee.first_name || "vos"}...`);
-    }
-
-    if (btnManualSearch) {
-        btnManualSearch.addEventListener("click", openManualSearch);
-    }
-    if (btnManualSearchCancel) {
-        btnManualSearchCancel.addEventListener("click", closeManualSearch);
-    }
-    if (manualSearchOverlay) {
-        manualSearchOverlay.addEventListener("click", (event) => {
-            if (event.target === manualSearchOverlay) closeManualSearch();
-        });
-    }
-    if (manualSearchInput) {
-        manualSearchInput.addEventListener("input", (event) => {
-            renderManualSearchResults(event.target.value);
-        });
-    }
+    initManualSearch({
+        onSelect: (employee) => {
+            terminalState.manualCandidate = employee;
+            terminalState.consecutiveFailures = 0;
+            updateStatus(`Mirá la cámara para confirmar que sos ${employee.first_name || "vos"}...`);
+        },
+    });
 
     // ============================================================================
     // SELECCIÓN DE TIPO POST-IDENTIFICACIÓN (solo si hay múltiples eventos válidos)

--- a/resources/js/attendances/terminal/manual-search.js
+++ b/resources/js/attendances/terminal/manual-search.js
@@ -1,0 +1,145 @@
+/**
+ * =============================================================================
+ * TERMINAL.JS — BÚSQUEDA MANUAL POR CI
+ * =============================================================================
+ *
+ * @fileoverview Fallback cuando el reconocimiento facial falla varias veces
+ * seguidas: el empleado se identifica por CI en vez de rostro. Extraído de
+ * terminal.js como parte de su descomposición en módulos más chicos — mismo
+ * comportamiento que el código original.
+ *
+ * NO reemplaza la verificación facial: elegir un candidato acá solo acota
+ * identifyEmployee() a esa única persona (`terminalState.manualCandidate`,
+ * que sigue viviendo en terminal.js) — la cámara sigue activa y el empleado
+ * igual tiene que superar el umbral de distancia normal contra ese
+ * descriptor específico antes de que se registre cualquier marcación.
+ *
+ * `initManualSearch()` cablea los listeners globales (botón abrir/cancelar,
+ * click en backdrop, input de búsqueda) una sola vez y recibe de terminal.js
+ * el callback `onSelect` — mutar `terminalState` y llamar a `updateStatus()`
+ * son responsabilidad de terminal.js, no del módulo.
+ */
+
+import { getCachedEmployees } from '../terminal-offline/db.js';
+
+const MAX_MANUAL_SEARCH_RESULTS = 8;
+
+/** @type {((employee: object) => void)|null} */
+let onSelectCallback = null;
+
+/** Muestra el enlace "Buscar por CI" (aparece tras varios fallos de reconocimiento seguidos). */
+export function showManualSearchLink() {
+    const btnManualSearch = document.getElementById("btnManualSearch");
+    if (btnManualSearch) btnManualSearch.classList.remove("hidden");
+}
+
+/** Oculta el enlace "Buscar por CI". */
+export function hideManualSearchLink() {
+    const btnManualSearch = document.getElementById("btnManualSearch");
+    if (btnManualSearch) btnManualSearch.classList.add("hidden");
+}
+
+/** Abre el overlay de búsqueda manual, limpio y con foco en el input. */
+export function openManualSearch() {
+    const manualSearchOverlay = document.getElementById("manualSearchOverlay");
+    const manualSearchInput = document.getElementById("manualSearchInput");
+
+    if (!manualSearchOverlay) return;
+    manualSearchOverlay.classList.remove("hidden");
+    if (manualSearchInput) {
+        manualSearchInput.value = "";
+        manualSearchInput.focus();
+    }
+    renderManualSearchResults("");
+}
+
+/** Cierra el overlay de búsqueda manual. */
+export function closeManualSearch() {
+    const manualSearchOverlay = document.getElementById("manualSearchOverlay");
+    if (manualSearchOverlay) manualSearchOverlay.classList.add("hidden");
+}
+
+/**
+ * Filtra los empleados cacheados por CI y renderiza los resultados.
+ * @param {string} query
+ * @returns {Promise<void>}
+ */
+export async function renderManualSearchResults(query) {
+    const manualSearchResults = document.getElementById("manualSearchResults");
+    const manualSearchEmpty = document.getElementById("manualSearchEmpty");
+
+    if (!manualSearchResults) return;
+    manualSearchResults.innerHTML = "";
+
+    const digits = (query || "").trim();
+    if (digits.length < 2) {
+        if (manualSearchEmpty) manualSearchEmpty.classList.add("hidden");
+        return;
+    }
+
+    const candidates = await getCachedEmployees();
+    const matches = candidates
+        .filter((employee) => employee.ci && String(employee.ci).includes(digits))
+        .slice(0, MAX_MANUAL_SEARCH_RESULTS);
+
+    if (manualSearchEmpty) manualSearchEmpty.classList.toggle("hidden", matches.length > 0);
+
+    matches.forEach((employee) => {
+        const fullName = `${employee.first_name || ""} ${employee.last_name || ""}`.trim() || "Empleado";
+        const item = document.createElement("button");
+        item.type = "button";
+        item.className = "manual-search-result";
+        item.setAttribute("role", "option");
+        item.innerHTML = `
+            <img src="${employee.photo_thumbnail || "/images/default-avatar.png"}" alt="" aria-hidden="true">
+            <span>
+                <span class="manual-search-result-name">${fullName}</span><br>
+                <span class="manual-search-result-ci">CI: ${employee.ci}</span>
+            </span>
+        `;
+        item.addEventListener("click", () => selectManualCandidate(employee));
+        manualSearchResults.appendChild(item);
+    });
+}
+
+/**
+ * Elige un candidato de la búsqueda manual: cierra el overlay y delega en
+ * `onSelect` (mutar terminalState.manualCandidate/consecutiveFailures y
+ * actualizar el texto de estado — responsabilidad de terminal.js).
+ * @param {object} employee
+ */
+export function selectManualCandidate(employee) {
+    hideManualSearchLink();
+    closeManualSearch();
+    onSelectCallback?.(employee);
+}
+
+/**
+ * Cablea los listeners globales de la búsqueda manual (una sola vez).
+ * @param {{onSelect?: (employee: object) => void}} callbacks
+ */
+export function initManualSearch({ onSelect } = {}) {
+    onSelectCallback = onSelect ?? null;
+
+    const btnManualSearch = document.getElementById("btnManualSearch");
+    const btnManualSearchCancel = document.getElementById("btnManualSearchCancel");
+    const manualSearchOverlay = document.getElementById("manualSearchOverlay");
+    const manualSearchInput = document.getElementById("manualSearchInput");
+
+    if (btnManualSearch) {
+        btnManualSearch.addEventListener("click", openManualSearch);
+    }
+    if (btnManualSearchCancel) {
+        btnManualSearchCancel.addEventListener("click", closeManualSearch);
+    }
+    if (manualSearchOverlay) {
+        manualSearchOverlay.addEventListener("click", (event) => {
+            if (event.target === manualSearchOverlay) closeManualSearch();
+        });
+    }
+    if (manualSearchInput) {
+        manualSearchInput.addEventListener("input", (event) => {
+            renderManualSearchResults(event.target.value);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Quinto paso de la descomposición de `terminal.js` (1540 líneas) — ver PR #158-#161 para los anteriores.

- Extrae `showManualSearchLink()`, `hideManualSearchLink()`, `openManualSearch()`, `closeManualSearch()`, `renderManualSearchResults()` y `selectManualCandidate()` (fallback de identificación por CI cuando el reconocimiento facial falla varias veces seguidas) a `resources/js/attendances/terminal/manual-search.js`, junto con el cableado de sus listeners globales (botón abrir/cancelar, click en backdrop, input de búsqueda) — reemplazado por una llamada a `initManualSearch()`.
- `selectManualCandidate()` mutaba `terminalState.manualCandidate`/`consecutiveFailures` y llamaba a `updateStatus()` — ambos siguen siendo responsabilidad de `terminal.js` (el estado central y el setter de texto de identificación no se tocan en este PR), ahora pasados como callback `onSelect` a `initManualSearch()`.
- Los 4 call sites externos que quedan en `terminal.js` (`hideManualSearchLink()`/`closeManualSearch()` en `startIdentificationFlow()`, `hideManualSearchLink()`/`showManualSearchLink()` en `identifyEmployee()`) no cambian — mismos imports, mismas firmas.
- Sin cambios de comportamiento.

## Test plan

- [x] `npm test` — 18/18 tests pasan (sin cambios en esta suite)
- [x] `npm run build` — build de Vite exitoso, sin errores
- [x] Revisión manual del diff completo de `terminal.js`: no quedan referencias a las funciones locales removidas ni a los `const` de DOM de búsqueda manual eliminados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY


---
_Generated by [Claude Code](https://claude.ai/code/session_0158tjwSfqgZJ3PLzPUER9WY)_