### PR TITLE
Instalabilidad PWA: /marcar y /terminal/{code} como apps independientes

### DIFF
--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\Terminal;
+use App\Settings\GeneralSettings;
+use App\Support\ThemeResolver;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Http\JsonResponse;
 
 class AttendanceFaceMarkController extends Controller
 {
@@ -53,5 +56,71 @@ class AttendanceFaceMarkController extends Controller
             'title' => $title !== '' ? $title : "Terminal — {$terminal->name}",
             'terminal' => $terminal,
         ]);
+    }
+
+    /** Manifest de PWA para el modo Marcación (dispositivo personal del empleado). */
+    public function markManifest(): JsonResponse
+    {
+        return $this->buildManifest(
+            name: 'Nominapp Marcación',
+            shortName: 'Marcación',
+            startUrl: '/marcar',
+            scope: '/marcar',
+        );
+    }
+
+    /**
+     * Manifest de PWA para el modo Terminal, específico de la sucursal.
+     *
+     * @param  string  $code  Código único de 8 caracteres de la terminal
+     */
+    public function terminalManifest(string $code): JsonResponse
+    {
+        $terminal = Terminal::where('code', $code)->first();
+
+        if (! $terminal) {
+            abort(404);
+        }
+
+        return $this->buildManifest(
+            name: 'Nominapp Terminal',
+            shortName: 'Terminal',
+            startUrl: "/terminal/{$terminal->code}",
+            scope: '/terminal/',
+        );
+    }
+
+    /**
+     * Construye el JSON del manifest, resolviendo el color primario configurado
+     * en Settings una sola vez por request (cae al default de ThemeResolver si
+     * el settings store no está disponible — mismo criterio defensivo que
+     * <x-theme-vars />: una lectura fallida no debe romper una ruta pública activa).
+     * Mismo set de íconos para ambos modos — sin variantes por modo.
+     */
+    private function buildManifest(string $name, string $shortName, string $startUrl, string $scope): JsonResponse
+    {
+        try {
+            $colorKey = app(GeneralSettings::class)->primary_color;
+        } catch (\Throwable) {
+            $colorKey = ThemeResolver::DEFAULT_COLOR;
+        }
+
+        $theme = ThemeResolver::primaryColorCss($colorKey);
+
+        return response()->json([
+            'name' => $name,
+            'short_name' => $shortName,
+            'start_url' => $startUrl,
+            'scope' => $scope,
+            'display' => 'standalone',
+            'theme_color' => $theme['hex'][600],
+            'background_color' => $theme['hex'][50],
+            'icons' => [
+                ['src' => asset('icons/icon-192.png'), 'sizes' => '192x192', 'type' => 'image/png'],
+                ['src' => asset('icons/icon-512.png'), 'sizes' => '512x512', 'type' => 'image/png'],
+                ['src' => asset('icons/icon-192-maskable.png'), 'sizes' => '192x192', 'type' => 'image/png', 'purpose' => 'maskable'],
+                ['src' => asset('icons/icon-512-maskable.png'), 'sizes' => '512x512', 'type' => 'image/png', 'purpose' => 'maskable'],
+            ],
+        ], 200, ['Content-Type' => 'application/manifest+json']);
     }
 }

--- a/resources/css/attendances/styles.css
+++ b/resources/css/attendances/styles.css
@@ -141,6 +141,67 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
 .conflict-dismiss-btn:hover { background: var(--c-danger); color: #fff; }
 
 /* ============================================================
+   BANNER E ÍCONO DE INSTALACIÓN PWA
+   ============================================================ */
+.install-toggle {
+    display: flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--c-border);
+    background: transparent;
+    color: var(--c-muted);
+    cursor: pointer;
+    transition: background var(--tr-f), color var(--tr-f), border-color var(--tr-f);
+    flex-shrink: 0;
+}
+.install-toggle:hover { background: var(--c-primary-bg); color: var(--c-primary); border-color: var(--c-primary); }
+.install-toggle svg { width: 16px; height: 16px; display: block; }
+.install-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--sp-2) var(--sp-3);
+    padding: var(--sp-2) var(--sp-4);
+    background: var(--c-primary-bg);
+    border-bottom: 1px solid var(--c-primary-ring);
+    color: var(--c-primary);
+    font-size: .8125rem;
+    font-weight: 600;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 400ms ease, opacity 400ms ease, padding 400ms ease;
+}
+.install-banner.is-visible { max-height: 140px; opacity: 1; padding: var(--sp-2) var(--sp-4); }
+.install-banner-btn {
+    background: var(--c-primary);
+    color: #fff;
+    font: inherit;
+    font-size: .75rem;
+    font-weight: 700;
+    padding: 4px var(--sp-3);
+    border: none;
+    border-radius: var(--r);
+    cursor: pointer;
+    white-space: nowrap;
+}
+.install-banner-btn:hover { background: var(--c-primary-h); }
+.install-banner-dismiss {
+    background: transparent;
+    border: 1px solid var(--c-primary);
+    color: var(--c-primary);
+    font: inherit;
+    font-size: .75rem;
+    font-weight: 700;
+    padding: 3px var(--sp-3);
+    border-radius: var(--r);
+    cursor: pointer;
+    white-space: nowrap;
+}
+.install-banner-dismiss:hover { background: var(--c-primary); color: #fff; }
+
+/* ============================================================
    ESTADO DE SINCRONIZACIÓN OFFLINE (dispositivo)
    ============================================================ */
 .sync-status-row {

--- a/resources/css/attendances/terminal-setup.css
+++ b/resources/css/attendances/terminal-setup.css
@@ -41,3 +41,13 @@ button:not(:disabled):hover { background: var(--color-primary-400); }
 .status { margin-top: 1.25rem; font-size: 0.9rem; min-height: 1.5rem; }
 .status--error { color: var(--c-danger-l); }
 .status--success { color: var(--c-success-l); }
+
+.install-section { margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--color-surface-800); }
+.install-instructions-ios { color: var(--c-primary-l); font-weight: 600; }
+.btn-secondary {
+    background: transparent;
+    border: 1px solid var(--c-primary-l);
+    color: var(--c-primary-l);
+    margin-top: 0.75rem;
+}
+.btn-secondary:hover { background: var(--c-primary-l); color: var(--color-surface-900); }

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -16,6 +16,14 @@ import { openMyEventsModal, closeMyEventsModal } from './mark/my-events-modal.js
 import { showSuccessModal } from './mark/success-modal.js';
 import { showErrorModal, initErrorModal, isErrorModalVisible, setErrorModalVisible } from './mark/error-modal.js';
 import {
+    captureInstallPrompt,
+    triggerInstallPrompt,
+    isStandalone,
+    isIOS,
+    isDismissed,
+    dismiss,
+} from '../shared/install-prompt.js';
+import {
     getLastGpsErrorCode,
     requestGPSBackground,
     requestGPSManual,
@@ -1926,6 +1934,65 @@ document.addEventListener("DOMContentLoaded", () => {
             localStorage.setItem("mark-theme", next);
         });
     }
+
+    (function initInstallUi() {
+        const installBanner = document.getElementById("installBanner");
+        const installBannerText = document.getElementById("installBannerText");
+        const btnInstallNow = document.getElementById("btnInstallNow");
+        const btnDismissInstall = document.getElementById("btnDismissInstall");
+        const btnInstallApp = document.getElementById("btnInstallApp");
+
+        const standalone = isStandalone(
+            window.navigator.standalone,
+            window.matchMedia("(display-mode: standalone)").matches
+        );
+        if (standalone) {
+            return;
+        }
+
+        function showBanner() {
+            if (isDismissed("mark")) {
+                return;
+            }
+            installBanner.classList.add("is-visible");
+        }
+
+        function hideBanner() {
+            installBanner.classList.remove("is-visible");
+        }
+
+        function showBackupButton() {
+            btnInstallApp.classList.remove("hidden");
+        }
+
+        if (isIOS(window.navigator.userAgent, window.navigator.maxTouchPoints)) {
+            installBannerText.textContent = 'Tocá el botón Compartir y elegí "Agregar a pantalla de inicio".';
+            btnInstallNow.classList.add("hidden");
+            showBanner();
+            showBackupButton();
+            btnInstallApp.addEventListener("click", () => installBanner.classList.add("is-visible"));
+        } else {
+            captureInstallPrompt(() => {
+                showBanner();
+                showBackupButton();
+            });
+
+            btnInstallNow.addEventListener("click", async () => {
+                const outcome = await triggerInstallPrompt();
+                if (outcome === "accepted") {
+                    hideBanner();
+                    btnInstallApp.classList.add("hidden");
+                }
+            });
+
+            btnInstallApp.addEventListener("click", () => triggerInstallPrompt());
+        }
+
+        btnDismissInstall.addEventListener("click", () => {
+            dismiss("mark");
+            hideBanner();
+        });
+    })();
 
     // ==========================================================================
     // INICIALIZACIÓN

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1950,12 +1950,27 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
+        /**
+         * Hace visible el banner incondicionalmente — sin chequear isDismissed().
+         * Uso exclusivo de disparadores explícitos del usuario (btnInstallApp, el
+         * botón de respaldo permanente) donde un dismiss anterior no debe impedir
+         * un nuevo pedido explícito de instalación.
+         */
+        function revealBanner() {
+            installBanner.classList.add("is-visible");
+            installBanner.setAttribute("aria-hidden", "false");
+        }
+
+        /**
+         * Muestra el banner solo si el usuario no lo descartó antes — uso exclusivo
+         * del pop-up *automático* inicial (al cargar la página o al capturar el
+         * evento beforeinstallprompt), nunca de un click explícito en el botón.
+         */
         function showBanner() {
             if (isDismissed("mark")) {
                 return;
             }
-            installBanner.classList.add("is-visible");
-            installBanner.setAttribute("aria-hidden", "false");
+            revealBanner();
         }
 
         function hideBanner() {
@@ -1971,10 +1986,13 @@ document.addEventListener("DOMContentLoaded", () => {
          * Fallback cuando el prompt nativo ya no está disponible (consumido en un
          * intento previo — dismissed/unavailable) — evita dejar el botón "muerto"
          * sin ninguna señal para el usuario. Reusa el mismo texto manual de iOS.
+         * Siempre se dispara desde un click explícito del usuario (btnInstallNow o
+         * btnInstallApp), así que revela el banner incondicionalmente — el dismiss
+         * previo no debe silenciar una nueva solicitud explícita de instalación.
          */
         function showManualInstallFallback() {
             installBannerText.textContent = "No se pudo iniciar la instalación automática — buscá \"Agregar a pantalla de inicio\" en el menú del navegador.";
-            showBanner();
+            revealBanner();
         }
 
         if (isIOS(window.navigator.userAgent, window.navigator.maxTouchPoints)) {
@@ -1982,7 +2000,9 @@ document.addEventListener("DOMContentLoaded", () => {
             btnInstallNow.classList.add("hidden");
             showBanner();
             showBackupButton();
-            btnInstallApp.addEventListener("click", () => showBanner());
+            // Botón de respaldo permanente — la única vía posterior de instalación
+            // tras un dismiss; debe funcionar siempre, dismissed o no.
+            btnInstallApp.addEventListener("click", () => revealBanner());
         } else {
             captureInstallPrompt(() => {
                 showBanner();
@@ -1999,12 +2019,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             });
 
+            // Botón de respaldo permanente — la única vía posterior de instalación
+            // tras un dismiss; debe producir un resultado visible siempre, dismissed
+            // o no, por eso usa showManualInstallFallback()/revealBanner() en vez
+            // de pasar por el gate de isDismissed() de showBanner().
             btnInstallApp.addEventListener("click", async () => {
                 const outcome = await triggerInstallPrompt();
                 if (outcome === "accepted") {
                     hideBanner();
                     btnInstallApp.classList.add("hidden");
-                } else if (outcome === "unavailable" || outcome === "dismissed") {
+                } else {
                     showManualInstallFallback();
                 }
             });

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1955,14 +1955,26 @@ document.addEventListener("DOMContentLoaded", () => {
                 return;
             }
             installBanner.classList.add("is-visible");
+            installBanner.setAttribute("aria-hidden", "false");
         }
 
         function hideBanner() {
             installBanner.classList.remove("is-visible");
+            installBanner.setAttribute("aria-hidden", "true");
         }
 
         function showBackupButton() {
             btnInstallApp.classList.remove("hidden");
+        }
+
+        /**
+         * Fallback cuando el prompt nativo ya no está disponible (consumido en un
+         * intento previo — dismissed/unavailable) — evita dejar el botón "muerto"
+         * sin ninguna señal para el usuario. Reusa el mismo texto manual de iOS.
+         */
+        function showManualInstallFallback() {
+            installBannerText.textContent = "No se pudo iniciar la instalación automática — buscá \"Agregar a pantalla de inicio\" en el menú del navegador.";
+            showBanner();
         }
 
         if (isIOS(window.navigator.userAgent, window.navigator.maxTouchPoints)) {
@@ -1970,7 +1982,7 @@ document.addEventListener("DOMContentLoaded", () => {
             btnInstallNow.classList.add("hidden");
             showBanner();
             showBackupButton();
-            btnInstallApp.addEventListener("click", () => installBanner.classList.add("is-visible"));
+            btnInstallApp.addEventListener("click", () => showBanner());
         } else {
             captureInstallPrompt(() => {
                 showBanner();
@@ -1982,10 +1994,20 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (outcome === "accepted") {
                     hideBanner();
                     btnInstallApp.classList.add("hidden");
+                } else {
+                    showManualInstallFallback();
                 }
             });
 
-            btnInstallApp.addEventListener("click", () => triggerInstallPrompt());
+            btnInstallApp.addEventListener("click", async () => {
+                const outcome = await triggerInstallPrompt();
+                if (outcome === "accepted") {
+                    hideBanner();
+                    btnInstallApp.classList.add("hidden");
+                } else if (outcome === "unavailable" || outcome === "dismissed") {
+                    showManualInstallFallback();
+                }
+            });
         }
 
         btnDismissInstall.addEventListener("click", () => {

--- a/resources/js/attendances/terminal-setup.js
+++ b/resources/js/attendances/terminal-setup.js
@@ -1,0 +1,106 @@
+/**
+ * Lógica de la página de aprovisionamiento de terminal — vincula el
+ * dispositivo (reclama el token Sanctum del enlace de un solo uso) y, tras
+ * vincular exitosamente, ofrece instalar la PWA antes de continuar al modo
+ * terminal. Extraído del <script> inline original para poder importar el
+ * módulo compartido de instalación (ver resources/js/shared/install-prompt.js).
+ */
+import { captureInstallPrompt, triggerInstallPrompt, isStandalone, isIOS } from '../shared/install-prompt.js';
+
+const btn = document.getElementById('btnClaim');
+const statusEl = document.getElementById('status');
+const installSection = document.getElementById('installSection');
+const installInstructionsIos = document.getElementById('installInstructionsIos');
+const btnInstallNow = document.getElementById('btnInstallNow');
+const btnContinue = document.getElementById('btnContinue');
+const csrf = document.querySelector('meta[name="csrf-token"]').content;
+
+let terminalCode = null;
+
+/**
+ * Modelo real del dispositivo, solo disponible vía Client Hints en navegadores
+ * Chromium sobre Android (Chrome, Edge...) — null en iOS/Safari/Firefox/desktop,
+ * donde el servidor cae al parseo del User-Agent (ver DeviceHintsParser). Sirve
+ * solo para prellenar marca/modelo como sugerencia editable en el panel.
+ */
+async function getClientHintModel() {
+    if (!navigator.userAgentData?.getHighEntropyValues) {
+        return null;
+    }
+    try {
+        const hints = await navigator.userAgentData.getHighEntropyValues(['model']);
+        return hints.model || null;
+    } catch {
+        return null;
+    }
+}
+
+captureInstallPrompt(() => {
+    btnInstallNow.hidden = false;
+});
+
+btn.addEventListener('click', async () => {
+    btn.disabled = true;
+    statusEl.textContent = 'Vinculando...';
+    statusEl.className = 'status';
+
+    try {
+        const response = await fetch(window.location.pathname.replace(/\/$/, '') + '/claim', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
+            body: JSON.stringify({ device_model_hint: await getClientHintModel() }),
+        });
+        const data = await response.json();
+
+        if (!data.ok) {
+            statusEl.textContent = data.message || 'No se pudo vincular el dispositivo.';
+            statusEl.className = 'status status--error';
+            btn.disabled = false;
+            return;
+        }
+
+        // Almacenamiento provisorio del token — en la fase de sincronización offline
+        // (IndexedDB, módulo terminal-offline/) este valor pasa a vivir en el store
+        // `terminal_meta` en vez de localStorage. Se guarda el id (estable, no cambia
+        // con "Cambiar URL del terminal") además del code (cambia con esa acción) —
+        // terminal.js usa el id para detectar si el estado local pertenece a OTRO
+        // terminal distinto, sin confundir un simple cambio de URL con eso.
+        localStorage.setItem('nominapp_terminal_token', data.token);
+        localStorage.setItem('nominapp_terminal_id', data.terminal.id);
+        localStorage.setItem('nominapp_terminal_code', data.terminal.code);
+
+        terminalCode = data.terminal.code;
+        statusEl.textContent = 'Dispositivo vinculado correctamente.';
+        statusEl.className = 'status status--success';
+        btn.hidden = true;
+
+        const standalone = isStandalone(
+            window.navigator.standalone,
+            window.matchMedia('(display-mode: standalone)').matches
+        );
+
+        if (standalone) {
+            // Reaprovisión de un terminal ya instalado como PWA — sin necesidad de
+            // volver a mostrar el flujo de instalación, continuar directo.
+            window.location.href = '/terminal/' + terminalCode;
+            return;
+        }
+
+        installSection.hidden = false;
+
+        if (isIOS(window.navigator.userAgent, window.navigator.maxTouchPoints)) {
+            btnInstallNow.hidden = true;
+            installInstructionsIos.hidden = false;
+        }
+    } catch (error) {
+        statusEl.textContent = 'Error de conexión. Intente nuevamente.';
+        statusEl.className = 'status status--error';
+        btn.disabled = false;
+    }
+});
+
+btnInstallNow.addEventListener('click', () => triggerInstallPrompt());
+
+btnContinue.addEventListener('click', () => {
+    window.location.href = '/terminal/' + terminalCode;
+});

--- a/resources/js/attendances/terminal-setup.js
+++ b/resources/js/attendances/terminal-setup.js
@@ -99,7 +99,25 @@ btn.addEventListener('click', async () => {
     }
 });
 
-btnInstallNow.addEventListener('click', () => triggerInstallPrompt());
+/**
+ * Fallback cuando el prompt nativo no está disponible o el usuario lo
+ * descarta (dismissed/unavailable) — evita dejar el botón inerte sin
+ * ninguna señal. Reutiliza el mismo elemento de instrucciones manuales que
+ * ya existe para iOS, y oculta el botón para dejar claro que ese camino ya
+ * se agotó.
+ */
+function showManualInstallFallback() {
+    installInstructionsIos.textContent = 'No se pudo iniciar la instalación automática — buscá "Agregar a pantalla de inicio" en el menú del navegador.';
+    installInstructionsIos.hidden = false;
+    btnInstallNow.hidden = true;
+}
+
+btnInstallNow.addEventListener('click', async () => {
+    const outcome = await triggerInstallPrompt();
+    if (outcome === 'unavailable' || outcome === 'dismissed') {
+        showManualInstallFallback();
+    }
+});
 
 btnContinue.addEventListener('click', () => {
     window.location.href = '/terminal/' + terminalCode;

--- a/resources/js/shared/install-prompt.js
+++ b/resources/js/shared/install-prompt.js
@@ -1,0 +1,84 @@
+/**
+ * Lógica de instalación de la PWA — detección de plataforma, captura del
+ * evento beforeinstallprompt (Android/Chrome/Edge) y persistencia del
+ * descarte del banner. Las funciones reciben sus dependencias del navegador
+ * (userAgent, storage, target de eventos) como parámetros en vez de leer
+ * los globals directamente, para poder testearlas sin un entorno jsdom —
+ * en producción los valores por defecto ya apuntan a los globals reales.
+ */
+
+let deferredPrompt = null;
+
+/**
+ * Captura el evento beforeinstallprompt antes de que el navegador lo
+ * descarte, y bloquea el mini-infobar nativo (preventDefault) para que la
+ * UI propia decida cuándo mostrarlo. Debe llamarse una sola vez al cargar
+ * la página — no dispara nada en iOS (ese navegador nunca emite el evento).
+ * @param {(event: Event) => void} onAvailable - se invoca cuando el prompt queda disponible
+ * @param {EventTarget} [target] - inyectable para tests; window en producción
+ */
+export function captureInstallPrompt(onAvailable, target = window) {
+    target.addEventListener('beforeinstallprompt', (event) => {
+        event.preventDefault();
+        deferredPrompt = event;
+        onAvailable(event);
+    });
+}
+
+/**
+ * Dispara el prompt nativo de instalación capturado previamente.
+ * @returns {Promise<'accepted'|'dismissed'|'unavailable'>}
+ */
+export async function triggerInstallPrompt() {
+    if (!deferredPrompt) {
+        return 'unavailable';
+    }
+
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    deferredPrompt = null;
+
+    return outcome;
+}
+
+/**
+ * @param {boolean|undefined} navigatorStandalone - navigator.standalone (solo iOS)
+ * @param {boolean} displayModeStandalone - window.matchMedia('(display-mode: standalone)').matches
+ */
+export function isStandalone(navigatorStandalone, displayModeStandalone) {
+    return navigatorStandalone === true || displayModeStandalone === true;
+}
+
+/**
+ * iPadOS moderno se anuncia como "Macintosh" en el user agent (indistinguible
+ * de un Mac de escritorio por UA solo) — se distingue por soporte táctil
+ * (maxTouchPoints > 1), que ningún Mac de escritorio real tiene.
+ * @param {string} userAgent
+ * @param {number} [maxTouchPoints]
+ */
+export function isIOS(userAgent, maxTouchPoints = 0) {
+    const isAppleDevice = /iPad|iPhone|iPod/.test(userAgent);
+    const isIpadOsDesktopUa = userAgent.includes('Macintosh') && maxTouchPoints > 1;
+
+    return isAppleDevice || isIpadOsDesktopUa;
+}
+
+function dismissKey(mode) {
+    return `nominapp_install_dismissed_${mode}`;
+}
+
+/**
+ * @param {'mark'|'terminal'} mode
+ * @param {{getItem: (key: string) => string|null}} [storage] - inyectable para tests; localStorage en producción
+ */
+export function isDismissed(mode, storage = localStorage) {
+    return storage.getItem(dismissKey(mode)) === '1';
+}
+
+/**
+ * @param {'mark'|'terminal'} mode
+ * @param {{setItem: (key: string, value: string) => void}} [storage] - inyectable para tests; localStorage en producción
+ */
+export function dismiss(mode, storage = localStorage) {
+    storage.setItem(dismissKey(mode), '1');
+}

--- a/resources/js/shared/install-prompt.test.js
+++ b/resources/js/shared/install-prompt.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    captureInstallPrompt,
+    triggerInstallPrompt,
+    isStandalone,
+    isIOS,
+    isDismissed,
+    dismiss,
+} from './install-prompt.js';
+
+describe('isStandalone', () => {
+    it('true si navigator.standalone es true (iOS instalado)', () => {
+        expect(isStandalone(true, false)).toBe(true);
+    });
+
+    it('true si display-mode: standalone matchea (Android/Chrome instalado)', () => {
+        expect(isStandalone(undefined, true)).toBe(true);
+    });
+
+    it('false si ninguna de las dos señales indica instalado', () => {
+        expect(isStandalone(false, false)).toBe(false);
+        expect(isStandalone(undefined, false)).toBe(false);
+    });
+});
+
+describe('isIOS', () => {
+    it('detecta iPhone por user agent', () => {
+        expect(isIOS('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')).toBe(true);
+    });
+
+    it('detecta iPad clásico por user agent', () => {
+        expect(isIOS('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)')).toBe(true);
+    });
+
+    it('detecta iPadOS moderno (se anuncia como Macintosh con soporte táctil)', () => {
+        expect(isIOS('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)', 5)).toBe(true);
+    });
+
+    it('no confunde un Mac de escritorio (sin touch) con iPadOS', () => {
+        expect(isIOS('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)', 0)).toBe(false);
+    });
+
+    it('no detecta Android como iOS', () => {
+        expect(isIOS('Mozilla/5.0 (Linux; Android 14)')).toBe(false);
+    });
+});
+
+describe('isDismissed / dismiss', () => {
+    function fakeStorage() {
+        const store = new Map();
+        return {
+            getItem: (key) => store.get(key) ?? null,
+            setItem: (key, value) => store.set(key, value),
+        };
+    }
+
+    it('no está descartado por defecto', () => {
+        const storage = fakeStorage();
+        expect(isDismissed('mark', storage)).toBe(false);
+    });
+
+    it('queda descartado después de llamar dismiss()', () => {
+        const storage = fakeStorage();
+        dismiss('mark', storage);
+        expect(isDismissed('mark', storage)).toBe(true);
+    });
+
+    it('el dismiss de un modo no afecta al otro (namespaced)', () => {
+        const storage = fakeStorage();
+        dismiss('mark', storage);
+        expect(isDismissed('terminal', storage)).toBe(false);
+    });
+});
+
+describe('captureInstallPrompt / triggerInstallPrompt', () => {
+    it('captura el evento, bloquea el default, y lo dispara bajo demanda', async () => {
+        const target = new EventTarget();
+        const onAvailable = vi.fn();
+
+        captureInstallPrompt(onAvailable, target);
+
+        const preventDefault = vi.fn();
+        const prompt = vi.fn();
+        const event = new Event('beforeinstallprompt', { cancelable: true });
+        event.preventDefault = preventDefault;
+        event.prompt = prompt;
+        event.userChoice = Promise.resolve({ outcome: 'accepted' });
+
+        target.dispatchEvent(event);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(onAvailable).toHaveBeenCalledWith(event);
+
+        const outcome = await triggerInstallPrompt();
+
+        expect(prompt).toHaveBeenCalled();
+        expect(outcome).toBe('accepted');
+    });
+
+    it('devuelve unavailable si nunca se capturó un evento', async () => {
+        // Este test corre después de que el test anterior ya consumió el
+        // deferredPrompt capturado (triggerInstallPrompt lo limpia tras usarlo).
+        const outcome = await triggerInstallPrompt();
+        expect(outcome).toBe('unavailable');
+    });
+});

--- a/resources/js/shared/install-prompt.test.js
+++ b/resources/js/shared/install-prompt.test.js
@@ -98,9 +98,13 @@ describe('captureInstallPrompt / triggerInstallPrompt', () => {
     });
 
     it('devuelve unavailable si nunca se capturó un evento', async () => {
-        // Este test corre después de que el test anterior ya consumió el
-        // deferredPrompt capturado (triggerInstallPrompt lo limpia tras usarlo).
-        const outcome = await triggerInstallPrompt();
+        // Independiente del orden de ejecución: usa una instancia fresca del
+        // módulo (vi.resetModules + import dinámico) en vez de depender de que
+        // el test anterior ya haya consumido el deferredPrompt module-level.
+        vi.resetModules();
+        const fresh = await import('./install-prompt.js');
+
+        const outcome = await fresh.triggerInstallPrompt();
         expect(outcome).toBe('unavailable');
     });
 });

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -117,7 +117,7 @@
         <button type="button" id="btnDismissConflict" class="conflict-dismiss-btn">Entendido</button>
     </div>
 
-    <div id="installBanner" class="install-banner" role="status" aria-live="polite">
+    <div id="installBanner" class="install-banner" role="status" aria-live="polite" aria-hidden="true">
         <span id="installBannerText">Instalá esta app en tu pantalla de inicio para acceso rápido</span>
         <button type="button" id="btnInstallNow" class="install-banner-btn">Instalar</button>
         <button type="button" id="btnDismissInstall" class="install-banner-dismiss">Ahora no</button>

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -80,6 +80,13 @@
                     <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
                 </svg>
             </button>
+            <button type="button" id="btnInstallApp" class="install-toggle hidden" aria-label="Instalar aplicación">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                    <polyline points="7 10 12 15 17 10"/>
+                    <line x1="12" y1="15" x2="12" y2="3"/>
+                </svg>
+            </button>
         </div>
         <div class="app-clock" id="headerClock" aria-live="off" aria-label="Hora actual"></div>
     </header>
@@ -108,6 +115,12 @@
         </svg>
         <span>Una marcación reciente no pudo confirmarse — RRHH la va a revisar.</span>
         <button type="button" id="btnDismissConflict" class="conflict-dismiss-btn">Entendido</button>
+    </div>
+
+    <div id="installBanner" class="install-banner" role="status" aria-live="polite">
+        <span id="installBannerText">Instalá esta app en tu pantalla de inicio para acceso rápido</span>
+        <button type="button" id="btnInstallNow" class="install-banner-btn">Instalar</button>
+        <button type="button" id="btnDismissInstall" class="install-banner-dismiss">Ahora no</button>
     </div>
 
     {{-- Estado de sincronización offline + sync manual — paridad con el botón "Sincronizar"

--- a/resources/views/attendances/mark.blade.php
+++ b/resources/views/attendances/mark.blade.php
@@ -10,6 +10,7 @@
     <x-favicon-links />
     @vite('resources/css/attendances/styles.css')
     <x-theme-vars />
+    <x-pwa-meta manifest-url="{{ route('mark.manifest') }}" app-title="Nominapp Marcación" />
     @vite('resources/js/attendances/mark.js')
 </head>
 

--- a/resources/views/attendances/terminal-setup.blade.php
+++ b/resources/views/attendances/terminal-setup.blade.php
@@ -24,70 +24,16 @@
 
         <button type="button" id="btnClaim">Vincular este dispositivo</button>
         <div id="status" class="status" role="status" aria-live="polite"></div>
+
+        <div id="installSection" class="install-section" hidden>
+            <p>Instalá esta app en la pantalla de inicio del dispositivo para que funcione como terminal fijo.</p>
+            <p id="installInstructionsIos" class="install-instructions-ios" hidden>En iOS: tocá el botón Compartir y elegí "Agregar a pantalla de inicio".</p>
+            <button type="button" id="btnInstallNow" hidden>Instalar ahora</button>
+            <button type="button" id="btnContinue" class="btn-secondary">Continuar al terminal</button>
+        </div>
     </div>
 
-    <script>
-        const btn = document.getElementById('btnClaim');
-        const statusEl = document.getElementById('status');
-        const csrf = document.querySelector('meta[name="csrf-token"]').content;
-
-        // Modelo real del dispositivo, solo disponible vía Client Hints en navegadores
-        // Chromium sobre Android (Chrome, Edge...) — null en iOS/Safari/Firefox/desktop,
-        // donde el servidor cae al parseo del User-Agent (ver DeviceHintsParser). Sirve
-        // solo para prellenar marca/modelo como sugerencia editable en el panel.
-        async function getClientHintModel() {
-            if (!navigator.userAgentData?.getHighEntropyValues) return null;
-            try {
-                const hints = await navigator.userAgentData.getHighEntropyValues(['model']);
-                return hints.model || null;
-            } catch {
-                return null;
-            }
-        }
-
-        btn.addEventListener('click', async () => {
-            btn.disabled = true;
-            statusEl.textContent = 'Vinculando...';
-            statusEl.className = 'status';
-
-            try {
-                const response = await fetch(window.location.pathname.replace(/\/$/, '') + '/claim', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
-                    body: JSON.stringify({ device_model_hint: await getClientHintModel() }),
-                });
-                const data = await response.json();
-
-                if (!data.ok) {
-                    statusEl.textContent = data.message || 'No se pudo vincular el dispositivo.';
-                    statusEl.className = 'status status--error';
-                    btn.disabled = false;
-                    return;
-                }
-
-                // Almacenamiento provisorio del token — en la fase de sincronización offline
-                // (IndexedDB, módulo terminal-offline/) este valor pasa a vivir en el store
-                // `terminal_meta` en vez de localStorage. Se guarda el id (estable, no cambia
-                // con "Cambiar URL del terminal") además del code (cambia con esa acción) —
-                // terminal.js usa el id para detectar si el estado local pertenece a OTRO
-                // terminal distinto, sin confundir un simple cambio de URL con eso.
-                localStorage.setItem('nominapp_terminal_token', data.token);
-                localStorage.setItem('nominapp_terminal_id', data.terminal.id);
-                localStorage.setItem('nominapp_terminal_code', data.terminal.code);
-
-                statusEl.textContent = 'Dispositivo vinculado correctamente. Redirigiendo...';
-                statusEl.className = 'status status--success';
-
-                setTimeout(() => {
-                    window.location.href = '/terminal/' + data.terminal.code;
-                }, 1200);
-            } catch (error) {
-                statusEl.textContent = 'Error de conexión. Intente nuevamente.';
-                statusEl.className = 'status status--error';
-                btn.disabled = false;
-            }
-        });
-    </script>
+    @vite('resources/js/attendances/terminal-setup.js')
 </body>
 
 </html>

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -10,6 +10,9 @@
     <x-favicon-links />
     @vite('resources/css/attendances/terminal.css')
     <x-theme-vars />
+    @isset($terminal)
+        <x-pwa-meta manifest-url="{{ route('terminal.manifest', $terminal->code) }}" app-title="Nominapp Terminal" />
+    @endisset
     @vite('resources/js/attendances/terminal.js')
 </head>
 

--- a/resources/views/components/pwa-meta.blade.php
+++ b/resources/views/components/pwa-meta.blade.php
@@ -1,0 +1,12 @@
+{{--
+    Meta tags de PWA que varían por modo (manifest y título) — no van en
+    favicon-links.blade.php porque ese componente es idéntico en las 5 vistas
+    públicas, mientras esto solo aplica a /marcar y /terminal (las únicas
+    instalables). apple-touch-icon ya lo provee <x-favicon-links />, no se
+    duplica acá.
+--}}
+@props(['manifestUrl', 'appTitle'])
+<link rel="manifest" href="{{ $manifestUrl }}">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<meta name="apple-mobile-web-app-title" content="{{ $appTitle }}">

--- a/resources/views/components/theme-vars.blade.php
+++ b/resources/views/components/theme-vars.blade.php
@@ -23,6 +23,7 @@
     $theme = \App\Support\ThemeResolver::primaryColorCss($colorKey);
     $fontFamily = \App\Support\ThemeResolver::fontFamily($fontKey);
 @endphp
+<meta name="theme-color" content="{{ $theme['hex'][600] }}">
 <style>
     :root {
         --color-primary-50: {{ $theme['hex'][50] }};

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,12 +40,14 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/marcar', [AttendanceFaceMarkController::class, 'show'])->name('mark.show');
+Route::get('/marcar/manifest.json', [AttendanceFaceMarkController::class, 'markManifest'])->name('mark.manifest');
 
 // Terminal legacy — mantener activa hasta migrar todos los dispositivos físicos
 Route::get('/terminal', [AttendanceFaceMarkController::class, 'terminal'])->name('terminal.legacy');
 
 // Terminal identificada por código — nueva arquitectura
 Route::get('/terminal/{code}', [AttendanceFaceMarkController::class, 'terminalByCode'])->name('terminal.show');
+Route::get('/terminal/{code}/manifest.json', [AttendanceFaceMarkController::class, 'terminalManifest'])->name('terminal.manifest');
 
 // Provisión del terminal como PWA offline — enlace de un solo uso generado desde TerminalResource,
 // emite el token Sanctum que el terminal usará contra la API de sincronización (routes/api.php).

--- a/tests/Feature/PwaManifestTest.php
+++ b/tests/Feature/PwaManifestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Terminal;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeManifestTestTerminal(): Terminal
+{
+    $company = Company::create(['name' => 'Empresa Manifest', 'ruc' => '90000001-1', 'employer_number' => 900001]);
+    $branch = Branch::create(['name' => 'Sucursal Manifest', 'company_id' => $company->id]);
+
+    return Terminal::create(['name' => 'Terminal Manifest', 'branch_id' => $branch->id, 'code' => 'ABC12345']);
+}
+
+it('el manifest de /marcar devuelve JSON válido con el color primario por defecto', function () {
+    $response = $this->get('/marcar/manifest.json');
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/manifest+json');
+    $response->assertJson([
+        'name' => 'Nominapp Marcación',
+        'start_url' => '/marcar',
+        'scope' => '/marcar',
+        'display' => 'standalone',
+        'theme_color' => '#0d9488',
+        'background_color' => '#f0fdfa',
+    ]);
+});
+
+it('el manifest de /marcar refleja un color primario distinto del default', function () {
+    $settings = app(GeneralSettings::class);
+    $settings->primary_color = 'rose';
+    $settings->save();
+
+    $response = $this->get('/marcar/manifest.json');
+
+    $response->assertOk();
+    $response->assertJsonPath('theme_color', '#e11d48');
+    $response->assertJsonPath('background_color', '#fff1f2');
+});
+
+it('el manifest de terminal incluye el start_url específico de esa sucursal', function () {
+    $terminal = makeManifestTestTerminal();
+
+    $response = $this->get("/terminal/{$terminal->code}/manifest.json");
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'application/manifest+json');
+    $response->assertJson([
+        'name' => 'Nominapp Terminal',
+        'start_url' => '/terminal/ABC12345',
+        'scope' => '/terminal/',
+        'display' => 'standalone',
+    ]);
+});
+
+it('el manifest de terminal devuelve 404 si el código no existe', function () {
+    $response = $this->get('/terminal/NOEXISTE/manifest.json');
+
+    $response->assertNotFound();
+});

--- a/tests/Feature/PwaMetaComponentTest.php
+++ b/tests/Feature/PwaMetaComponentTest.php
@@ -1,0 +1,18 @@
+<?php
+
+it('el componente pwa-meta renderiza el link de manifest y los meta tags de iOS', function () {
+    $html = (string) $this->blade(
+        '<x-pwa-meta manifest-url="/marcar/manifest.json" app-title="Nominapp Marcación" />'
+    );
+
+    expect($html)
+        ->toContain('<link rel="manifest" href="/marcar/manifest.json">')
+        ->toContain('name="apple-mobile-web-app-capable" content="yes"')
+        ->toContain('name="apple-mobile-web-app-title" content="Nominapp Marcación"');
+});
+
+it('theme-vars incluye el meta theme-color con el hex del color primario', function () {
+    $html = (string) $this->blade('<x-theme-vars />');
+
+    expect($html)->toContain('<meta name="theme-color" content="#0d9488">');
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
                 'resources/js/attendances/terminal.js',
                 'resources/css/attendances/terminal.css',
                 'resources/css/attendances/terminal-setup.css',
+                'resources/js/attendances/terminal-setup.js',
                 'resources/js/shared/capture-face.js',
                 'resources/css/shared/capture-face.css',
                 'resources/css/shared/fonts/poppins.css',


### PR DESCRIPTION
## Resumen

Sub-proyecto B de la iniciativa de rediseño de marcación de asistencia (A→F→B→E→D→C; A y F ya mergeados en #163/#164). Permite instalar `/marcar` (dispositivo personal) y `/terminal/{code}` (kiosko de sucursal) como PWAs independientes, con soporte manual para iOS/Safari (no dispara `beforeinstallprompt`).

- **Manifests dinámicos**: `/marcar/manifest.json` y `/terminal/{code}/manifest.json`, con `theme_color`/`background_color` que reflejan el color primario configurado en sub-proyecto F (vía `ThemeResolver`) — mismo resolver que ya usa `<x-theme-vars />`, no pueden divergir.
- **Meta tags**: `theme-color` agregado a `<x-theme-vars />`; nuevo `<x-pwa-meta />` solo en `/marcar` y `/terminal/{code}` (la ruta legacy `/terminal` sin código queda afuera, correctamente).
- **Módulo compartido `install-prompt.js`**: detección de plataforma, captura de `beforeinstallprompt`, dismiss permanente por dispositivo — diseñado con inyección de dependencias para ser testeable en el entorno Node por defecto de Vitest, sin jsdom.
- **`/marcar`**: banner de instalación descartable + botón de respaldo fijo en el header.
- **Aprovisionamiento de Terminal**: reemplaza el auto-redirect de 1.2s tras vincular por un paso explícito de instalación + botón "Continuar al terminal" — requirió convertir el `<script>` inline de esa página en un entry point real de Vite (los imports ES no resuelven en un script inline crudo).

## Hallazgos de la revisión final de branch completo (ya corregidos en este PR, 2 rondas)

- **Importante**: el banner de instalación nunca gestionaba `aria-hidden` (a diferencia de sus banners hermanos `#offlineBanner`/`#conflictBanner`) — un lector de pantalla anunciaba el prompt de instalación en cada carga de `/marcar`, incluso ya instalado o descartado. Corregido.
- **Importante**: los botones de instalar quedaban mudos (sin ningún feedback) después de que el prompt nativo se consumía una vez (cancelado o ya usado) — el peor caso era el aprovisionamiento del Terminal, donde todo el punto de este cambio era darle al admin un momento deliberado de instalación. Corregido con un fallback de instrucciones manuales.
- **Regresión detectada en la re-revisión del fix anterior**: el arreglo de `aria-hidden` enrutó por error el botón de respaldo permanente a través del mismo gate de "ya descartado" que usa el auto-popup — quedaba mudo justo después de un dismiss, violando el propósito explícito del botón (única vía posterior de instalación). Corregido en una segunda ronda, re-revisado y confirmado limpio.

## Test plan

- [x] `npm run build` — build limpio desde cero
- [x] `php artisan test --compact` — 636/636 Pest, sobre el árbol final (incluyendo ambas rondas del fix wave)
- [x] `npm run test` — 31/31 Vitest
- [x] `vendor/bin/pint --dirty` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)